### PR TITLE
PaP: Enable pot-updates for Of Pearls and Pirates

### DIFF
--- a/data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg
@@ -202,8 +202,9 @@
         #############################
         # PIRATES ARRIVE
         #############################
+        {NAMED_UNIT 2 "Fishing Boat" 8 33 skiff
         #po: this is a fishing boat name, and a pun on the phrase "seize the day"
-        {NAMED_UNIT 2 "Fishing Boat" 8 33 skiff _"Seas the Day" ()} {FACING ne} {ANIMATE} {IMMOBILE}
+        _"Seas the Day" ()} {FACING ne} {ANIMATE} {IMMOBILE}
         {MOVE_UNIT id=skiff 19 25}
         {NAMED_UNIT 2 Bandit 18 24 leader2 _"Boryn" canrecruit=yes} {FACING nw} {ANIMATE}
         {MODIFY_TERRAIN Ke 18 24} {REDRAW} {DELAY 150}

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -18,6 +18,7 @@ set(NORMAL_DOMAINS
 	wesnoth-low
 	wesnoth-multiplayer
 	wesnoth-nr
+	wesnoth-pap
 	wesnoth-sof
 	wesnoth-sota
 	wesnoth-sotbe

--- a/po/wesnoth-pap/af.po
+++ b/po/wesnoth-pap/af.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ang@latin.po
+++ b/po/wesnoth-pap/ang@latin.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ang@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ar.po
+++ b/po/wesnoth-pap/ar.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/bg.po
+++ b/po/wesnoth-pap/bg.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/bn.po
+++ b/po/wesnoth-pap/bn.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ca.po
+++ b/po/wesnoth-pap/ca.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ca_ES@valencia.po
+++ b/po/wesnoth-pap/ca_ES@valencia.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca_ES@valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/cs.po
+++ b/po/wesnoth-pap/cs.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/cy.po
+++ b/po/wesnoth-pap/cy.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cy\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/da.po
+++ b/po/wesnoth-pap/da.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/de.po
+++ b/po/wesnoth-pap/de.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/el.po
+++ b/po/wesnoth-pap/el.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/en@shaw.po
+++ b/po/wesnoth-pap/en@shaw.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en@shaw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/en_GB.po
+++ b/po/wesnoth-pap/en_GB.po
@@ -1,0 +1,2111 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr "Of Pearls and Pirates"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr "PaP"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr "1x enemies, 70% XP"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr "Easy"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr "2x enemies, 90% XP"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr "Normal"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr "3x enemies, 100% XP"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr "Hard"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr "4x enemies, 100% XP"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr "Deadly"
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr "(Novice level, 5 scenarios.)"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr "Author"
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr "Art"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr "No! Not like this..."
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr "What will Thea do without me..."
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr "Argh! I’ve breathed my last!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr "The depths have taken me..."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr "Complete <i>Pirates!</i> without losing any units."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr "Scenario 1: Overprotective"
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr "Scenario 2: The Best Defense..."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr "Defeat the enemy leader in <i>Desolation</i>."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr "Scenario 3: Little Red Riding Hood"
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr "Complete <i>Lee Shore</i> without freeing any slaves."
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr "Scenario 4: Tunnel Vision"
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr "Scenario 5: Vendetta"
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr "Strike the final blow in <i>Lady Maudie</i> with Thea."
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr "Pirates!"
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr "Corsairs"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr "Rochelm"
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr "Tip Dialogue &amp; Popups: On"
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr "Tip Dialogue &amp; Popups: Off"
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr "Alderman! Alderman Rael!"
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr "Pirates? What, here?!"
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr "Seas the Day"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr "Boryn"
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr "(yawn) It’s too early for this, Pa..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr "Rah!"
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr "Defeat the enemy leader"
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr "Death of Thea, Rael, or Elyn"
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr "Fighting from a Disadvantage"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr "Experience Per Kill"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr "Take that! Don’t mess with Rochelm!"
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr "Well, that sounded ominous."
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr "Crier"
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr "No news of outlaws, goodman. Ahem..."
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr "The message is given. Onwards to the next village."
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr "Swimming with Serpents"
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr "Naga"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr "Lookout"
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr "Pirates again? Why has the Crown not dealt with this!"
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr "Pirate filth. Like hell you will. What do you say, lads?"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr "Charming. My new allies will make short work of you."
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr "Pseail"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr "Briloss"
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr "Hisss... We are ready, Missstresss."
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr "Snake monsters! The pirates have brought naga!"
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr "Manpower Shortage"
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+#, fuzzy
+#| msgid ""
+#| "Survive until reinforcements arrive on turn 13, then defeat the enemy "
+#| "leaders"
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+"Survive until reinforcements arrive on turn 13, then defeat the enemy leaders"
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+#, fuzzy
+#| msgid "Defeat the enemy leaders"
+msgid "Then, defeat the enemy leaders"
+msgstr "Defeat the enemy leaders"
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr "Death of Thea"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr "Mixed Terrain"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr "Village Control"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr "New Recruits"
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr "Defeat the enemy leaders"
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr "Death of Thea or Diondra"
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr "Accursssed mermaid! We are lossst... I mussst essscape..."
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr "Begone! Flee and cower in your dark caves and silent grottos!"
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr "Constable Thea? I’m not— err..."
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr "Constable Thea"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr "Alright. Mermaid, are you willing to take the fight to these pirates?"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr "Desolation"
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr "Wild Wolves"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr "Stuxton"
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr "Great White"
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr "The Garard"
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr "Still here, however, are their boats. Get them, Thea."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr "Move any unit adjacent to both fishing skiffs"
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr "What’s this? There’s a living man inside this wolf’s belly!"
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr "Red"
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr "By Haldric, I’m free!"
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr "Halfway done, everyone. We’ll need both skiffs to carry us all."
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr "Forget it. Come on, everyone. Let’s get away from this dead place."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr "Lee Shore"
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr "Havan"
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr "Rhaddin"
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr "Is that possible?!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr "An invading army. And our neighbors enslaved! We can’t abide this."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr "($cages.length remaining)"
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr "Free the imprisoned slaves"
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr "Attack and break a cage to free the slave inside."
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr "Hah! You missed me!"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr "Elusive Enemies"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr "They burned my whole village! I want revenge!"
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr "We’re almost finished. There’s only a few more prisoners left to free."
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr "No!"
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr "Urgh..."
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr "Hisss..."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr "Additional Manpower"
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr "Peasants and Woodsmen no longer cost twice as much to recruit."
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr "What’s this? An unruly mob in place of my orderly divers?"
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr "No, wait—"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr "Walk the plank!"
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr "I can’t swim, please—"
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr "Look! That’s the constable!"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr "Elyn! My brother!"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr "..."
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr "What’s this? An unruly mob harassing my divers?"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr "Lady Maudie"
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr "Analla"
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr "Shipmaster Derryn"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr "Makeshift Shipyard"
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr "My, such language. Who in the world are you talking about?"
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr "My brother! The mustached javelineeer you drowned not two days ago?"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr "Defeat Lady Maudie"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr "Madam, I’ve told you, it might still be weeks—"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr "Know Thy Enemy"
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr "A unit’s statistics determine the best strategy for fighting them."
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr "(grim) Ta ta."
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr "Epilogue"
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr "Caged Slave"
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr "Fishing Boat"
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr "Villagers"
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr "Thea"
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr "loyal"
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr "Zero upkeep"
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr "Alderman Rael"
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr "Constable Elyn"
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr "Diondra"

--- a/po/wesnoth-pap/eo.po
+++ b/po/wesnoth-pap/eo.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/es.po
+++ b/po/wesnoth-pap/es.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/es_419.po
+++ b/po/wesnoth-pap/es_419.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es_419\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/et.po
+++ b/po/wesnoth-pap/et.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/eu.po
+++ b/po/wesnoth-pap/eu.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/fi.po
+++ b/po/wesnoth-pap/fi.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/fr.po
+++ b/po/wesnoth-pap/fr.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ga.po
+++ b/po/wesnoth-pap/ga.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/gd.po
+++ b/po/wesnoth-pap/gd.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gd\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/gl.po
+++ b/po/wesnoth-pap/gl.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/grc.po
+++ b/po/wesnoth-pap/grc.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: grc\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/he.po
+++ b/po/wesnoth-pap/he.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/hr.po
+++ b/po/wesnoth-pap/hr.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/hu.po
+++ b/po/wesnoth-pap/hu.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/id.po
+++ b/po/wesnoth-pap/id.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/is.po
+++ b/po/wesnoth-pap/is.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/it.po
+++ b/po/wesnoth-pap/it.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ja.po
+++ b/po/wesnoth-pap/ja.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ko.po
+++ b/po/wesnoth-pap/ko.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/la.po
+++ b/po/wesnoth-pap/la.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: la\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/lt.po
+++ b/po/wesnoth-pap/lt.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/lv.po
+++ b/po/wesnoth-pap/lv.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/mk.po
+++ b/po/wesnoth-pap/mk.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/mr.po
+++ b/po/wesnoth-pap/mr.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/my.po
+++ b/po/wesnoth-pap/my.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: my\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/nb_NO.po
+++ b/po/wesnoth-pap/nb_NO.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/nl.po
+++ b/po/wesnoth-pap/nl.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/pl.po
+++ b/po/wesnoth-pap/pl.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/pt.po
+++ b/po/wesnoth-pap/pt.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/pt_BR.po
+++ b/po/wesnoth-pap/pt_BR.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/racv.po
+++ b/po/wesnoth-pap/racv.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: racv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ro.po
+++ b/po/wesnoth-pap/ro.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/ru.po
+++ b/po/wesnoth-pap/ru.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sk.po
+++ b/po/wesnoth-pap/sk.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sl.po
+++ b/po/wesnoth-pap/sl.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sr.po
+++ b/po/wesnoth-pap/sr.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sr@ijekavian.po
+++ b/po/wesnoth-pap/sr@ijekavian.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sr@ijekavianlatin.po
+++ b/po/wesnoth-pap/sr@ijekavianlatin.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavianlatin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sr@latin.po
+++ b/po/wesnoth-pap/sr@latin.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/sv.po
+++ b/po/wesnoth-pap/sv.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/tl.po
+++ b/po/wesnoth-pap/tl.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/tr.po
+++ b/po/wesnoth-pap/tr.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/uk.po
+++ b/po/wesnoth-pap/uk.po
@@ -1,0 +1,1760 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/vi.po
+++ b/po/wesnoth-pap/vi.po
@@ -1,0 +1,1759 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/wesnoth-pap.pot
+++ b/po/wesnoth-pap/wesnoth-pap.pot
@@ -1,0 +1,1757 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/zh_CN.po
+++ b/po/wesnoth-pap/zh_CN.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""

--- a/po/wesnoth-pap/zh_TW.po
+++ b/po/wesnoth-pap/zh_TW.po
@@ -1,0 +1,1758 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2026-02-08 07:10 UTC\n"
+"PO-Revision-Date: 2026-02-06 22:59 UTC\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. [campaign]: id=Pearls_and_Pirates
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:28
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:22
+msgid "Of Pearls and Pirates"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:29
+msgid "PaP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "1x enemies, 70% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:36
+msgid "Easy"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "2x enemies, 90% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:37
+msgid "Normal"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "3x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:38
+msgid "Hard"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "4x enemies, 100% XP"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:39
+msgid "Deadly"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:41
+msgid ""
+"A sleepy fishing village on Wesnoth’s west coast finds itself suddenly beset "
+"by corsairs. With requests for royal aid falling on deaf ears, the villagers "
+"must join forces with the local merfolk and bring the fight to the pirates."
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:43
+msgid "(Novice level, 5 scenarios.)"
+msgstr ""
+
+#. [campaign]: id=Pearls_and_Pirates
+#. this campaign is not a direct continuation of the story and characters, but is next chronologically and is the recommended next campaign
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:47
+msgid ""
+"The saga continues in\n"
+"<i>The Deceiver’s Gambit</i>"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:51
+msgid "Author"
+msgstr ""
+
+#. [about]
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:57
+msgid "Art"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:115
+msgid ""
+"I have so much gold! Unless I’m already winning easily, I should make sure "
+"to take full advantage of our treasury."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:119
+msgid ""
+"Many hands make light work, in war as well as peace. Even the most "
+"experienced fighter will fall in the face of numbers."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:134
+msgid "No! Not like this..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:147
+msgid "What will Thea do without me..."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:160
+msgid "Argh! I’ve breathed my last!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/_main.cfg:173
+msgid "The depths have taken me..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Complete <i>Pirates!</i> without losing any units."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:26
+msgid "Scenario 1: Overprotective"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid ""
+"Defeat an enemy leader before your allies arrive in <i>Swimming with "
+"Serpents</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:27
+msgid "Scenario 2: The Best Defense..."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Defeat the enemy leader in <i>Desolation</i>."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:28
+msgid "Scenario 3: Little Red Riding Hood"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Complete <i>Lee Shore</i> without freeing any slaves."
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:29
+msgid "Scenario 4: Tunnel Vision"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Scenario 5: Vendetta"
+msgstr ""
+
+#. [achievement_group]
+#: data/campaigns/Of_Pearls_and_Pirates/achievements.cfg:30
+msgid "Strike the final blow in <i>Lady Maudie</i> with Thea."
+msgstr ""
+
+#. [scenario]: id=01_Pirates
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:9
+msgid "Pirates!"
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:26
+msgid ""
+"Far north from Westin, on the west coast of the Kingdom of Wesnoth, there "
+"lies a place called the Bay of Pearls. The waters of the bay are calm, and "
+"clear, and warm even in winter. But its most notable feature is that for "
+"which it is named — abundant beds of oysters and a vast wealth in pearls."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:31
+msgid ""
+"Many have tried to claim the bay for their own; sometimes with words, and "
+"sometimes with swords. But in the end the Crown declared it the domain of "
+"the merfolk, those most suited to care for and harvest the bay’s undersea "
+"resources."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:36
+msgid ""
+"Attracted by the temperate climate and easily-accessible wealth, a large and "
+"thriving community of mermen quickly sprang up along the bay’s eastern coast."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:38
+msgid ""
+"Along the west coast, where the pearls were less plentiful, hardy clans of "
+"human fishers and farmers began to settle. Though not wealthy — at least not "
+"compared with their merfolk neighbors — the human hamlets afforded a simple, "
+"secure life for those disinterested in the wider kingdom’s hustle and bustle."
+msgstr ""
+
+#. [part]
+#. S01 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:43
+msgid ""
+"But for every man content with a quiet life, there is another who seeks to "
+"take it from him..."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:64
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:69
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:94
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:67
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:92
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:111
+msgid "Corsairs"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:100
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:101
+msgid "Rochelm"
+msgstr ""
+
+#. [message]: speaker=narrator
+#. notice that appears at the beginning of the scenario if you select Deadly difficulty
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:110
+msgid ""
+"NOTE: ‘Deadly’ difficulty is intended to be a moderate challenge even for "
+"experienced players! If you’re new to Wesnoth, I strongly suggest trying a "
+"lower difficulty."
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_on
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:120
+msgid "Tip Dialogue &amp; Popups: On"
+msgstr ""
+
+#. [set_menu_item]: id=tutorial_toggle_off
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:132
+msgid "Tip Dialogue &amp; Popups: Off"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:178
+msgid "Alderman! Alderman Rael!"
+msgstr ""
+
+#. [message]: role=fisher
+#. a peasant is running towards town, calling out to the village leader
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:184
+msgid ""
+"(panting) Pirates! Alderman, it’s pirates! Burned my farm... (pant) Stole my "
+"skiff... (pant) Thought you should know..."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:199
+msgid "Pirates? What, here?!"
+msgstr ""
+
+#. [event]
+#. this is a fishing boat name, and a pun on the phrase "seize the day"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:207
+msgid "Seas the Day"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:209
+msgid "Boryn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:217
+msgid ""
+"Blast! Haven’t seen outlaws in these parts since I were a lad... these ones "
+"even dare to leave their faces uncovered. What do you make of it, Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:221
+msgid ""
+"I don’t know, Father. This is a strange thing. These outlaws couldn’t’ve "
+"come from the other villages — the other aldermen won’t stand for "
+"troublemakers."
+msgstr ""
+
+#. [message]: speaker=Rael
+#. "waxed" can be substituted with any other kind of routine bow maintenance
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:226
+msgid ""
+"Well, it’s a good thing I’ve been keeping my old war-bow waxed. There’s "
+"nothing for it but to drive them off. Constable Elyn, report!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just been woken up, and is getting ready to help fight a battle
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:241
+msgid "(yawn) It’s too early for this, Pa..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:245
+msgid ""
+"I’ll get to our keep and rally the farmers too; get a posse together. It’ll "
+"take more than the three of us to win this fight."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:251
+msgid ""
+"Well done for taking the initiative, Thea. Let’s show these pirates what we "
+"stand for. What do you say, lads?"
+msgstr ""
+
+#. [message]: role=fisher
+#. [message]: speaker=Lookout
+#. [message]: race=human
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#. The speaker is shouting a cheer and preparing to attack his enemy. Can be translated into any kind of cheer, but please stay consistent with the other instances of "Rah!"
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:256
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:153
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:491
+msgid "Rah!"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:264
+msgid "Defeat the enemy leader"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:268
+msgid "Death of Thea, Rael, or Elyn"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:289
+msgid ""
+"(whistles) There’s more of them than I expected. We’re going to be "
+"outnumbered until we have the time and gold to rally a larger force."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:292
+msgid "Fighting from a Disadvantage"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:293
+msgid ""
+"Your enemy in this scenario starts with much more gold than you.\n"
+"Even worse, your only recruit options are Peasants and Woodsmen:\n"
+"cheap-but-frail fighters with makeshift weapons and minimal \n"
+"training. Peasants and Woodsmen are level 0 units, and as such \n"
+"do not enforce a Zone of Control (enemies can move freely around \n"
+"them without being stopped).\n"
+"\n"
+"Fortunately, you’re much smarter than our AI (probably), and this \n"
+"scenario has a generous turn limit. Don’t sacrifice your entire \n"
+"army right away. Play smart — control villages to gain gold and \n"
+"use the time of day to your advantage. <i><b>Slowly build up your army\n"
+"while whittling down the opponent’s.</b></i>"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:308
+msgid ""
+"We’ll need more experienced fighters, too. You’ve done your best to train me "
+"and Thea, Pa, but most of the farmers are just that... farmers."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:311
+msgid "Experience Per Kill"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:312
+msgid ""
+"Peasants and Woodsmen may be weak, but they also require little experience\n"
+"to advance to the next level. Units gain 8 XP per level of the opponent "
+"they \n"
+"kill (e.g. 16 XP for killing a level 2 opponent). Killing a level 0 "
+"opponent \n"
+"grants 4 XP.\n"
+"\n"
+"Even if units don’t kill their opponent, they still gain XP just for "
+"attacking:\n"
+"0 XP for attacking a level 0 opponent, 1 XP for attacking a level 1 "
+"opponent, etc."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#. Elyn has just defeated a bandit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:338
+msgid "Take that! Don’t mess with Rochelm!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The bandit is dying, and is insulting his killers. "leeches" means that the "pearl-folk" (the people living around the Bay of Pearls) didn't earn the pearls.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:376
+msgid ""
+"Pfft. You’re just leeches... All you pearl-folk are. You’ll get... what’s "
+"coming to you..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:396
+msgid "Well, that sounded ominous."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:402
+msgid "Crier"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:406
+msgid "Hear ye! Word from Weldyn! I bring a proclamation from King Garard!"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:410
+msgid "Oh? Fortunate timing. Mayhaps this will explain our bandit attack."
+msgstr ""
+
+#. [message]: speaker=Crier
+#. "goodman" is an archaic term of respect, similar to "good sir".
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:415
+msgid "No news of outlaws, goodman. Ahem..."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:422
+msgid ""
+"In the interest of common defense and the clearing of new lands, His Majesty "
+"Garard, second of that name, calls forth a force of stout-hearted men to "
+"wage war against the orcs of the north, being those who have long-threatened "
+"our home."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:429
+msgid ""
+"Of-age free men holding in excess of ten acres are obligated to purchase "
+"spear, shield, helmet, and knife, and shall report for muster at the "
+"fortress of Halstead within five weeks time."
+msgstr ""
+
+#. [message]: speaker=narrator
+#. a crier is reading from a scroll
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:436
+msgid ""
+"Hear and obey.\n"
+"\n"
+"— His Majesty Garard II, King of Wesnoth"
+msgstr ""
+
+#. [message]: speaker=Crier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:442
+msgid "The message is given. Onwards to the next village."
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:451
+msgid "Ten acres... well, that’d be most of us. Blimey. But it is our duty."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:455
+msgid ""
+"You’re leading the village to war? But you’re our only veteran fighter. What "
+"will we do if the outlaws come back?"
+msgstr ""
+
+#. [message]: speaker=Rael
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:459
+msgid ""
+"I have faith in you, son. Take good care of your sister. The lads and I will "
+"return before you know it."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:477
+msgid ""
+"This battle is dragging on... if we can’t finish off these pirates soon, we "
+"won’t have enough spare hands to bring in the harvest."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg:484
+msgid ""
+"Brr, it’s starting to snow and we’re still stuck fighting. Our crops are all "
+"dead! Even if we win this battle, we’ll be sure to starve during the "
+"winter..."
+msgstr ""
+
+#. [scenario]: id=02_Swimming_with_Serpents
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:9
+msgid "Swimming with Serpents"
+msgstr ""
+
+#. [part]
+#. S02 intro. Alderman Rael left the village months ago, and has not returned.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:24
+msgid ""
+"But Rael did not return. Autumn turned to winter, winter to spring, and "
+"trouble once again returned to the Peninsula of Pearls."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:56
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:71
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:115
+msgid "Naga"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:104
+msgid "Lookout"
+msgstr ""
+
+#. [message]: speaker=Lookout
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:120
+msgid ""
+"Constable Elyn, sir! Ship on the horizon! I don’t recognize the trim... and "
+"it has black sails!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:124
+msgid "Pirates again? Why has the Crown not dealt with this!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:128
+msgid ""
+"I’m sure Pa would’ve told the army about the thieves who attacked us. The "
+"lords must be too busy to pay any mind to free-holds like us. But maybe the "
+"merfolk—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. Maudie is speaking to adults, not children. "Children" is used in a demeaning way here.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:144
+msgid ""
+"Hello, children. This is a shakedown. Empty your treasury or we’ll come and "
+"take the pearls ourselves."
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:148
+msgid "Pirate filth. Like hell you will. What do you say, lads?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:157
+msgid "Charming. My new allies will make short work of you."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:164
+msgid "Pseail"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:175
+msgid "Briloss"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:181
+msgid "Hisss... We are ready, Missstresss."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:185
+msgid ""
+"Kill their warriors, then shackle the others and march them north. I’ve more "
+"important places to be. Ta ta!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:195
+msgid "Snake monsters! The pirates have brought naga!"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:199
+msgid ""
+"Curse it all! Thea, rally the farmers and keep yourself safe. I’ve got to "
+"take the old skiff and warn the merfolk that naga are here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:203
+msgid ""
+"Rally the farmers? What farmers? Most of our fighting-age men are away with "
+"Dad."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:211
+msgid "Manpower Shortage"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:212
+msgid ""
+"Peasants and Woodsmen cost twice as much to recruit (but not to recall)."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:216
+msgid ""
+"Besides, the army hasn’t helped us. What makes you think the merfolk will?"
+msgstr ""
+
+#. [message]: speaker=Elyn
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:220
+msgid ""
+"Merfolk are ancient enemies of the naga, and are part of the kingdom just "
+"the same as us. They’ll help us, but I have to get the word out!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:229
+msgid ""
+"First Dad leaves, then my brother... It was nice while it lasted. I guess "
+"it’s up to me now."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:237
+msgid ""
+"Survive until reinforcements arrive at the east edge of the map on turn 13"
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:241
+msgid "Then, defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:245
+msgid "Death of Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:266
+msgid ""
+"Careful, everyone. Naga are powerful in water, but clumsier than we are on "
+"land. Don’t fight on the coast. Flee inland if we need to, and then cut them "
+"to pieces!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:269
+msgid "Mixed Terrain"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:270
+msgid ""
+"Some hexes are <i><b>mixtures of multiple terrain types.</b></i> Bridges, "
+"for example,\n"
+"count as both shallow water and flat land — whichever is better for the \n"
+"unit passing through.\n"
+"\n"
+"If you’re confused about a unit’s defense (chance to evade) or movement \n"
+"on a particular hex and want to see exactly what terrains are included,\n"
+"right-click the hex and select <i>Terrain Description</i>."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:280
+msgid ""
+"But we can’t afford to give up too many villages either. We’ll have a hard "
+"time recovering if our enemies’ gold reserves get out of hand."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:283
+msgid "Village Control"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:284
+msgid ""
+"Remember that each village you own generates 1 gold per turn,\n"
+"and supports 1 unit’s worth of upkeep. Level 2 units cost 2\n"
+"upkeep, level 3 units cost 3 upkeep, etc. But level 0 units,\n"
+"like Peasants and Woodsmen, cost no upkeep at all.\n"
+"\n"
+"<i><b>Enemies collect income and pay upkeep just like you do</b></i>,\n"
+"so capturing just a small handful of villages from your\n"
+"opponents can make a big difference."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Thea is waiting for her brother Elyn to return, bringing merfolk soldiers to help fight
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:303
+msgid ""
+"I see movement on the horizon! Something is coming closer... it’ll reach us "
+"in barely an hour. Is Elyn finally back?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "two-legs" is meant to be a neutral (not insulting) term for humans
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:325
+msgid ""
+"Hail, two-legs! I see you are imperiled! I knew I smelled the stench of naga."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:333
+msgid "Hooray! The merfolk have come! Constable Elyn has brought the merfolk!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:337
+msgid ""
+"Elyn? I know no such man. We come hunting a ship with black sails. It has "
+"been the cause of much mischief in our waters."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:341
+msgid ""
+"That’s the same ship that launched this attack on our village. But you say "
+"my brother isn’t with you? What can have happened to him?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:345
+msgid ""
+"This is a matter for after the battle. First, we must aid you against these "
+"vermin!"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:353
+msgid "New Recruits"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:354
+msgid ""
+"Merman Fighters and Hunters are level 1 units: proper fighters, unlike your "
+"untrained Peasants and Woodsmen."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:356
+msgid ""
+"Compared with level 1 Spearmen and Bowmen, Merman Fighters and Hunters have "
+"improved defense (chance to evade) and speed, but lower damage."
+msgstr ""
+
+#. [objective]: condition=win
+#. [objectives]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:368
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:377
+msgid "Defeat the enemy leaders"
+msgstr ""
+
+#. [objective]: condition=lose
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:372
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:261
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:379
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:284
+msgid "Death of Thea or Diondra"
+msgstr ""
+
+#. [message]: speaker=unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:427
+msgid "Accursssed mermaid! We are lossst... I mussst essscape..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:444
+msgid "Begone! Flee and cower in your dark caves and silent grottos!"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:452
+msgid ""
+"Thank you for helping us, mermaid of the bay! But what do we do now? Many of "
+"us are hurt. Our leader is away at war, and our constable is missing — or "
+"dead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:456
+msgid ""
+"No, my brother couldn’t be... not like that. It’d take more than a few "
+"snakes to kill Constable Elyn Nicolin. I know we’ll see him again."
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:464
+msgid ""
+"But he’s not here now. What happens the next time the pirates come, "
+"Constable Thea?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:468
+msgid "Constable Thea? I’m not— err..."
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:470
+msgid "Constable Thea"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:473
+msgid "Alright. Mermaid, are you willing to take the fight to these pirates?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:477
+msgid ""
+"Of course. The fleeing naga follow the coast south and west. I must go in "
+"pursuit!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. "What do you say, lads?" echoes Rael's and Elyn's words earlier
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:482
+msgid ""
+"Then that is where we’ll go too. We won’t cower in fear until the next "
+"attack, or wait for outside aid that may never come. We’re going to get out "
+"there, hunt down that pirate lady and put an end to this! What do you say, "
+"lads?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:507
+msgid ""
+"We will not fight here forever, villagers. The black ship is our real "
+"quarry! Let us swiftly vanquish these naga and be done with it."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg:514
+msgid ""
+"I cannot fight on behalf of your village any longer, humans. I must pursue "
+"the black ship before it escapes us! You will have to finish this battle "
+"yourselves."
+msgstr ""
+
+#. [scenario]: id=03_Desolation
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:9
+msgid "Desolation"
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:24
+msgid ""
+"Under Thea’s command, the villagers appointed a handful of guards with "
+"instructions to keep a watchful eye on the horizon. Should trouble return — "
+"or Constable Elyn — they were to send a messenger immediately."
+msgstr ""
+
+#. [part]
+#. S03 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:29
+msgid ""
+"The rest of the militia provisioned themselves and set off on foot. Guided "
+"by the merfolk, they followed the coast, tracking the fleeing naga around "
+"the Peninsula."
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:68
+msgid "Wild Wolves"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:95
+msgid "Stuxton"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:144
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:302
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:230
+msgid "Great White"
+msgstr ""
+
+#. [event]
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:145
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:307
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:231
+msgid "The Garard"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#. "Your feet are lead" means that Thea is traveling too slowly.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:171
+msgid ""
+"Your feet are lead, woman of Rochem. How can we pursue creatures of the "
+"water when you are bound to land? Have you no swift gryphons or sleek boats "
+"to carry you hence?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:175
+msgid ""
+"Good mermaid, most of us are farmers, not fishers. Elyn took our best "
+"seaworthy boat, and— well, you know that story..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:179
+msgid ""
+"But we’re almost upon the fishing village of Stuxton. Mayhaps they’ve had "
+"trouble with pirates too. Even if they aren’t willing to join us, I’m sure "
+"they’ll let us borrow of their fishing fleet."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:203
+msgid "What?! Stuxton lies in ruins! Wolves feast on corpses in the streets!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:207
+msgid ""
+"There was clearly a battle here, one which has left several bodies. But most "
+"of the village humans are unaccounted for. They are certainly not still "
+"living here."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:211
+msgid "Still here, however, are their boats. Get them, Thea."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:244
+msgid ""
+"I can do that. The two boats still afloat are damaged and taking on water. "
+"We may have to split our forces if we want to claim both before they sink."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:248
+msgid ""
+"This will be a quick expedition, but that doesn’t mean we should let down "
+"our guard. The forest echoes with the howls of wolves..."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:256
+msgid "Move any unit adjacent to both fishing skiffs"
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:285
+msgid "What’s this? There’s a living man inside this wolf’s belly!"
+msgstr ""
+
+#. [event]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:287
+msgid "Red"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:290
+msgid "By Haldric, I’m free!"
+msgstr ""
+
+#. [message]: speaker=Red
+#. This is a reference to the "Little Red Riding Hood" fairy tale
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:295
+msgid ""
+"I was supposed to be delivering tea to my poor sick grandmother. “<i>My, "
+"what big teeth you have</i>”, I told her... and then my “grandmother” leapt "
+"out of bed and swallowed me whole!"
+msgstr ""
+
+#. [message]: speaker=Red
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:299
+msgid ""
+"Tricked by a wolf, hrmph. I suppose I’ve nothing better to do now than to "
+"join you. Perhaps someday I’ll write a popular childrens’ fable about my "
+"harrowing experience..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. The player has defeated the wolf leader, but there may still be wolves on the map, and the scenario has not ended.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:306
+msgid ""
+"The worst of the wolves are dealt with, but we must still reach the last "
+"boats before they sink."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the first one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:324
+msgid ""
+"I’ve reached the first skiff! The damage doesn’t look bad. I think I can get "
+"it seaworthy again."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:348
+msgid "Halfway done, everyone. We’ll need both skiffs to carry us all."
+msgstr ""
+
+#. [message]: speaker=$unit.id
+#. The player is trying to reach two damaged skiffs before they sink. The player has reached the second one.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:361
+msgid ""
+"I’m repairing the second skiff! There’s more bodies inside. It looks like a "
+"family tried to hide here."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:385
+msgid ""
+"Pa used to take me here for festivals, back when. I knew some of these "
+"dead... Was there anything we could have done?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:390
+msgid "Forget it. Come on, everyone. Let’s get away from this dead place."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:413
+msgid ""
+"The boats are taking on too much water. We have to hurry and reach them "
+"before they sink!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:419
+msgid ""
+"The last boat is taking on too much water. We have to hurry and reach it "
+"before it sinks!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:435
+msgid ""
+"The last boats have sunk! Without boats we can’t keep up with the merfolk. "
+"You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg:441
+msgid ""
+"The last boat has sunk! Without both boats we can’t keep up with the "
+"merfolk. You’ll have to go ahead without us, Diondra..."
+msgstr ""
+
+#. [scenario]: id=04_Lee_Shore
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:9
+msgid "Lee Shore"
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:25
+msgid ""
+"The villagers boarded their new ships and set sail. The skill of their "
+"merfolk escorts more than compensated for the inexperience of the sailors, "
+"and the makeshift flotilla made good time around the cape."
+msgstr ""
+
+#. [part]
+#. S04 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:30
+msgid ""
+"They passed several other small hamlets. Like Stuxton, all were empty, and "
+"marred by signs of weeks-old battle. Finally, five days after leaving home, "
+"the villagers and merfolk sighted signs of activity on the coast."
+msgstr ""
+
+#. [leader]: type=Outlaw, id=leader2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:58
+msgid "Havan"
+msgstr ""
+
+#. [leader]: type=Huntsman, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:83
+msgid "Rhaddin"
+msgstr ""
+
+#. [message]: speaker=leader4
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:280
+msgid ""
+"Sssmall boatsss are coming! I sssussspect these are sssurvivors from that "
+"last hovel; the onesss who hurt me. I am sssure they are here to caussse "
+"problemsss."
+msgstr ""
+
+#. [message]: speaker=leader3
+#. "The Lady" refers to Lady Maudie, the main villain of this campaign.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:285
+msgid ""
+"The Lady won’t be happy if any of our trainees escape, especially not with "
+"the invasion so near."
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:289
+msgid ""
+"Call off the dive! Chattel, back to your quarters. Corsairs, get ready to "
+"fight!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:324
+msgid ""
+"Here are the missing villagers — in chains! Would this have been our fate if "
+"not for your intervention, Diondra?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:328
+msgid ""
+"I think the prisoners are being forced to... dive for pearls? But there "
+"aren’t any pearls on this part of the coast."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:332
+msgid ""
+"Perhaps this is not the slaves’ final home. A grim omen. It sounds almost as "
+"if they mean to conquer the Bay of Pearls itself."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:336
+msgid "Is that possible?!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:340
+msgid ""
+"My city nurtures the continent’s largest and wealthiest merfolk population, "
+"yet most of us are not warriors. With Wesnoth’s army away at war in the "
+"east, I think it unlikely but not impossible for a coordinated group of "
+"corsairs to take control."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:344
+msgid "An invading army. And our neighbors enslaved! We can’t abide this."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:348
+msgid ""
+"Grab your weapons, everyone. Free every prisoner... but take none ourselves."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "($cages.length remaining)"
+msgstr ""
+
+#. [objective]: condition=win
+#. $cages.length will be between 1 and 20
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:374
+msgid "Free the imprisoned slaves"
+msgstr ""
+
+#. [note]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:388
+msgid "Attack and break a cage to free the slave inside."
+msgstr ""
+
+#. [message]: speaker=second_unit
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:406
+msgid "Hah! You missed me!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:409
+msgid "Elusive Enemies"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:410
+msgid ""
+"Not all units are created equal. As you know, fighters like Naga or Merfolk "
+"have high defense (chance\n"
+"to evade) in water, but pay for that strength by having low defense while on "
+"land.\n"
+"\n"
+"Other units, like the Footpad you just attacked, have abnormally high "
+"defense <b><i>everywhere</i></b>. That’s a major\n"
+"strength, but comes at the cost of poor damage output and vulnerability to "
+"most damage types.\n"
+"\n"
+"To see a unit’s terrain defence and damage resistances/vulnerabilities, "
+"<b><i>right-click on it and select \n"
+"“Unit Type Description.”</i></b>"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:429
+msgid "What’s happening? Is that... Thea? Alderman Rael’s daughter?"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:433
+msgid ""
+"We come to free you from your bonds, human. These pirates took you from your "
+"home. Now take from them their lives."
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:440
+msgid "They burned my whole village! I want revenge!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. The player has just freed a slave from his cage.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:447
+msgid ""
+"Thank you! These pirates lock us up whenever they aren’t forcing us to "
+"dive..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:467
+msgid "We’re almost finished. There’s only a few more prisoners left to free."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:485
+msgid "No!"
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:500
+msgid "Urgh..."
+msgstr ""
+
+#. [message]: speaker=unit
+#. An enemy naga leader is dying.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:515
+msgid "Hisss..."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:540
+msgid ""
+"The outlaw leaders are dead! Time to release the rest of their prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:563
+msgid "Well done, everyone! We’ve freed all of the pirates’ prisoners."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:570
+msgid ""
+"With so many new farmers and fishers swelling our ranks, we finally have the "
+"numbers we need to field more human fighters."
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:579
+msgid "Additional Manpower"
+msgstr ""
+
+#. [object]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:580
+msgid "Peasants and Woodsmen no longer cost twice as much to recruit."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:596
+msgid "What’s this? An unruly mob in place of my orderly divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "trainees" refers to new slaves. "dispose of them" means to kill them.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:601
+msgid ""
+"My, my. How unlucky. I had meant to introduce some new trainees I’d "
+"acquired... but given the present state of affairs, I suppose I’ll have to "
+"dispose of them instead."
+msgstr ""
+
+#. [message]: role=prisoner1
+#. A prisoner is being made to walk the plank (which will kill them).
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:611
+msgid "No, wait—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:615
+msgid "Walk the plank!"
+msgstr ""
+
+#. [message]: role=prisoner2
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:624
+msgid "I can’t swim, please—"
+msgstr ""
+
+#. [message]: race=human
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:665
+msgid "Look! That’s the constable!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:670
+msgid "Elyn! My brother!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:683
+msgid ""
+"Ta ta, dears. This was unfortunate, but really, I had no choice. There’s no "
+"room for freeloaders on my ship."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish-tailed sweethearts" refers to the merfolk. Maudie doesn't acknowledge the human villagers as a meaningful adversary.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:688
+msgid ""
+"You see, there’s a new power growing in these parts: me. It’s time for Lady "
+"Maudie to take back what she’s owed. I’ll see you fish-tailed sweethearts "
+"again real soon."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:698
+msgid ""
+"Elyn!! My brother can swim, but not for long in this surf! Diondra, you have "
+"to rescue him! Rescue them all!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:786
+msgid ""
+"I am sorry, Thea. His arms and legs were bound... I’ve retrieved only a "
+"corpse. The pirates must’ve captured him while he sailed in search of help."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:790
+msgid "..."
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:794
+msgid ""
+"Do not let his death be in vain. We must catch this “Maudie” and bring her "
+"to justice. Follow the black ship!"
+msgstr ""
+
+#. [message]: speaker=Diondra
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:812
+msgid ""
+"Do not delay, Thea. These pirates are planning something. If we cannot "
+"finish our battle here, I fear they will be reinforced, and us overwhelmed."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:826
+msgid "What’s this? An unruly mob harassing my divers?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:830
+msgid ""
+"Now now, we can’t be having that. Luckily for me, you’ve given me enough "
+"time to prepare a whole fleet of warships, all filled to the brim with angry "
+"outlaws."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/04_Lee_Shore.cfg:838
+msgid ""
+"The merfolk aren’t prepared to battle such a large fleet! We have to flee "
+"before we’re destroyed..."
+msgstr ""
+
+#. [scenario]: id=05_Lady_Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:6
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:91
+msgid "Lady Maudie"
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:23
+msgid ""
+"The villagers held a sombre shipboard funeral for Constable Elyn, and a "
+"burial at sea. The alderman’s son had always been there for them... until "
+"suddenly he wasn’t."
+msgstr ""
+
+#. [part]
+#. S05 intro. Thea's father left many months ago, along with other villagers.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:28
+msgid ""
+"Not for the first time, Thea worried about her father; about all those who’d "
+"gone to war. She’d heard stories, of course — but experiencing battle and "
+"loss herself was something else entirely."
+msgstr ""
+
+#. [part]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:30
+msgid ""
+"She wondered how her father could so readily return to something so grim. "
+"She wondered what drives “Lady Maudie” to inflict it upon others."
+msgstr ""
+
+#. [part]
+#. S05 intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:35
+msgid ""
+"Guided by merfolk, the flotilla kept station several dozen miles behind "
+"Maudie’s ship; too slow to catch her, but fast enough to stay in sight. "
+"Maudie’s destination soon became apparent: the wild, unsettled islands known "
+"as the Three Sisters."
+msgstr ""
+
+#. [leader]: type=Assassin, id=leader2, gender=female
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:55
+msgid "Analla"
+msgstr ""
+
+#. [leader]: type=Ranger, id=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:81
+msgid "Shipmaster Derryn"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:182
+msgid ""
+"This island is covered in villages. Even if we don’t need the gold "
+"ourselves, we should still make sure Maudie doesn’t take so many that we "
+"become overwhelmed."
+msgstr ""
+
+#. [message]: speaker=narrator
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:187
+msgid ""
+"To see how much gold and income your enemies have, press <i>Alt+S</i>, or "
+"open the Menu and select “Status Table”."
+msgstr ""
+
+#. [event]: id=immobile_derelict
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:198
+msgid "Makeshift Shipyard"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "fish" is meant to be an insulting way to refer to merfolk
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:248
+msgid ""
+"Tut-tut, the mermaid followed me all this way? Show some deference, fish. "
+"Soon you’ll be calling me your lord."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:252
+msgid ""
+"It’s not just merfolk who followed you here. I’m here to avenge my brother, "
+"you soulless murderer!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:256
+msgid "My, such language. Who in the world are you talking about?"
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:260
+msgid "My brother! The mustached javelineeer you drowned not two days ago?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:264
+msgid ""
+"I’m sorry, sweetie, you smallfolk all look the same to me. But if you’re so "
+"beaten up about his death, I’d be happy to help you join him. Shipmaster, is "
+"my fleet ready?"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:268
+msgid ""
+"Not yet, milady. As we’ve discussed, repairing derelicts takes quite some "
+"time. It might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:272
+msgid ""
+"Yes, yes, I remember now. Just... deal with these peasants, will you? That "
+"business with the freed prisoners has given me a terrible headache. I’m "
+"really not in the mood to entertain riff-raff."
+msgstr ""
+
+#. [objective]: condition=win
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:280
+msgid "Defeat Lady Maudie"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:317
+msgid ""
+"They’re getting closer. Shipmaster, how long until the fleet is finished?!"
+msgstr ""
+
+#. [message]: speaker=leader3
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:321
+msgid "Madam, I’ve told you, it might still be weeks—"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:327
+msgid ""
+"They’re getting closer. And my shipmaster got himself killed... Do I have to "
+"do everything myself?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:333
+msgid ""
+"Fine! Since these ships cannot serve me in any useful capacity, set them "
+"ablaze and send them to run down anything in the water!"
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:349
+msgid "Know Thy Enemy"
+msgstr ""
+
+#. [display_tip]
+#. knowing about the Fireship specifically isn't that important (although it does make it clear that this isn't a bug). But the Fireship is a good example about how knowing an enemy's weaknesses can make them much easier to fight. This also makes exploiting the Fireships feel less like a mistake ("oh, the AI is dumb"), and makes it clear that making them exploitable like this is a deliberate design choice
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:351
+msgid "A unit’s statistics determine the best strategy for fighting them."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:353
+msgid ""
+"Maudie’s new fireships, for example, can deal massive damage in\n"
+"melee combat. But their <i>deteriorate</i> ability drains their health\n"
+"every turn, and being ships they cannot chase you onto land."
+msgstr ""
+
+#. [display_tip]
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:357
+msgid ""
+"While many units are general-purpose, others — like the Fireship — \n"
+"have clear strengths and weaknesses. If you haven’t been doing so\n"
+"already, consider checking new units’ stats to identify any\n"
+"weaknesses they may have."
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Princess Bride movie reference
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:378
+msgid "My name is Thea Nicolin. You killed my brother! Prepare to die!!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:396
+msgid ""
+"Get away from my ship, you low-born churl! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#. "you're all leeches" echoes the S01 leader's dying words
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:403
+msgid ""
+"Get away from my ship, you filthy fish! You’re all just leeches! The Bay "
+"should be <i>mine</i>, not yours!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:409
+msgid ""
+"It belongs to me and my blood by right! My noble ancestors fought our way to "
+"the top, and we would have stayed there if those idiot kings hadn’t stolen "
+"it from us and given it to the merfolk instead."
+msgstr ""
+
+#. [message]: speaker=Thea
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:413
+msgid ""
+"You’re talking about when the Bay was first awarded to the merfolk? But that "
+"was over three hundred years ago!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:417
+msgid ""
+"And my line <i>has not forgotten</i>! It should have been <i>me</i> who "
+"inherited the pearls!"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:419
+msgid ""
+"Eating caviar instead of hardtack, served by slaves instead of outlaws, "
+"living in a villa instead of a smelly, grungy, fish-smelling pirate ship... "
+"oh, I’m going to be seasick again..."
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:429
+msgid ""
+"But you’re just a bunch of fish and smallfolk! It’s my right to rule! How— I "
+"mean... well, surely you can’t fault a girl for having ambition?"
+msgstr ""
+
+#. [message]: speaker=Maudie
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:453
+msgid "We’re sinking. Someone, stop the sinking! No. No! I can’t swim!!"
+msgstr ""
+
+#. [message]: speaker=Thea
+#. Echoing Maudie's lines from S04 and S02.
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/05_Lady_Maudie.cfg:460
+msgid "(grim) Ta ta."
+msgstr ""
+
+#. [scenario]: id=06_Epilogue
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:6
+msgid "Epilogue"
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:13
+msgid ""
+"With Maudie defeated, her surviving supporters scattered, hotly pursued by "
+"Diondra and her merfolk. The villagers worked to dismantle and loot the "
+"pirate shipyard, then set sail once more for their home, where they were "
+"greeted with a resounding cheer."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:18
+msgid ""
+"The neighboring hamlets, briefly pillaged and empty, started to refill with "
+"their newly-freed inhabitants. Many had died in the pirate raids, but many "
+"more had lived, and what remained of Lady Maudie’s fleet now made for rich "
+"plunder. Constable Thea took it upon herself to distribute food and "
+"supplies, and soon became the de-facto leader of the Peninsula’s human "
+"community."
+msgstr ""
+
+#. [part]
+#. epilogue intro. The "next serious threat" is Asheviere's orcs' takeover, as seen in HttT
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:23
+msgid ""
+"Untouched by the fighting, the merfolk city at the Bay of Pearls continued "
+"to prosper. It would be many decades until the next serious threat."
+msgstr ""
+
+#. [part]
+#. epilogue intro
+#: data/campaigns/Of_Pearls_and_Pirates/scenarios/06_Epilogue.cfg:28
+msgid ""
+"Finally, many years later, Alderman Rael and his much-diminished warband "
+"made a weary return to Rochelm, their tour of duty complete. Thea’s father "
+"spoke grimly; of orc and lizard, siege and ambush. But that story — King "
+"Garard’s war — is a tale for another hero..."
+msgstr ""
+
+#. [unit_type]: id=Cage, race=mechanical
+#: data/campaigns/Of_Pearls_and_Pirates/units/Cage.cfg:5
+msgid "Caged Slave"
+msgstr ""
+
+#. [unit_type]: id=Fishing Boat
+#: data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg:9
+msgid "Fishing Boat"
+msgstr ""
+
+#. [side]
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:21
+msgid "Villagers"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:38
+msgid "Thea"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:47
+msgid "loyal"
+msgstr ""
+
+#. [trait]: id=loyal_dummy
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:48
+msgid "Zero upkeep"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:58
+msgid "Alderman Rael"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:69
+msgid "Constable Elyn"
+msgstr ""
+
+#: data/campaigns/Of_Pearls_and_Pirates/utils/characters.cfg:80
+msgid "Diondra"
+msgstr ""


### PR DESCRIPTION
The existence of the .pot file enables this for SCons, and the CMake builds are enabled with po/CMakeLists.txt.

The en@shaw.po file has been cleared of automatic translations. The en_GB.po file contains the automatic copy of the American English text.