### PR TITLE
Avoid UtBS copies of translatable strings for healing abilities

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -715,7 +715,7 @@ _ "At the start of the turn this unit increases movement points of surrounding u
 # delayed by healers, so they must not actually heal a dehydrated unit any
 # hitpoints.
 #
-# The ability macros go into wesnoth textdomain since the strings are identical
+# The ability macros go into the wesnoth-help textdomain since the strings are identical
 # to their core counterparts, but the special notes belong to wesnoth-utbs.
 #textdomain wesnoth-help
 
@@ -729,7 +729,7 @@ _ "At the start of the turn this unit increases movement points of surrounding u
         description=  _ "Allows the unit to heal adjacent allied units at the beginning of our turn.
 
 A unit cared for by this healer may heal up to 4 HP per turn, or stop poison from taking effect for that turn.
-A poisoned unit cannot be cured of its poison by a healer, and must seek the care of a village or a unit that can cure."
+This ability will not cure an affected unit of poison, however, only delay its effect."
         special_note=_"This unit is capable of basic healing and slowing dehydration."
         affect_self=no
         poison=slowed
@@ -753,7 +753,7 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
         description= _ "This unit combines herbal remedies with magic to heal units more quickly than is normally possible on the battlefield.
 
 A unit cared for by this healer may heal up to 8 HP per turn, or stop poison from taking effect for that turn.
-A poisoned unit cannot be cured of its poison by a healer, and must seek the care of a village or a unit that can cure."
+This ability will not cure an affected unit of poison, however, only delay its effect."
         affect_self=no
         poison=slowed
         [affect_adjacent]
@@ -780,10 +780,11 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
         affect_allies=yes
         name= _ "heals +12"
         female_name= _ "female^heals +12"
+        #po: only exists in UtBS, but is the same wording as heals+8 with a bigger number
         description= _ "This unit combines herbal remedies with magic to heal units more quickly than is normally possible on the battlefield.
 
 A unit cared for by this healer may heal up to 12 HP per turn, or stop poison from taking effect for that turn.
-A poisoned unit cannot be cured of its poison by a healer, and must seek the care of a village or a unit that can cure."
+This ability will not cure an affected unit of poison, however, only delay its effect."
         affect_self=no
         poison=slowed
         [affect_adjacent]


### PR DESCRIPTION
Synchronises the healing descriptions with be8eb90d2f23. Updates the doc about which textdomain they're in, without changing a textdomain line, because these strings were already in wesnoth-help.

Leaves some other strings in the Lua unchanged, because they would cause merge conflicts with #10383, and they're single-word strings. Will make a separate PR for that, if we decide to do it separately from #10383.