### PR TITLE
Add [overwrite_specials] to replace overwrite_specials and add [overwrite_abilities]  to abilities other than specials weapons.

### DIFF
--- a/changelog_entries/overwrite_abilities.md
+++ b/changelog_entries/overwrite_abilities.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add a [overwrite_abilities] to abilities that use the value attribute with the exception of abilities used as weapons ([damage], [chance_to_hit], etc... implemented in the [abilities] tag).

--- a/changelog_entries/overwrite_specials.md
+++ b/changelog_entries/overwrite_specials.md
@@ -1,0 +1,4 @@
+### WML Engine
+   * Because overwrite_specials cannot be applied to other abilities and its design and functionality leave something to be desired, an [overwrite_specials] subtag will be added to eventually replace it.
+     * Add to [overwrite_specials] an affect attribute to suppress special abilities affecting a unit applied to a particular side (apply_to=self or opponent) and which discriminates special abilities that affect self/student from special abilities belonging to the opponent, even if apply_to=attacker/defender is used.
+   * The use of 'overwrite_specials' attribute and [overwrite] subtag in specials are deprecated

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -415,7 +415,9 @@ sentinel #enddef
                     [damage]
                         apply_to=self
                         value=0
-                        overwrite_specials=one_side # not overwriting causes issues with the survivor trait
+                        [overwrite_specials] # not overwriting causes issues with the survivor trait
+                            affect=self
+                        [/overwrite_specials]
                     [/damage]
                 [/set_specials]
             [/effect]

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -551,10 +551,9 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=both_sides
-                        [overwrite]
-                            priority=1000
-                        [/overwrite]
+                        [overwrite_specials]
+                            priority=100000
+                        [/overwrite_specials]
                         priority=1000
                         [filter_opponent]
                             {SECOND_FILTER}
@@ -608,10 +607,9 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=both_sides
-                        [overwrite]
-                            priority=1000
-                        [/overwrite]
+                        [overwrite_specials]
+                            priority=100000
+                        [/overwrite_specials]
                         priority=1000
                         [filter_opponent]
                             {SECOND_FILTER}

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -4,7 +4,7 @@
 	max=0
 	{SIMPLE_KEY id string_list}
 	{SIMPLE_KEY tag_name string_list}
-	{SIMPLE_KEY overwrite_specials ability_overwrite}
+	{DEPRECATED_KEY overwrite_specials ability_overwrite}
 	{SIMPLE_KEY apply_to string_list}
 	{SIMPLE_KEY type string_list}
 	{SIMPLE_KEY replacement_type string_list}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -37,6 +37,10 @@
         value="self|opponent|attacker|defender|both"
     [/type]
     [type]
+        name="priority_apply"
+        value="self|opponent|both"
+    [/type]
+    [type]
         name="ability_overwrite"
         value="none|one_side|both_sides"
     [/type]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -77,6 +77,11 @@
 	{SIMPLE_KEY divide f_int}
 	{SIMPLE_KEY priority real}
 	{SIMPLE_KEY cumulative bool}
+	[tag]
+		name="overwrite_abilities"
+		{FILTER_TAG "filter_ability" abilities ()}
+		{SIMPLE_KEY priority real}
+	[/tag]
 [/tag]
 [tag]
 	name="defense"

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -48,7 +48,7 @@
 	# Using invalid characters to ensure it doesn't match a real tag.
 	name="~value~"
 	max=0
-	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~,units/unit_type/attack/specials/~overwrite_specials~"
 	{SIMPLE_KEY value s_f_int}
 	{SIMPLE_KEY add f_int}
 	{SIMPLE_KEY sub f_int}
@@ -73,6 +73,16 @@
 	[/tag]
 [/tag]
 [tag]
+	name="~overwrite_specials~"
+	max=0
+	[tag]
+		name="overwrite_specials"
+		{DEFAULT_KEY affect priority_apply both}
+		{FILTER_TAG "filter_special" abilities ()}
+		{SIMPLE_KEY priority real}
+	[/tag]
+[/tag]
+[tag]
 	name="attacks"
 	max=infinite
 	super="units/unit_type/attack/specials/~value~"
@@ -90,7 +100,7 @@
 [tag]
 	name="damage_type"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~,units/unit_type/attack/specials/~overwrite_specials~"
 	{SIMPLE_KEY replacement_type string}
 	{SIMPLE_KEY alternative_type string}
 [/tag]
@@ -107,20 +117,20 @@
 [tag]
 	name="berserk"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~,units/unit_type/attack/specials/~overwrite_specials~"
 	{SIMPLE_KEY value f_int}
 	{SIMPLE_KEY cumulative bool}
 [/tag]
 [tag]
 	name="plague"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~,units/unit_type/attack/specials/~overwrite_specials~"
 	{SIMPLE_KEY type string}
 [/tag]
 [tag]
 	name="swarm"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~,units/unit_type/attack/specials/~overwrite_specials~"
 	{SIMPLE_KEY swarm_attacks_max f_int}
 	{SIMPLE_KEY swarm_attacks_min f_int}
 	{SIMPLE_KEY cumulative bool}

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -64,12 +64,12 @@
 [tag]
 	name="~overwrite_special~"
 	max=0
-	{DEFAULT_KEY overwrite_specials ability_overwrite none}
+	{DEPRECATED_KEY overwrite_specials ability_overwrite}
 	[tag]
 		name="overwrite"
 		{FILTER_TAG "experimental_filter_specials" abilities (deprecated=yes)}
-		{FILTER_TAG "filter_specials" abilities ()}
-		{SIMPLE_KEY priority real}
+		{FILTER_TAG "filter_specials" abilities (deprecated=yes)}
+		{DEPRECATED_KEY priority real}
 	[/tag]
 [/tag]
 [tag]

--- a/data/test/macros/unit_setup.cfg
+++ b/data/test/macros/unit_setup.cfg
@@ -27,6 +27,15 @@
     [/overwrite_specials]
 #enddef
 
+#define OVERWRITE_ABILITIES FILTER EXTRA
+    [overwrite_abilities]
+        {EXTRA}
+        [filter_ability]
+            {FILTER}
+        [/filter_ability]
+    [/overwrite_abilities]
+#enddef
+
 #define TEST_ABILITY ABIL VALUE OTHER
 
 #arg ID

