### PR TITLE
Add [variables] ConditionalWML tag.

### DIFF
--- a/data/lua/wml-conditionals.lua
+++ b/data/lua/wml-conditionals.lua
@@ -43,6 +43,62 @@ function wesnoth.wml_conditionals.variable(cfg)
 	end
 end
 
+-- Similar to [variable], but works on container variables
+function wesnoth.wml_conditionals.variables(cfg)
+	-- Step 1: load the variable we're comparing
+	local value, is_single
+	if cfg.name:match('%[%d+%]$') then
+		value = {wml.tag.value(wml.variables[cfg.name])}
+		is_single = true
+	else
+		value = wml.array_access.get(cfg.name)
+		is_single = false
+		-- This turns the array into a valid WML table
+		for i = 1,#value do
+			value[i] = wml.tag.value(value[i])
+		end
+	end
+	if not wml.valid(value) then return false end
+	for _,t in ipairs(cfg) do
+		if t.tag == 'equals' then
+			-- The entire variable contents matches exactly
+			local other
+			if is_single then
+				other = {wml.tag.value(t.contents)}
+			else
+				other = wml.child_array(cfg, 'value')
+				-- This turns the array into a valid WML table
+				for i = 1,#other do
+					other[i] = wml.tag.value(other[i])
+				end
+			end
+			if #value ~= #other then return false end
+			if not wml.equal(value, other) then return false end
+		elseif t.tag == 'contains' then
+			-- There exists an element of the array that matches exactly
+			local found = false
+			for i = 1, #value do
+				if wml.equal(value[i].contents, t.contents) then
+					found = true
+					break
+				end
+			end
+			if not found then return false end
+		elseif t.tag == 'filter_wml' then
+			-- There exists an element that matches the filter
+			local found = false
+			for i = 1, #value do
+				if wml.matches_filter(value[i].contents, t.contents) then
+					found = true
+					break
+				end
+			end
+			if not found then return false end
+		end
+	end
+	return true
+end
+
 function wesnoth.wml_conditionals.has_achievement(cfg)
 	return wesnoth.achievements.has(cfg.content_for, cfg.id);
 end


### PR DESCRIPTION
This supports equality, contains, and match-finding operations for container variables.

Usage would look like this:
```ini
# Exact match of an entire array
[variables]
	name=my_var
	[equals]
		[value]
			x,y=12,6
		[/value]
		[value]
			x,y=24,2
		[/value]
		[value]
			x,y=9,15
		[/value]
	[/equals]
[/variables]
# Exact match on one element of an array
[variables]
	name=my_var[3]
	[equals]
		x,y=12,9
	[/equals]
[/variables]
# Find an exact match in an array
[variables]
	name=my_var
	[contains]
		x,y=9,9
	[/contains]
[/variables]
# Find a partial match in an array
[variables]
	name=my_var
	[filter_wml]
		x=9
	[/filter_wml]
[/variables]
```
