### PR TITLE
Use gender-specific strings for female_name / female_message

### DIFF
--- a/data/campaigns/Dusk_of_Dawn/utils/items.cfg
+++ b/data/campaigns/Dusk_of_Dawn/utils/items.cfg
@@ -44,8 +44,8 @@
                                         speaker=$unit.id|
                                         image="wesnoth-icon.png"
                                         caption=""
-                                        male_message= _ "Potion grants steadfast ability and 20% resistance to impact."
-                                        female_message= _ "Potion grants steadfast ability and 20% resistance to impact."
+                                        message= _ "Potion grants steadfast ability and 20% resistance to impact."
+                                        female_message= _ "female^Potion grants steadfast ability and 20% resistance to impact."
                                     [/message]
                                     {VARIABLE potion_drank 1}
                                 [/then]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/02_Flight_of_the_Elves.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/02_Flight_of_the_Elves.cfg
@@ -561,8 +561,8 @@
         {NOTRAIT_UNITC 7 ({ON_DIFFICULTY4 "Elvish Civilian" "Elvish Fighter"  "Elvish Fighter"  "Elvish Ranger" }) 43 9 ({FACING sw}{ANIMATE} {ADD_MODIFICATION({TRAIT_INTELLIGENT}{TRAIT_STRONG}     )} )}
         [message]
             id=$elf_leader.id
-            male_message  =_"Konrad, I lead the last of the evacuees — we shall make for the ford at once. But be wary, for the human general comes nipping at our heels!"
-            female_message=_"Konrad, I lead the last of the evacuees — we shall make for the ford at once. But be wary, for the human general comes nipping at our heels!"
+            message =_"Konrad, I lead the last of the evacuees — we shall make for the ford at once. But be wary, for the human general comes nipping at our heels!"
+            female_message=_"female^Konrad, I lead the last of the evacuees — we shall make for the ford at once. But be wary, for the human general comes nipping at our heels!"
         [/message]
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/42_A_Crisis_of_Leadership.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/42_A_Crisis_of_Leadership.cfg
@@ -559,8 +559,9 @@
             [abilities]
                 [hides]
                     id=disguised
+                    #po: ability given to a wagon
                     name= _ "disguised"
-                    female_name= _ "disguised"
+                    #po: ability given to a wagon
                     description= _ "This unit’s mundane exterior conceals assassins within."
                     affect_self=yes
                 [/hides]

--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -247,7 +247,7 @@
                     value=-13
                     cumulative=no
                     name=_ "forcefield"
-                    female_name=_ "forcefield"
+                    female_name=_ "female^forcefield"
                     description=_ "Adjacent enemies do 13% less damage."
                     affect_self=no
                     affect_allies=no
@@ -622,7 +622,7 @@
                 [berserk]
                     id=wct_fury
                     name=_ "fury"
-                    female_name=_ "fury"
+                    female_name=_ "female^fury"
                     description=_ "Whether used offensively or defensively, this attack presses the engagement until one of the combatants is slain, or 3 rounds of attacks have occurred."
                     value=3
                 [/berserk]
@@ -672,14 +672,14 @@
                     min_value=-25
                     cumulative=no
                     name=_ "darkness"
-                    female_name=_ "darkness"
+                    female_name=_ "female^darkness"
                     description=_ "This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse. Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk."
                     affect_self=yes
                 [/illuminates]
                 [dummy]
                     id=wc2_corruption
                     name=_ "corruption"
-                    female_name=_ "corruption"
+                    female_name=_ "female^corruption"
                     description=_ "This unit corrupts adjacent enemies at the beginning of our turn. Corrupted units lose 6 HP or are reduced to 1 HP. Corruption cannot, of itself, kill a unit."
                 [/dummy]
             [/abilities]
@@ -782,7 +782,7 @@
                     id=banner
                     add=20
                     name=_ "banner"
-                    female_name=_ "banner"
+                    female_name=_ "female^banner"
                     description=_ "This unit can lead ~allied~ units that are next to it, making them fight better. Adjacent allied units will do 20% more damage. This is cumulative with leadership."
                     affect_self=no
                     affect_allies=yes

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -401,7 +401,7 @@
     [skirmisher]
         id=distract
         name=_ "distract"
-        female_name=_ "distract"
+        female_name=_ "female^distract"
         description=_ "Allied units ignore enemy zones of control adjacent to this unit."
         affect_self=no
         affect_allies=yes
@@ -425,7 +425,7 @@
             less_than=0
         [/filter_base_value]
         name=_ "tenacity"
-        female_name=_ "tenacity"
+        female_name=_ "female^tenacity"
         description=_ "This unit’s vulnerabilities are halved when defending."
         affect_self=yes
         active_on=defense

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -333,7 +333,7 @@ Enemy units cannot see this unit while it is resting in forest or sand, except i
     [hides]
         id=nightstalk
         name= _ "nightstalk"
-        female_name= _ "nightstalk"
+        female_name= _ "female^nightstalk"
         description= _ "The unit becomes invisible during night.
 
 Enemy units cannot see this unit at night, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."


### PR DESCRIPTION
These were using gender-neutral English strings, which meant that there was no way to provide gender-specific translations.

UtBS's "intercept" ability is also affected, but that's in #11005. It's also not important, because only Kaleh can get that ability currently; it isn't in Nym's AMLAs.