### PR TITLE
HttT: remove reference to the Ka'lian

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/00_The_Great_Continent.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/00_The_Great_Continent.cfg
@@ -983,7 +983,7 @@
             [/message]
             [message]
                 speaker=Kalenz
-                message=_"But this is no idle visit of reminiscence, for I bring word from Lintanir forest. Your mentor called upon the advice of the elvish sages some weeks ago, Konrad."
+                message=_"But this is no idle visit of reminiscence, for I bring word from Lintanir Forest. Your mentor called upon the advice of the elvish sages some weeks ago, Konrad."
             [/message]
             [message]
                 speaker=Kalenz


### PR DESCRIPTION
LoW (both the current one and Mechanical/DwarfTough's revision) establishes that the Ka'lian was destroyed by Landar, and says nothing about re-establishing the Ka'lian - rather _"As Landar had wiped out the Elvish Council, Kalenz was unanimously chosen as High Lord of the Elves. North and South Elves swore allegiance to him."_

The Wesnoth wiki timeline says that Kalenz reconstituted the Ka'lian. But in our campaigns, the only post-LoW mention of the Ka'lian is in HttT, which only mentions it once. Rather than require the Ka'lian be re-established "off screen" (and contradicting the ending of LoW), I'd like to remove mention of the Ka'lian from HttT.

The Ka'lian is also mentioned twice in HttTC, which I haven't touched in this PR.