--- a/data/test/macros/unit_setup.cfg
+++ b/data/test/macros/unit_setup.cfg
@@ -18,6 +18,15 @@
     [/affect_adjacent]
 #enddef
 
+#define OVERWRITE_SPECIALS FILTER EXTRA
+    [overwrite_specials]
+        {EXTRA}
+        [filter_special]
+            {FILTER}
+        [/filter_special]
+    [/overwrite_specials]
+#enddef
+
 #define TEST_ABILITY ABIL VALUE OTHER
 
 #arg ID

--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_nested.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_nested.cfg
@@ -43,12 +43,14 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
-            [effect]#test if macro work when ability with overwrite_special is used
+            [effect]#test if macro work when ability with [overwrite_specials] is used
                 apply_to=new_ability
                 [abilities]
                     [chance_to_hit]
                         value=100
-                        overwrite_specials=one_side
+                        [overwrite_specials]
+                            affect=self
+                        [/overwrite_specials]
                     [/chance_to_hit]
                 [/abilities]
             [/effect]
@@ -74,12 +76,14 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
-            [effect]#test if macro work when ability with overwrite_special is used
+            [effect]#test if macro work when ability with [overwrite_specials] is used
                 apply_to=new_ability
                 [abilities]
                     [chance_to_hit]
                         value=100
-                        overwrite_specials=one_side
+                        [overwrite_specials]
+                            affect=self
+                        [/overwrite_specials]
                     [/chance_to_hit]
                 [/abilities]
             [/effect]

--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_toplevel.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_toplevel.cfg
@@ -43,12 +43,14 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
-            [effect]#test if macro work when ability with overwrite_special is used
+            [effect]#test if macro work when ability with [overwrite_specials] is used
                 apply_to=new_ability
                 [abilities]
                     [chance_to_hit]
                         value=100
-                        overwrite_specials=one_side
+                        [overwrite_specials]
+                            affect=self
+                        [/overwrite_specials]
                     [/chance_to_hit]
                 [/abilities]
             [/effect]
@@ -74,12 +76,14 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
-            [effect]#test if macro work when ability with overwrite_special is used
+            [effect]#test if macro work when ability with [overwrite_specials] is used
                 apply_to=new_ability
                 [abilities]
                     [chance_to_hit]
                         value=100
-                        overwrite_specials=one_side
+                        [overwrite_specials]
+                            affect=self
+                        [/overwrite_specials]
                     [/chance_to_hit]
                 [/abilities]
             [/effect]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks][overwrite_specials]
