### PR TITLE
Luacheck: ignore redefinitions of __

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,3 +13,5 @@ global=false
 -- don't show unused variables
 unused=false
 exclude_files={"src/modules/lua/testes/*.lua"}
+-- allow __ to be used for ignored return values, by disabling warnings about redefining a variable called __
+ignore={"411/^__$"}


### PR DESCRIPTION
We use `_` as the conventional name for the Gettext lookup function. This commit makes Luacheck happy when a double-underscore is used to ignore a value in an assignment, which by Lua convention would be normally be done with a single underscore.

Internally, Luacheck does the same for the single underscore. It generates the warnings, then its `passes_filter` function ignores any 2xx, 3xx or 4xx warning when `name == "_"`.