### PR TITLE
GUI2/Rich Label: automatic width adjustment

### DIFF
--- a/data/gui/themes/default/dialogs/fps_report.cfg
+++ b/data/gui/themes/default/dialogs/fps_report.cfg
@@ -38,7 +38,6 @@
 					[rich_label]
 						id = "values"
 						definition = "monospace"
-						width = 320
 					[/rich_label]
 
 				[/column]

--- a/data/gui/themes/default/dialogs/gui_test_dialog.cfg
+++ b/data/gui/themes/default/dialogs/gui_test_dialog.cfg
@@ -33,7 +33,6 @@
 				[column]
 
 					[rich_label]
-						width = 500
 						label = _ "GUI Test Dialog"
 					[/rich_label]
 

--- a/data/gui/themes/default/dialogs/help_browser.cfg
+++ b/data/gui/themes/default/dialogs/help_browser.cfg
@@ -267,7 +267,6 @@
 												vertical_grow = true
 
 												[rich_label]
-													width = 950
 													id = "topic_text"
 												[/rich_label]
 

--- a/data/gui/themes/default/dialogs/units_dialog.cfg
+++ b/data/gui/themes/default/dialogs/units_dialog.cfg
@@ -207,7 +207,6 @@
 									vertical_alignment = "center"
 
 									[rich_label]
-										width = 350
 										id = "unit_details"
 										definition = "default"
 										linked_group = "type"

--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -192,7 +192,6 @@
         super="$generic/widget_instance"
         {DEFAULT_KEY "text_alignment" h_align "left"}
         {DEFAULT_KEY "link_aware" bool false}
-        {DEFAULT_KEY "width" f_unsigned 500}
         {DEFAULT_KEY "padding" unsigned 5}
         
     [/tag]

--- a/src/gui/widgets/rich_label.hpp
+++ b/src/gui/widgets/rich_label.hpp
@@ -238,6 +238,8 @@ private:
 	unsigned init_w_;
 	point size_;
 
+	config dom_;
+
 	/** Padding */
 	int padding_;
 
@@ -276,7 +278,11 @@ private:
 		return font::get_text_renderer().get_cursor_position(offset);
 	}
 
-	point calculate_best_size() const override { return size_; };
+	point calculate_best_size() const override;
+
+	void request_reduce_width(const unsigned maximum_width) override;
+
+	void place(const point& origin, const point& size) override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
@@ -344,7 +350,6 @@ struct builder_rich_label : public builder_styled_widget
 
 	PangoAlignment text_alignment;
 	bool link_aware;
-	typed_formula<unsigned> width;
 	unsigned padding;
 };
 


### PR DESCRIPTION
Rich Label now layouts the content based on the size value available from the GUI2 layout cycle. Removes the `width` variable since it is no longer needed, because it it automatic like other GUI2 widgets (for example, Label).

One downside is that the content DOM is now kept, instead of immediately discard after layouting. This is unfortunately needed to relayout the contents in case a width change happens. Optimization ideas in this regard are welcome.

Fixes #10261