### PR TITLE
Add [tree_view]has_minimum, defaulting to the current behavior

### DIFF
--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -550,6 +550,7 @@
             {DEFAULT_KEY "id" string ""}
             {DEFAULT_KEY "unfolded" bool false}
         [/tag]
+        {DEFAULT_KEY "has_minimum" bool true}
         {DEFAULT_KEY "horizontal_scrollbar_mode" scrollbar_mode initial_auto}
         {DEFAULT_KEY "indentation_step_size" unsigned 0}
         {DEFAULT_KEY "vertical_scrollbar_mode" scrollbar_mode initial_auto}

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -38,6 +38,7 @@ tree_view::tree_view(const implementation::builder_tree_view& builder)
 	: scrollbar_container(builder, type())
 	, node_definitions_(builder.nodes)
 	, indentation_step_size_(builder.indentation_step_size)
+	, has_minimum_(builder.has_minimum)
 	, need_layout_(false)
 	, root_node_(nullptr)
 	, selected_item_(nullptr)
@@ -278,6 +279,7 @@ namespace implementation
 builder_tree_view::builder_tree_view(const config& cfg)
 	: builder_scrollbar_container(cfg)
 	, indentation_step_size(cfg["indentation_step_size"].to_unsigned())
+	, has_minimum(cfg["has_minimum"].to_bool(true))
 	, nodes()
 {
 	for(const auto& node : cfg.child_range("node")) {

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -95,6 +95,16 @@ public:
 		return indentation_step_size_;
 	}
 
+	/**
+	 * If true, adding an item when no item is selected will automatically select that item.
+	 *
+	 * Name chosen for similarity to list_view::has_minimum().
+	 */
+	bool has_minimum() const
+	{
+		return has_minimum_;
+	}
+
 	tree_view_node* selected_item()
 	{
 		return selected_item_;
@@ -137,6 +147,8 @@ private:
 	const std::vector<node_definition> node_definitions_;
 
 	unsigned indentation_step_size_;
+
+	bool has_minimum_;
 
 	bool need_layout_;
 
@@ -210,6 +222,7 @@ struct tree_view_definition : public styled_widget_definition
 		explicit resolution(const config& cfg);
 
 		builder_grid_ptr grid;
+		bool has_minimum;
 	};
 };
 
@@ -227,6 +240,8 @@ struct builder_tree_view : public builder_scrollbar_container
 	virtual std::unique_ptr<widget> build() const override;
 
 	unsigned indentation_step_size;
+
+	bool has_minimum;
 
 	/**
 	 * The types of nodes in the tree view.

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -99,7 +99,7 @@ tree_view_node::tree_view_node(const std::string& id,
 			std::bind(&tree_view_node::signal_handler_label_left_button_click, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
 			event::dispatcher::front_pre_child);
 
-		if(!get_tree_view().selected_item_) {
+		if(get_tree_view().has_minimum() && !get_tree_view().selected_item_) {
 			get_tree_view().selected_item_ = this;
 			label_->set_value(true);
 		}


### PR DESCRIPTION
This is the first commit of #10825, split out because I assume #10825 is going to be squash-merged. Running the CI on it, then planning to merge immediately ].

Similarly to [list_view]has_minimum, this controls whether a tree with at least one item will always have something selected (except when items are being deleted). Defaults to true.

An example use for setting it to false is for the Campaign Menu to start with a landing page on the right hand side instead of defaulting to showing the first campaign.