### PR TITLE
Rephrase the intercept ability's strings and move to wesnoth-help

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -1932,13 +1932,17 @@ _ "After using this attack, you can’t use it during your next two turns."#endd
     [/event]
 #enddef
 
+# At the time of writing, we're about to string-freeze for 1.20 but not yet to feature-freeze. There's discussion about moving
+# this to core for the Dunefolk to use, which is why these strings are in wesnoth-help instead of wesnoth-utbs.
 #define WEAPON_SPECIAL_INTERCEPT
     [extra_attack]#I think it's a good idea to call abilities which launch extra attacks (even if without combat XP) [attack]
         id=intercept
+        #textdomain wesnoth-help
         name= _ "intercept"
-        female_name= _ "intercept"
-        description=_ "When an enemy unit enters an adjacent space, the wielder immediately executes an uncountered intercepting strike with this weapon."
+        female_name= _ "female^intercept"
+        description=_ "When an enemy unit enters an adjacent space, the wielder immediately attacks with this weapon, with the normal damage and number of strikes. The enemy doesn’t get to retaliate. Activates at most once per turn."
         special_note=_ "Delivers a full-power, uncountered attack when enemies move to an adjacent space. Activates once per turn."
+        #textdomain wesnoth-utbs
         [filter_self] #so this shows as inactive in combat preview, since the ability doesn't affect regular combat at all
             [not]
             [/not]


### PR DESCRIPTION
At the time of writing, we're about to string-freeze for 1.20 but not yet to feature-freeze. There's discussion about moving this ability to core for the Dunefolk to use (PR #10383), this would move and rephrase just the necessary strings.