### PR TITLE
Correctly Hide haloes of items from displayed team

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2665,6 +2665,10 @@ void display::draw_overlays_at(const map_location& loc)
 			bool item_visible_for_team = std::find_first_of(team_names.begin(), team_names.end(),
 				current_team_names.begin(), current_team_names.end()) != team_names.end();
 
+			if(ov.halo_handle && ov.halo_handle->valid()) {
+				halo_man_.set_visible(ov.halo_handle, item_visible_for_team);
+			}
+
 			if(!item_visible_for_team) {
 				continue;
 			}

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -52,6 +52,8 @@ class halo_impl
 		);
 
 		void set_location(int x, int y);
+		void set_visible(bool visible);
+
 		rect get_draw_location();
 
 		/** Whether the halo is currently visible */
@@ -93,6 +95,8 @@ class halo_impl
 		// The map location the halo is attached to, if any
 		map_location map_loc_ = {-1, -1};
 
+		bool visible_by_team_ = true;
+
 		display* disp = nullptr;
 	};
 
@@ -124,6 +128,9 @@ public:
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(int handle, int x, int y);
+
+	/** Set whether to show the halo to the viewer based on their team. */
+	void set_visible(int handle, bool visible);
 
 	/** Remove the halo with the given handle. */
 	void remove(int handle);
@@ -161,6 +168,11 @@ void halo_impl::effect::set_location(int x, int y)
 		DBG_HL << "setting halo location " << new_center;
 		abs_mid_ = new_center;
 	}
+}
+
+void halo_impl::effect::set_visible(bool visible)
+{
+	visible_by_team_ = visible;
 }
 
 rect halo_impl::effect::get_draw_location()
@@ -222,6 +234,10 @@ void halo_impl::effect::update()
 
 bool halo_impl::effect::visible()
 {
+	if(!visible_by_team_) {
+		return false;
+	}
+
 	// Source is shrouded
 	// The halo will be completely obscured here, even if it would
 	// technically be large enough to peek out of the shroud.
@@ -330,6 +346,14 @@ void halo_impl::set_location(int handle, int x, int y)
 	}
 }
 
+void halo_impl::set_visible(int handle, bool visible)
+{
+	const std::map<int,effect>::iterator itor = haloes.find(handle);
+	if(itor != haloes.end()) {
+		itor->second.set_visible(visible);
+	}
+}
+
 void halo_impl::remove(int handle)
 {
 	// Silently ignore invalid haloes.
@@ -418,8 +442,14 @@ void manager::set_location(const handle & h, int x, int y)
 	impl_->set_location(h->id_,x,y);
 }
 
+/** Set whether to show the halo based on the currently displayed team. */
+void manager::set_visible(const handle& h, bool visible)
+{
+	impl_->set_visible(h->id_, visible);
+}
+
 /** Remove the halo with the given handle. */
-void manager::remove(const handle & h)
+void manager::remove(const handle& h)
 {
 	impl_->remove(h->id_);
 	h->id_ = NO_HALO;

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -56,6 +56,9 @@ public:
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(const handle & h, int x, int y);
 
+	/** Set whether to show the halo to the viewer based on their team. */
+	void set_visible(const handle& h, bool visible);
+
 	/** Remove the halo with the given handle. */
 	void remove(const handle & h);
 


### PR DESCRIPTION
Adding a new boolean value to halo to show or hide it depending on which team is the current team.

Fixes #10840