### PR TITLE
Blackwaterport is the one scenario in HtttClassic to have "scenario_name^" prefix

### DIFF
--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/02_Blackwater_Port.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/02_Blackwater_Port.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-httt
 [scenario]
     id=02_Blackwater_Port
-    name= _ "scenario name^Blackwater Port"
+    name= _ "Blackwater Port"
     next_scenario=03_The_Isle_of_Alduin
     map_file=02_Blackwater_Port.map
     {DEFAULT_SCHEDULE}


### PR DESCRIPTION
solve translation bug in Htttc S02 black waterPort