### PR TITLE
Remove bogus LANGUAGE unsetting

### DIFF
--- a/src/language.cpp
+++ b/src/language.cpp
@@ -218,17 +218,9 @@ static void wesnoth_setlocale(int category, const std::string& slocale,
 	std::vector<std::string> const *alternates)
 {
 	std::string locale = slocale;
-	// FIXME: ideally we should check LANGUAGE and on first invocation
-	// use that value, so someone with es would get the game in Spanish
-	// instead of en_US the first time round
-	// LANGUAGE overrides other settings, so for now just get rid of it
-	// FIXME: add configure check for unsetenv
 
 	//category is never LC_MESSAGES since that case was moved to gettext.cpp to remove the dependency to libintl.h in this file
 	//that's why code like if (category == LC_MESSAGES) is outcommented here.
-#ifndef _WIN32
-	unsetenv ("LANGUAGE"); // void so no return value to check
-#endif
 #ifdef __APPLE__
 	//if (category == LC_MESSAGES && setenv("LANG", locale.c_str(), 1) == -1) {
 	//	ERR_G << "setenv LANG failed: " << strerror(errno);


### PR DESCRIPTION
See ab69efb which was based on https://forums.wesnoth.org/viewtopic.php?f=5&t=6614 with wrong or at the least long outdated claims.

----

IMO this should not break anything (it just restores being able to change system language via `LANGUAGE`, something you can do now with `LANG` or `LC_ALL` etc anyway) but to be extra safe we could only merge this after 1.20.