### PR TITLE
H2tt: fix editor group icon

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -43,7 +43,7 @@
 [editor_group]
     id=heir_2_the_throne
     name= _ "Heir to the Throne"
-    icon="group_custom"
+    icon="group_mainline"
 [/editor_group]
 {campaigns/Heir_To_The_Throne/terrain.cfg}
 {campaigns/Heir_To_The_Throne/terrain-graphics.cfg}


### PR DESCRIPTION
Mainline campaigns are supposed to use group_mainline and not a UMC one.