### PR TITLE
Help/Trait Generator: show a listing of units having a trait

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -768,8 +768,10 @@ std::vector<topic> generate_trait_topics(const bool sort_generated)
 			continue;
 		}
 
+		text << "\n";
+
 		if(!trait_races[trait_id].empty()) {
-			text << "\n\n" << markup::tag("header", _("Races with this trait")) << "\n";
+			text << "\n" << markup::tag("header", _("Races with this trait")) << "\n";
 		}
 
 		unsigned i = 0;


### PR DESCRIPTION
Like Weapon Special/Ability pages, Trait pages will show which unit types/races have a particular trait.

<img width="1353" height="802" alt="Screenshot from 2026-02-25 14-14-09" src="https://github.com/user-attachments/assets/ae8908f7-2f0e-4a6d-bf58-826184ac7b67" />

Global traits will mention it, and will show no listing.
<img width="989" height="281" alt="Screenshot from 2026-02-25 13-58-42" src="https://github.com/user-attachments/assets/96c3beca-afe0-47f1-b4c2-3917eddb28a5" />

Too long lists of Unit Types will be paginated. (old screenshot, but layouting remains same.)

<img width="1353" height="800" alt="Screenshot from 2026-02-25 11-14-50" src="https://github.com/user-attachments/assets/11844296-c641-4af7-8645-a896ba014299" />
<img width="1354" height="808" alt="Screenshot from 2026-02-25 11-15-04" src="https://github.com/user-attachments/assets/2404d7e7-09d2-403f-bbee-b32e466189e7" />