+##
+# Actions:
+# Give the leaders an attacks ability with both the value and add attributes and [overwrite_specials] for overwrite attacks with sub=
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes (5+1), because sub=4 not used
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_add_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (sub=4) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials_affect_side_no_match.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader an attacks ability with both add attributes and [overwrite_specials] for overwrite other abilities with sub applied to opponent.
+# Give side 1 leader an attacks ability who decrease attack of opponent of 4.
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 2 strikes (5+1-4), because sub=4 not erased by affect who erase applied to self only.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_add_overwrite_specials_affect_no_match" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=opponent}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (sub=4) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "2,2" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials_affect_side_succced.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_add_overwrite_specials_affect_side_succced.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader an attacks ability with both the value and add attributes and [overwrite_specials] for overwrite other abilities similar to lower priority.
+# Give side 1 leader an attacks ability who decrease attack of 4.
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes (5+1), because sub=4 not used
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_add_overwrite_specials_affect_succeed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=self}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE attacks (sub=4) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_overwrite_specials.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [berserk][overwrite_specials]
+##
+# Actions:
+# Give the side 1 leader a berserk ability with the [overwrite_specials] subtag
+# Give the side 1 leader a berserk ability without the [overwrite_specials] subtag
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons which strike 10 (2*5) and 20 (4*5) times, since the 5 value ability takes priority due to [overwrite_specials]
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "berserk_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY berserk 5 ({OVERWRITE_SPECIALS value=6-10 ()}) SELF=yes}
+                    {TEST_ABILITY berserk 7 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "10,20" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_overwrite_specials_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk/berserk_overwrite_specials_no_match.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [berserk][overwrite_specials]
+##
+# Actions:
+# Give the side 1 leader a berserk ability with the [overwrite_specials] subtag
+# Give the side 1 leader a berserk ability without the [overwrite_specials] subtag
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons which strike 12 (2*6) and 24 (4*6) times, since the 5 value ability can't takes priority without [overwrite_specials] who match
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "berserk_overwrite_specials_no_match" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY berserk 5 ({OVERWRITE_SPECIALS value=7 ()}) SELF=yes}
+                    {TEST_ABILITY berserk 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "12,24" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials.cfg
@@ -1,0 +1,38 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit][overwrite_specials]
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the value and add attributes, adding up to 100, with [overwrite_specials] for overwrite abilities with sub
+# Give the leaders a chance_to_hit ability with both the value and sub attributes
+# Give each unit 1000 hp and 100 strikes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 100 times
+# The side 1 leader's second weapon strikes 100 times
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_add_overwrite_specials" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (add=100
+                    {OVERWRITE_SPECIALS sub=0-100 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (sub=100) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "100,100" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials_affect_side_no_match.cfg
@@ -1,0 +1,41 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader a chance_to_hit ability with add attributes, adding up to 100, with [overwrite_specials] for overwrite abilities with sub applied to opponent
+# Give side 1 leader a chance_to_hit ability with both the value and sub attributes
+# Give each unit 1000 hp and 100 strikes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon don't strikes 0 or 100 times
+# The side 1 leader's second weapon don't strikes 0 or 100 times
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_add_overwrite_specials_affect_no_match" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 50 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (add=50
+                    {OVERWRITE_SPECIALS sub=0-100 affect=opponent}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (sub=50) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "0,0" ({SUCCEED}) COMPARE=numerical_not_equals (CHANCE_TO_HIT=)}
+    {CHECK_STRIKES "100,100" ({SUCCEED}) COMPARE=numerical_not_equals (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials_affect_side_succeed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_add_overwrite_specials_affect_side_succeed.cfg
@@ -1,0 +1,40 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader a chance_to_hit ability with add attributes, adding up to 100, with [overwrite_specials] for overwrite abilities with sub applied to opponent
+# Give side 1 leader a chance_to_hit ability with both the value and sub attributes
+# Give each unit 1000 hp and 100 strikes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 100 times
+# The side 1 leader's second weapon strikes 100 times
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_add_overwrite_specials_affect_succeed" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 50 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (add=50
+                    {OVERWRITE_SPECIALS sub=0-100 affect=self}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE chance_to_hit (sub=100) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "100,100" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials.cfg
@@ -1,0 +1,34 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage][overwrite_specials]
+##
+# Actions:
+# Give the leaders a damage ability with add attributes with [overwrite_specials] for overwrite abilities with sub=
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage (5+1)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_add_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials_affect_side_no_match.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader a damage ability with add attributes with [overwrite_specials] for overwrite abilities with sub= applied to opponent
+# Give side 1 leader a damage ability with sub attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 4 damage (5+1-2)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_add_overwrite_specials_affect_no_match" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=opponent}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 5 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 5 DAMAGE2=4 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials_affect_side_succeed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_add_overwrite_specials_affect_side_succeed.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage][overwrite_specials]affect=
+##
+# Actions:
+# Give side 1 leader a damage ability with add attributes with [overwrite_specials] for overwrite abilities with sub= applied to self
+# Give side 1 leader a damage ability with sub attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage (5+1)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_add_overwrite_specials_affect_succeed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=1
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=self}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE damage (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 5 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 5 DAMAGE2=6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_many_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_many_overwrite_specials.cfg
@@ -1,0 +1,66 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,replacement_type= with [overwrite_specials]
+##
+# Actions:
+# Give the leaders damage_type abilities with
+#   replacement_type=pierce, 3x
+#   replacement_type=arcane, 1x
+#   alternative_type=blade, 3x
+#   alternative_type=arcane, 1x
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage, 40% weakness to arcane, and 20% weakness to blade
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the arcane damage type(replacement_type=arcane and alternative_type=blade and arcane make more damage what blade to opponent, others [damage_type] with pierce type are overwrited by [overwrite_specials])
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_many_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                        alternative_type = "blade"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "arcane"
+                        alternative_type = "blade"
+                        {OVERWRITE_SPECIALS () ()}
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "pierce"
+                        alternative_type = "arcane"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "blade"
+                        {OVERWRITE_SPECIALS () ()}
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                    arcane = 150
+                    blade = 120
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 3 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/defense/defense_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/defense/defense_add_overwrite_abilities.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [defense][overwrite_abilities]
+##
+# Actions:
+# Give the leaders a defense ability with both the value and add attributes, adding up to 100, with [overwrite_abilities] for overwrite abilities with sub attributes
+# Give each unit 1000 hp and 100 strikes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 0 times
+# The side 1 leader's second weapon strikes 0 times
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "defense_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE defense (add=100
+                    {OVERWRITE_ABILITIES sub=0-100 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE defense (sub=100) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "0,0" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials.cfg
@@ -1,0 +1,36 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains][overwrite_specials]
+##
+# Actions:
+# Give the leaders an drains ability with both the value and add attributes and [overwrite_specials] who overwrite drains with sub
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now drains 6 hp (5+1), sub is ignored
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_add_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_no_match.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains][overwrite_specials]affect=
+##
+# Actions:
+# Give side 2 leader a drains ability with  attributes and [overwrite_specials] who overwrite drains with sub applied to opponent
+# Give side 1 leader a drains ability with sub attributes applied to self
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 2 leader have 2 weapons each of which now drains 6 hp (5+3-2)
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_add_overwrite_specials_affect_no_match" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (add=3
+                    {OVERWRITE_SPECIALS sub=1-4 affect=opponent}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 200 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_succeed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_succeed.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains][overwrite_specials]affect=
+##
+# Actions:
+# Give side 2 leader a drains ability with  attributes and [overwrite_specials] who overwrite drains with sub applied to self
+# Give side 2 leader a drains ability with sub attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 2 leader have 2 weapons each of which now drains 6 hp (5+1), sub is ignored
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_add_overwrite_specials_affect_succeed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=self}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 200 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials.cfg
@@ -1,0 +1,36 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit][overwrite_specials]
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with add attributes and [overwrite_specials] who overwrite heal_on_hit with sub
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp (5+1), sub is ignored
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_add_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (add=1
+                    {OVERWRITE_SPECIALS (sub=1-4) ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials_affect_side_no_match.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit][overwrite_specials]affect=
+##
+# Actions:
+# Give side 2 leader a heal_on_hit ability with  attributes and [overwrite_specials] who overwrite heal_on_hit with sub applied to opponent
+# Give side 1 leader a heal_on_hit ability with sub attributes applied to self
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 2 leader have 2 weapons each of which now heal_on_hit 6 hp (5+3-2)
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_add_overwrite_specials_affect_no_match" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (add=3
+                    {OVERWRITE_SPECIALS sub=1-4 affect=opponent}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 200 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials_affect_side_succeed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_add_overwrite_specials_affect_side_succeed.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit][overwrite_specials]affect=
+##
+# Actions:
+# Give side 2 leader a heal_on_hit ability with  attributes and [overwrite_specials] who overwrite heal_on_hit with sub applied to self
+# Give side 2 leader a heal_on_hit ability with sub attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heal_on_hit 6 hp (5+1), sub is ignored
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_add_overwrite_specials_affect_succeed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 5 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (add=1
+                    {OVERWRITE_SPECIALS sub=1-4 affect=self}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE heal_on_hit (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 200 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heal_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heal_add_overwrite_abilities.cfg
@@ -1,0 +1,62 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heals][overwrite_abilities]
+##
+# Actions:
+# Give the leaders a heals ability with both the value and add attributes and [overwrite_abilities] who overwrite heals with sub
+# Spawn a Mage next to the side 1 leader.
+# Set all units' hitpoints to 1.
+# Wait a turn for healing to take place.
+##
+# Expected end state:
+# The Mage has 7 hp: 1 + 2 (rest healing) + 4 ([heals], 2 (value) + 2 (add))
+#####
+{GENERIC_UNIT_TEST "heal_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE heals ([affect_adjacent][/affect_adjacent]
+                    add=4
+                    {OVERWRITE_ABILITIES sub=1-4 ()}) ALLIES=yes}
+                    {TEST_ABILITY_NO_VALUE heals ([affect_adjacent][/affect_adjacent]
+                    sub=2) ALLIES=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {NOTRAIT_UNIT 1 (Mage) 7 4}
+        {SET_HP VALUE=1}
+
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name = side 2 turn 1
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name =side 1 turn 2
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name = side 2 turn 2
+
+        [store_unit]
+            [filter]
+                type = "Mage"
+            [/filter]
+            variable = temp
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 7}}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/illuminates/illuminates_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/illuminates/illuminates_add_overwrite_abilities.cfg
@@ -1,0 +1,34 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [illuminates][overwrite_abilities]
+##
+# Actions:
+# Give all units 70% self-illuminates bonus damage (+70) and [overwrite_abilities] who overwrite illuminates with sub
+# Attack each other
+##
+# Expected end state:
+# The damage from the attack is increased by 70%
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "illuminates_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE illuminates (max_value,add=100,70
+                    {OVERWRITE_ABILITIES sub=1-40 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE illuminates (max_value=100
+                    sub=40) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 170}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER=Mage SIDE2_LEADER=Mage}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_add_overwrite_abilities.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [leadership][overwrite_abilities]
+##
+# Actions:
+# Give all units 70% self-leadership bonus damage (+70) and [overwrite_abilities] who overwrite leadership with sub
+# Attack each other
+##
+# Expected end state:
+# The damage from the attack is increased by 70%
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "leadership_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE leadership (add=70
+                    {OVERWRITE_ABILITIES sub=1-40 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE leadership (sub=20) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 170}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/plague/plague_ability_multiple_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/plague/plague_ability_multiple_overwrite_specials.cfg
@@ -1,0 +1,99 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [plague][overwrite_specials]
+##
+# Actions:
+# Give the leaders a plague ability
+# Spawn a side 2 unit
+# Have side 1's leader attack the side 2 unit with their first weapon
+# Spawn a side 2 unit
+# Have side 1's leader attack the side 2 unit with their second weapon
+##
+# Expected end state:
+# Both weapons cause a Chocobone to spawn
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "plague_ability_multiple_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE plague (type="Walking Corpse") SELF=yes}
+                    {TEST_ABILITY_NO_VALUE plague (type="Chocobone"
+                    {OVERWRITE_SPECIALS () ()}) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=alice,bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=100
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [unit]
+            type = Mage
+            x,y = 4,2
+            side = 2
+            id = "z1"
+        [/unit]
+        [unit]
+            type = Mage
+            x,y = 5,4
+            side = 2
+            id = "z2"
+        [/unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=z1
+            weapon=0
+            resupply_attacks_left=1
+        [/test_do_attack_by_id]
+
+        {ASSERT (
+            [have_unit]
+                side = 1
+                type = "Chocobone"
+                x,y = 4,2
+            [/have_unit]
+        )}
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=z2
+            weapon=1
+            resupply_attacks_left=1
+        [/test_do_attack_by_id]
+
+        {ASSERT (
+            [have_unit]
+                side = 1
+                type = "Chocobone"
+                x,y = 5,4
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/regenerate/regenerate_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/regenerate/regenerate_add_overwrite_abilities.cfg
@@ -1,0 +1,58 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [regenerate][overwrite_abilities]
+##
+# Actions:
+# Give the leaders a regenerate ability with add attributes and [overwrite_abilities] who erase regenerate with sub
+# Set all units' hitpoints to 1.
+# Wait a turn for regenerating to take place.
+##
+# Expected end state:
+# The Mage has 7 hp: 1 + 2 (rest healing) + 4 ([regenerate], 2 (value) + 2 (add))
+#####
+{GENERIC_UNIT_TEST "regenerate_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE regenerate (add=4
+                    {OVERWRITE_ABILITIES sub=1-4 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE regenerate (sub=2) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {SET_HP VALUE=1}
+
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name = side 2 turn 1
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name =side 1 turn 2
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name = side 2 turn 2
+
+        [store_unit]
+            [filter]
+                type = "Elvish Archer"
+            [/filter]
+            variable = temp
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 7}}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_add_overwrite_abilities.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_add_overwrite_abilities.cfg
@@ -1,0 +1,34 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [resistance][overwrite_abilities]
+##
+# Actions:
+# Give all units 70% resistance to all damage types (50+20) and [overwrite_abilities] who overwrite resistance with sub
+# Attack each other
+##
+# Expected end state:
+# The damage from the attack is reduced by 70%
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "resistance_add_overwrite_abilities" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY resistance 50 () SELF=yes}
+                    {TEST_ABILITY_NO_VALUE resistance (max_value,add=100,20
+                    {OVERWRITE_ABILITIES sub=1-40 ()}) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE resistance (max_value,sub=100,20) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 30}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/swarm/swarm_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/swarm/swarm_overwrite_specials.cfg
@@ -1,0 +1,54 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [swarm][overwrite_specials]
+##
+# Actions:
+# Give the side 1 leader a swarm ability/special with the [overwrite_specials] subtag
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# For both weapons, the first attack has 10 strikes and the second attack has 6 strikes (19/29, rounded down), special with [overwrite_specials] take priority
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "swarm_overwrite_specials" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY_NO_VALUE swarm ({OVERWRITE_SPECIALS () ()}
+                    swarm_attacks_min=0
+                    swarm_attacks_max=10) SELF=yes}
+                    {TEST_ABILITY_NO_VALUE swarm (swarm_attacks_min=4
+                    swarm_attacks_max=6) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {SWARM_ATTACK_TEST 0 alice bob 10 10 16 16}
+        {SWARM_ATTACK_TEST 1 alice bob 10 10 16 16}
+
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -132,6 +132,7 @@ unit_ability_t::unit_ability_t(std::string tag, config cfg, bool inside_attack)
 	, affects_enemies_(false)
 	, priority_(cfg["priority"].to_double(0.00))
 	, suppress_special_priority_(-100000.00)
+	, suppress_ability_priority_(-100000.00)
 	, cfg_(std::move(cfg))
 	, currently_checked_(false)
 {
@@ -175,6 +176,9 @@ unit_ability_t::unit_ability_t(std::string tag, config cfg, bool inside_attack)
 		} else {
 			suppress_special_priority_ = 0.00;
 		}
+	}
+	if(auto overwrite_abilities = cfg_.optional_child("overwrite_abilities")) {
+		suppress_ability_priority_ = overwrite_abilities["priority"].to_double(0.00);
 	}
 }
 
@@ -2003,6 +2007,54 @@ bool specials_context_t::is_special_active(const specials_combatant& self, const
 	return true;
 }
 
+namespace
+{
+	bool priority_checking(active_ability_list& overwriters, const active_ability& overwritten)
+	{
+		if(overwriters.empty()){
+			return false;
+		}
+		const unit_ability_t& ab = overwritten.ability();
+
+		for(const auto& j : overwriters) {
+			// If this element of overwriters does not have a priority strictly higher than ab,
+			// either it does not have [overwrite_abilities] or both have [overwrite_abilities] of the same priority;
+			// in either case, ab cannot be suppressed by this element of the list
+			if(j.ability().suppress_ability_priority() <= ab.suppress_ability_priority()) {
+				continue;
+			}
+
+			// [overwrite_abilities]priority= having already been checked above, it remains to check if a sub-filter [filter_ability] exists and if so,
+			// if it corresponds to ab.
+			auto overwrite_filter = j.ability_cfg().optional_child("overwrite_abilities");
+			if(overwrite_filter) {
+				auto filter_abilities = (*overwrite_filter).optional_child("filter_ability");
+				if(filter_abilities && !common_matches_filter(ab.cfg(), ab.tag(), *filter_abilities)) {
+					continue;
+				}
+				// if all checks match, ab can be suppressed and other elements of the list won't be checked.
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void apply_ability_suppression(active_ability_list& abil_list)
+	{
+		// If two or more abilities have [overwrite_abilities],
+		// priority sorting allows the highest priority ability to suppress a lower priority ability before the lower priority ability can,
+		// in turn, suppress an ability with an even lower priority than the first two.
+		utils::sort_if(abil_list,[](const active_ability& i, const active_ability& j){
+			double l = i.ability().suppress_ability_priority();
+			double r = j.ability().suppress_ability_priority();
+			return l > r;
+		});
+		utils::erase_if(abil_list, [&](const active_ability& i) {
+			return (priority_checking(abil_list, i));
+		});
+	}
+}
+
 namespace unit_abilities
 {
 
@@ -2049,11 +2101,15 @@ static int individual_value_double(const config::attribute_value *v, int def, co
 	return value;
 }
 
-effect::effect(const active_ability_list& list, int def, const specials_context_t* ctx, EFFECTS wham) :
+effect::effect(active_ability_list list, int def, const specials_context_t* ctx, EFFECTS wham) :
 	effect_list_(),
 	composite_value_(def),
 	composite_double_value_(def)
 {
+	// If ctx is not empty, then this is a special. The [overwrite_specials] feature is handled in get_specials_and_abilities() and so nothing should be done here in that case.
+	if(!ctx) {
+		apply_ability_suppression(list);
+	}
 	std::map<double, active_ability_list> base_list;
 	for(const active_ability& i : list) {
 		double priority = i.ability().priority();

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -131,6 +131,7 @@ unit_ability_t::unit_ability_t(std::string tag, config cfg, bool inside_attack)
 	, affects_self_(true)
 	, affects_enemies_(false)
 	, priority_(cfg["priority"].to_double(0.00))
+	, suppress_special_priority_(-100000.00)
 	, cfg_(std::move(cfg))
 	, currently_checked_(false)
 {
@@ -164,6 +165,14 @@ unit_ability_t::unit_ability_t(std::string tag, config cfg, bool inside_attack)
 	}
 	affects_self_ = cfg_["affect_self"].to_bool(true);
 	affects_enemies_ = cfg_["affect_enemies"].to_bool(false);
+
+	if(cfg_["overwrite_specials"] == "one_side" || cfg_["overwrite_specials"] == "both_sides") {
+		if(auto overwrite = cfg_.optional_child("overwrite")) {
+			suppress_special_priority_ = overwrite["priority"].to_double(0.00);
+		} else {
+			suppress_special_priority_ = 0.00;
+		}
+	}
 }
 
 void unit_ability_t::do_compat_fixes(config& cfg, const std::string& tag, bool inside_attack)
@@ -1405,108 +1414,54 @@ std::vector<unit_ability_t::tooltip_info> specials_context_t::abilities_special_
 //units (abilities of type 'aura') or else on all types of weapons even if the
 //beneficiary unit does not have a corresponding weapon
 //(defense against ranged weapons abilities for a unit that only has melee attacks)
-static bool overwrite_special_affects(const unit_ability_t& ab)
-{
-	const std::string& apply_to = ab.cfg()["overwrite_specials"];
-	return (apply_to == "one_side" || apply_to == "both_sides");
+namespace {
+	bool overwrite_special_affects(const unit_ability_t& ab)
+	{
+		const std::string& apply_to = ab.cfg()["overwrite_specials"];
+		return (apply_to == "one_side" || apply_to == "both_sides");
+	}
 }
 
-active_ability_list attack_type::overwrite_special_overwriter(active_ability_list overwriters) const
-{
-	//remove element without overwrite_specials key, if list empty after check return empty list.
-	utils::erase_if(overwriters, [&](const active_ability& i) {
-		return (!overwrite_special_affects(i.ability()));
-	});
-
-	// if empty, nothing is doing any overwriting
-	if(overwriters.empty()){
-		return overwriters;
-	}
-
-	// if there are specials/"specials as abilities" that could potentially overwrite each other
-	if(overwriters.size() >= 2){
-		// sort them by overwrite priority from highest to lowest (default priority is 0)
-		utils::sort_if(overwriters,[](const active_ability& i, const active_ability& j){
-			auto oi = i.ability_cfg().optional_child("overwrite");
-			double l = 0;
-			if(oi && !oi["priority"].empty()){
-				l = oi["priority"].to_double(0);
-			}
-			auto oj = j.ability_cfg().optional_child("overwrite");
-			double r = 0;
-			if(oj && !oj["priority"].empty()){
-				r = oj["priority"].to_double(0);
-			}
-			return l > r;
-		});
-		// remove any that need to be overwritten
-		utils::erase_if(overwriters, [&](const active_ability& i) {
-			return (overwrite_special_checking(overwriters, i));
-		});
-	}
-	return overwriters;
-}
-
-bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const active_ability& i) const
+bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const active_ability& overwrited) const
 {
 	auto ctx = fallback_context();
 	auto [self, other] = context_->self_and_other(*this);
+	const map_location& loc = overwrited.student_loc;
 	if(overwriters.empty()){
 		return false;
 	}
 
-	const unit_ability_t& ab = i.ability();
-	const map_location& loc = i.student_loc;
-
+	const unit_ability_t& ab = overwrited.ability();
 	for(const auto& j : overwriters) {
-		const map_location& ov_loc = j.student_loc;
-		// whether the overwriter affects a single side
-		bool affect_side = (j.ability_cfg()["overwrite_specials"] == "one_side");
-		// the overwriter's priority, default of 0
-		auto overwrite_specials = j.ability_cfg().optional_child("overwrite");
-		double priority = overwrite_specials ? overwrite_specials["priority"].to_double(0) : 0.00;
-		// the cfg being checked for whether it will be overwritten
-		auto has_overwrite_specials = ab.cfg().optional_child("overwrite");
-		// if the overwriter's priority is greater than 0, then true if the cfg being checked has a higher priority
-		// else true
-		bool prior = (priority > 0) ? (has_overwrite_specials && has_overwrite_specials["priority"].to_double(0) >= priority) : true;
-		// true if the cfg being checked affects one or both sides and doesn't have a higher priority, or if it doesn't affect one or both sides
-		// aka whether the cfg being checked can potentially be overwritten by the current overwriter
-		bool is_overwritable = (overwrite_special_affects(ab) && !prior) || !overwrite_special_affects(ab);
-		bool one_side_overwritable = true;
+		if(j.ability().suppress_special_priority() <= ab.suppress_special_priority() || !overwrite_special_affects(j.ability())) {
+			continue;
+		}
 
-		// if the current overwriter affects one side and the cfg being checked can be overwritten by this overwriter
-		// then check that the current overwriter and the cfg being checked both affect either this unit or its opponent
-		if(affect_side && is_overwritable) {
-			if(ov_loc == self.loc) {
-				one_side_overwritable = loc == self.loc;
+		//the location of the fighters is used to differentiate the specials applied to 'self' from those applied to 'opponent'
+		//in all cases including 'apply_to=attacker/defender'
+		if(j.ability_cfg()["overwrite_specials"].str() == "one_side") {
+			if(j.student_loc == self.loc && loc != self.loc) {
+				continue;
 			}
-			else if(other.un && (ov_loc == other.loc)) {
-				one_side_overwritable = loc == other.loc;
+			if(other.un && j.student_loc == other.loc && loc != other.loc) {
+				continue;
 			}
 		}
 
-		// check whether the current overwriter is disabled due to a filter
-		bool special_matches = true;
-		if(overwrite_specials){
-			auto overwrite_filter = (*overwrite_specials).optional_child("filter_specials");
-			if(!overwrite_filter){
-				overwrite_filter = (*overwrite_specials).optional_child("experimental_filter_specials");
-				if(overwrite_filter){
+		auto overwrite_filter = j.ability_cfg().optional_child("overwrite");
+		if(overwrite_filter) {
+			auto filter_abilities_specials = (*overwrite_filter).optional_child("filter_specials");
+			if(!filter_abilities_specials) {
+				filter_abilities_specials = (*overwrite_filter).optional_child("experimental_filter_specials");
+				if(filter_abilities_specials) {
 					deprecated_message("experimental_filter_specials", DEP_LEVEL::FOR_REMOVAL, {1, 21, 0}, "Use filter_specials instead.");
 				}
 			}
-			if(overwrite_filter && is_overwritable && one_side_overwritable){
-				special_matches = ab.matches_filter(*overwrite_filter);
+			if(filter_abilities_specials && !ab.matches_filter(*filter_abilities_specials)) {
+				continue;
 			}
 		}
-
-		// if the cfg being checked should be overwritten
-		// and either this unit or its opponent are affected
-		// and the current overwriter is not disabled due to a filter
-		if(is_overwritable && one_side_overwritable && special_matches){
-			return true;
-		}
+		return true;
 	}
 	return false;
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -166,7 +166,10 @@ unit_ability_t::unit_ability_t(std::string tag, config cfg, bool inside_attack)
 	affects_self_ = cfg_["affect_self"].to_bool(true);
 	affects_enemies_ = cfg_["affect_enemies"].to_bool(false);
 
-	if(cfg_["overwrite_specials"] == "one_side" || cfg_["overwrite_specials"] == "both_sides") {
+	if(auto overwrite_specials = cfg_.optional_child("overwrite_specials")) {
+		suppress_special_priority_ = overwrite_specials["priority"].to_double(0.00);
+	}
+	else if(cfg_["overwrite_specials"] == "one_side" || cfg_["overwrite_specials"] == "both_sides") {
 		if(auto overwrite = cfg_.optional_child("overwrite")) {
 			suppress_special_priority_ = overwrite["priority"].to_double(0.00);
 		} else {
@@ -1422,23 +1425,49 @@ namespace {
 	}
 }
 
-bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const active_ability& overwrited) const
+bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const active_ability& overwritten) const
 {
 	auto ctx = fallback_context();
 	auto [self, other] = context_->self_and_other(*this);
-	const map_location& loc = overwrited.student_loc;
-	if(overwriters.empty()){
+	const map_location& loc = overwritten.student_loc;
+	if(overwriters.empty()) {
 		return false;
 	}
 
-	const unit_ability_t& ab = overwrited.ability();
+	const unit_ability_t& ab = overwritten.ability();
 	for(const auto& j : overwriters) {
-		if(j.ability().suppress_special_priority() <= ab.suppress_special_priority() || !overwrite_special_affects(j.ability())) {
+		if(j.ability().suppress_special_priority() <= ab.suppress_special_priority()) {
 			continue;
 		}
 
-		//the location of the fighters is used to differentiate the specials applied to 'self' from those applied to 'opponent'
-		//in all cases including 'apply_to=attacker/defender'
+		// code for new feature [overwrite_specials].
+		auto overwrite_specials = j.ability_cfg().optional_child("overwrite_specials");
+		if(overwrite_specials) {
+			// the location of the fighters is used to differentiate the specials applied to 'self' from those applied to 'opponent'
+			// in all cases including 'apply_to=attacker/defender'.
+			if((*overwrite_specials)["affect"].str("both") == "self" && loc != self.loc) {
+				continue;
+			}
+			if(other.un && (*overwrite_specials)["affect"].str("both") == "opponent" && loc != other.loc) {
+				continue;
+			}
+			// if ab don't match with [filter_special], continue check with next element of overwriters list.
+			auto filter_abilities_specials = (*overwrite_specials).optional_child("filter_special");
+			if(filter_abilities_specials && !ab.matches_filter(*filter_abilities_specials)) {
+				continue;
+			}
+			return true;
+		}
+
+		// If neither the tag nor the 'overwrite_specials' attribute are valid, we move directly to the next element in the overwriters list.
+		if(!overwrite_special_affects(j.ability())) {
+			continue;
+		}
+
+		//code for old feature 'overwrite_specials' if special don't have new one.
+
+		// the location of the fighters is used to differentiate the specials applied to 'self' from those applied to 'opponent'
+		// in all cases including 'apply_to=attacker/defender'.
 		if(j.ability_cfg()["overwrite_specials"].str() == "one_side") {
 			if(j.student_loc == self.loc && loc != self.loc) {
 				continue;

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -241,6 +241,10 @@ void unit_ability_t::do_compat_fixes(config& cfg, const std::string& tag, bool i
 		cfg.remove_children("filter_second_weapon");
 		cfg.remove_children("filter_weapon");
 	}
+
+	if(!cfg["overwrite_specials"].blank() || cfg.optional_child("overwrite")) {
+		deprecated_message("overwrite_specials= or [overwrite] in weapon specials", DEP_LEVEL::INDEFINITE, "", "Use [overwrite_specials] instead.");
+	}
 }
 
 
@@ -1709,6 +1713,9 @@ namespace
 		if(!bool_matches_if_present(filter, cfg, "cumulative", false))
 			return false;
 
+		if(!cfg["overwrite_specials"].blank() || cfg.optional_child("overwrite")) {
+			deprecated_message("overwrite_specials= or [overwrite] in weapon specials", DEP_LEVEL::INDEFINITE, "", "Use [overwrite_specials] instead.");
+		}
 		if(!string_matches_if_present(filter, cfg, "overwrite_specials", "none"))
 			return false;
 

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -59,6 +59,8 @@ public:
 	apply_to_t apply_to() const { return apply_to_; };
 	double priority() const { return priority_; };
 
+	double suppress_special_priority() const { return suppress_special_priority_; };
+
 	//has no effect in [specials]
 	affects_allies_t affects_allies() const { return affects_allies_; }
 	//has no effect in [specials]
@@ -149,6 +151,7 @@ private:
 	bool affects_self_;
 	bool affects_enemies_;
 	double priority_;
+	double suppress_special_priority_;
 	config cfg_;
 
 	mutable bool currently_checked_;

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -60,6 +60,7 @@ public:
 	double priority() const { return priority_; };
 
 	double suppress_special_priority() const { return suppress_special_priority_; };
+	double suppress_ability_priority() const { return suppress_ability_priority_; };
 
 	//has no effect in [specials]
 	affects_allies_t affects_allies() const { return affects_allies_; }
@@ -152,6 +153,7 @@ private:
 	bool affects_enemies_;
 	double priority_;
 	double suppress_special_priority_;
+	double suppress_ability_priority_;
 	config cfg_;
 
 	mutable bool currently_checked_;
@@ -354,7 +356,7 @@ struct individual_effect
 class effect
 {
 	public:
-		effect(const active_ability_list& list, int def, const specials_context_t* ctx = nullptr, EFFECTS wham = EFFECT_DEFAULT);
+		effect(active_ability_list list, int def, const specials_context_t* ctx = nullptr, EFFECTS wham = EFFECT_DEFAULT);
 		// Provide read-only access to the effect list:
 		typedef std::vector<individual_effect>::const_iterator iterator;
 		typedef std::vector<individual_effect>::const_iterator const_iterator;

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -876,20 +876,19 @@ bool attack_type::special_active(const unit_ability_t& ab, AFFECTS whom) const
 	return context_->is_special_active(self, ab, whom);
 }
 
-
 active_ability_list attack_type::get_specials_and_abilities(const std::string& special) const
 {
 	auto ctx = fallback_context();
 	auto abil_list = context_->get_active_specials(*this, special);
 
-	// get a list of specials/"specials as abilities" that may potentially overwrite others
-	active_ability_list overwriters = overwrite_special_overwriter(abil_list);
-	if (!abil_list.empty() && !overwriters.empty()) {
-		// remove all abilities that would be overwritten
-		utils::erase_if(abil_list, [&](const active_ability& j) {
-			return (overwrite_special_checking(overwriters, j));
-			});
-	}
+	utils::sort_if(abil_list,[](const active_ability& i, const active_ability& j){
+		double l = i.ability().suppress_special_priority();
+		double r = j.ability().suppress_special_priority();
+		return l > r;
+	});
+	utils::erase_if(abil_list, [&](const active_ability& i) {
+		return (overwrite_special_checking(abil_list, i));
+	});
 	return abil_list;
 }
 /**

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -188,20 +188,13 @@ public:
 	 */
 	std::pair<std::string, int> select_alternative_type(const active_ability_list& damage_type_list, const active_ability_list& resistance_list) const;
 	/**
-	 * Filter a list of abilities or weapon specials, removing any entries that don't own
-	 * the overwrite_specials attributes.
-	 *
-	 * @param overwriters list that may have overwrite_specials attributes.
-	 */
-	active_ability_list overwrite_special_overwriter(active_ability_list overwriters) const;
-	/**
-	 * Check whether @a cfg would be overwritten by any element of @a overwriters.
+	 * Check whether @a overwrited would be overwritten by any element of @a overwriters.
 	 *
 	 * @return True if element checked is overwritable.
 	 * @param overwriters list used for check if element is overwritable.
-	 * @param i the ability/special checked
+	 * @param overwrited the ability/special checked
 	 */
-	bool overwrite_special_checking(active_ability_list& overwriters, const active_ability& i) const;
+	bool overwrite_special_checking(active_ability_list& overwriters, const active_ability& overwrited) const;
 
 	bool special_active(const unit_ability_t& ab, AFFECTS whom) const;
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -619,6 +619,7 @@
 0 heal_affect_enemies
 0 heal_affect_everybody
 0 heal_divide
+0 heal_add_overwrite_abilities
 0 heal_high_fraction
 0 heal_low_fraction
 0 heal_multiply
@@ -659,6 +660,7 @@
 0 regenerate_affect_enemies
 0 regenerate_affect_everybody
 0 regenerate_divide
+0 regenerate_add_overwrite_abilities
 0 regenerate_high_fraction
 0 regenerate_low_fraction
 0 regenerate_multiply
@@ -698,6 +700,7 @@
 0 resistance_affect_enemies
 0 resistance_affect_everybody
 0 resistance_divide
+0 resistance_add_overwrite_abilities
 0 resistance_high_fraction
 0 resistance_low_fraction
 0 resistance_multiply
@@ -749,6 +752,7 @@
 0 leadership_affect_enemies
 0 leadership_affect_everybody
 0 leadership_divide
+0 leadership_add_overwrite_abilities
 0 leadership_high_fraction
 0 leadership_low_fraction
 0 leadership_multiply
@@ -787,6 +791,7 @@
 0 illuminates_affect_everybody
 0 illuminates_affect_self_no
 0 illuminates_divide
+0 illuminates_add_overwrite_abilities
 0 illuminates_high_fraction
 0 illuminates_low_fraction
 0 illuminates_max_value

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -847,6 +847,9 @@
 0 attacks_zero
 0 attacks_add
 0 attacks_add_cumulative
+0 attacks_add_overwrite_specials
+0 attacks_add_overwrite_specials_affect_no_match
+0 attacks_add_overwrite_specials_affect_succeed
 0 attacks_add_divide
 0 attacks_add_multiply
 0 attacks_add_sub
@@ -894,6 +897,8 @@
 0 berserk_affect_enemies
 0 berserk_affect_everybody
 0 berserk_divide
+0 berserk_overwrite_specials
+0 berserk_overwrite_specials_no_match
 0 berserk_high_fraction
 0 berserk_low_fraction
 0 berserk_multiply
@@ -922,6 +927,9 @@
 0 chance_to_hit_priority_low
 0 chance_to_hit_negative_value
 0 chance_to_hit_add
+0 chance_to_hit_add_overwrite_specials
+0 chance_to_hit_add_overwrite_specials_affect_no_match
+0 chance_to_hit_add_overwrite_specials_affect_succeed
 0 chance_to_hit_add_cumulative
 0 chance_to_hit_add_divide
 0 chance_to_hit_add_multiply
@@ -961,6 +969,9 @@
 0 damage_zero
 0 damage_add
 0 damage_add_cumulative
+0 damage_add_overwrite_specials
+0 damage_add_overwrite_specials_affect_no_match
+0 damage_add_overwrite_specials_affect_succeed
 0 damage_add_divide
 0 damage_add_multiply
 0 damage_add_sub
@@ -1020,10 +1031,12 @@
 0 damage_type_both_same_replacement_best
 0 damage_type_both_same_alternative_best
 0 damage_type_many
+0 damage_type_many_overwrite_specials
 # defense ability tests
 0 defense_negative_value
 0 defense_add
 0 defense_add_cumulative
+0 defense_add_overwrite_abilities
 0 defense_overwrited_by_chance_to_hit
 0 defense_add_divide
 0 defense_add_multiply
@@ -1065,6 +1078,9 @@
 0 drains_zero
 0 drains_add
 0 drains_add_cumulative
+0 drains_add_overwrite_specials
+0 drains_add_overwrite_specials_affect_no_match
+0 drains_add_overwrite_specials_affect_succeed
 0 drains_add_divide
 0 drains_add_multiply
 0 drains_add_sub
@@ -1116,6 +1132,9 @@
 0 heal_on_hit_zero
 0 heal_on_hit_add
 0 heal_on_hit_add_cumulative
+0 heal_on_hit_add_overwrite_specials
+0 heal_on_hit_add_overwrite_specials_affect_no_match
+0 heal_on_hit_add_overwrite_specials_affect_succeed
 0 heal_on_hit_add_divide
 0 heal_on_hit_add_multiply
 0 heal_on_hit_add_sub
@@ -1159,6 +1178,7 @@
 0 petrifies_affect_everybody
 # plague tests
 0 plague_ability
+0 plague_ability_multiple_overwrite_specials
 0 plague_affect_allies
 0 plague_affect_allies_distant
 0 plague_affect_self_no
@@ -1196,6 +1216,7 @@
 0 swarm_attacks_min_lower
 0 swarm_attacks_min_negative
 0 swarm_attacks_min_wfl
+0 swarm_overwrite_specials
 0 swarm_min_max_zero
 0 swarm_no_min_no_max
 0 swarm_overwrite_specials_both_sides


### PR DESCRIPTION
`overwrite_specials` not only cannot be used in abilities like leadership or healing, but also suffers from overly rigid behavior with special weapons. It either suppresses weapons of the same origin as the overwriter special (if the overwriter special applied to `self` is `overwrite_specials=one_side`, it suppresses specials also applied to 'self'), or it ignores the origin altogether. To fix these two problems, which stem from my own mistakes, I propose implementing `[overwrite_abilities]` and `[overwrite_specials]`. This first applies on abilities who are not weapon specials. The second can discriminate weapon special of the list based on origin more flexibly (a special with `[overwrite_specials]affect_side=opponent` will suppress specials applied to the opponent even if it is applied itself to 'self').

Otherwise, aside from the fact that theses functions is entirely contained within the subtag, and what [filter_specials] subtag is replaced by [filter_special] the design remains quite similar to `overwrite_specials`.
an [overwrite_abilities] is also added for engine abilities like [leadership] or [heals] who return numerical value.