### PR TITLE
real range missile animation and UI arrow fix

### DIFF
--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -377,11 +377,14 @@ void game_display::draw_hex(const map_location& loc)
 	}
 
 	// Draw the attack direction indicator
+	const bool is_ranged = distance_between(attack_indicator_src_, attack_indicator_dst_) > 1;
 	if(on_map && loc == attack_indicator_src_) {
-		drawing_buffer_add(drawing_layer::attack_indicator, loc,
-			[tex = image::get_texture("misc/attack-indicator-src-" + attack_indicator_direction() + ".png", image::HEXED)](const rect& dest)
-		 	{ draw::blit(tex, dest); }
-		);
+		if(!is_ranged) { // Don't draw the src part for ranged attacks.
+			drawing_buffer_add(drawing_layer::attack_indicator, loc,
+				[tex = image::get_texture("misc/attack-indicator-src-" + attack_indicator_direction() + ".png", image::HEXED)](const rect& dest)
+		 		{ draw::blit(tex, dest); }
+			);
+		}
 	} else if(on_map && loc == attack_indicator_dst_) {
 		drawing_buffer_add(drawing_layer::attack_indicator, loc,
 			[tex = image::get_texture("misc/attack-indicator-dst-" + attack_indicator_direction() + ".png", image::HEXED)](const rect& dest)

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -1058,10 +1058,11 @@ void unit_animation::start_animation(const std::chrono::milliseconds& start_time
 	}
 }
 
-void unit_animation::update_parameters(const map_location& src, const map_location& dst)
+void unit_animation::update_parameters(const map_location& src, const map_location& dst, const map_location& dst_missile)
 {
 	src_ = src;
 	dst_ = dst;
+	dst_missile_ = dst_missile;
 }
 
 void unit_animation::pause_animation()
@@ -1082,6 +1083,23 @@ void unit_animation::restart_animation()
 	}
 }
 
+void unit_animation::get_sub_anim_coords(const std::string& name,
+	map_location& out_src,
+	map_location& out_dst) const
+{
+	// For real ranged missile animations (distance > 1), shift the missile's source
+	// to the hex adjacent to the target, so the end of the flight is shown rather than the start.
+	if(name.find("missile_") == 0 &&
+		dst_missile_ != map_location::null_location() && distance_between(src_, dst_missile_) > 1)
+	{
+		out_src = dst_missile_.get_direction(dst_missile_.get_relative_dir(src_));
+		out_dst = dst_missile_;
+	} else {
+		out_src = src_;
+		out_dst = dst_;
+	}
+}
+
 void unit_animation::redraw(frame_parameters& value, halo::manager& halo_man)
 {
 	invalidated_ = false;
@@ -1092,7 +1110,9 @@ void unit_animation::redraw(frame_parameters& value, halo::manager& halo_man)
 
 	value.primary_frame = false;
 	for(auto& anim : sub_anims_) {
-		anim.second.redraw(value, src_, dst_, halo_man);
+		map_location s, d;
+		get_sub_anim_coords(anim.first, s, d);
+		anim.second.redraw(value, s, d, halo_man);
 	}
 }
 
@@ -1119,7 +1139,9 @@ bool unit_animation::invalidate(frame_parameters& value)
 			value.primary_frame = false;
 
 			for(auto& anim : sub_anims_) {
-				std::set<map_location> tmp = anim.second.get_overlaped_hex(value, src_, dst_);
+				map_location s, d;
+				get_sub_anim_coords(anim.first, s, d);
+				std::set<map_location> tmp = anim.second.get_overlaped_hex(value, s, d);
 				overlaped_hex_.insert(tmp.begin(), tmp.end());
 			}
 		} else {
@@ -1315,7 +1337,7 @@ void unit_animator::add_animation(unit_const_ptr animated_unit
 	if(!anim) return;
 
 	start_time_ = std::max(start_time_, anim->get_begin_time());
-	animated_units_.AGGREGATE_EMPLACE(std::move(animated_unit), anim, text, text_color, src, with_bars);
+	animated_units_.AGGREGATE_EMPLACE(std::move(animated_unit), anim, text, text_color, src, dst, with_bars);
 }
 
 void unit_animator::add_animation(unit_const_ptr animated_unit
@@ -1328,7 +1350,7 @@ void unit_animator::add_animation(unit_const_ptr animated_unit
 	if(!animated_unit || !anim) return;
 
 	start_time_ = std::max(start_time_, anim->get_begin_time());
-	animated_units_.AGGREGATE_EMPLACE(std::move(animated_unit), anim, text, text_color, src, with_bars);
+	animated_units_.AGGREGATE_EMPLACE(std::move(animated_unit), anim, text, text_color, src, map_location::null_location(), with_bars);
 }
 
 bool unit_animator::has_animation(const unit_const_ptr& animated_unit
@@ -1364,7 +1386,7 @@ void unit_animator::replace_anim_if_invalid(const unit_const_ptr& animated_unit
 		 animated_unit->anim_comp().get_animation()->matches(
 			src, dst, animated_unit, event, value, hit_type, attack, second_attack, value2) > unit_animation::MATCH_FAIL)
 	{
-		animated_units_.AGGREGATE_EMPLACE(animated_unit, nullptr, text, text_color, src, with_bars);
+		animated_units_.AGGREGATE_EMPLACE(animated_unit, nullptr, text, text_color, src, dst, with_bars);
 	} else {
 		add_animation(animated_unit,event,src,dst,value,with_bars,text,text_color,hit_type,attack,second_attack,value2);
 	}
@@ -1388,9 +1410,8 @@ void unit_animator::start_animations()
 		if(anim.animation) {
 			anim.my_unit->anim_comp().start_animation(begin_time, anim.animation, anim.with_bars, anim.text, anim.text_color);
 			anim.animation = nullptr;
-		} else {
-			anim.my_unit->anim_comp().get_animation()->update_parameters(anim.src, anim.src.get_direction(anim.my_unit->facing()));
 		}
+		anim.my_unit->anim_comp().get_animation()->update_parameters(anim.src, anim.src.get_direction(anim.my_unit->facing()), anim.dst_missile);
 	}
 }
 

--- a/src/units/animation.hpp
+++ b/src/units/animation.hpp
@@ -88,7 +88,7 @@ public:
 		, const color_t text_color = {0,0,0}
 		, const bool accelerate = true);
 
-	void update_parameters(const map_location& src, const map_location& dst);
+	void update_parameters(const map_location& src, const map_location& dst, const map_location& dst_missile = map_location::null_location());
 	void pause_animation();
 	void restart_animation();
 	auto get_current_frame_begin_time() const
@@ -162,6 +162,9 @@ private:
 		bool cycles_;
 	};
 
+	/** Helper to calculate the effective source and destination for a sub-animation. */
+	void get_sub_anim_coords(const std::string& name, map_location& out_src, map_location& out_dst) const;
+
 	t_translation::ter_list terrain_types_;
 	std::vector<config> unit_filter_;
 	std::vector<config> secondary_unit_filter_;
@@ -179,6 +182,7 @@ private:
 	/* these are drawing parameters, but for efficiency reason they are in the anim and not in the particle */
 	map_location src_;
 	map_location dst_;
+	map_location dst_missile_;
 	// optimization
 	bool invalidated_;
 	bool play_offscreen_;
@@ -269,6 +273,7 @@ private:
 		std::string text;
 		color_t text_color;
 		map_location src;
+		map_location dst_missile;
 		bool with_bars = false;
 	};
 

--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -203,6 +203,11 @@ void attack::draw_hex(const map_location& hex)
 		return;
 	}
 
+	const bool is_ranged = distance_between(get_dest_hex(), target_hex_) > 1;
+	if(is_ranged && hex == get_dest_hex()) {
+		return; // Don't draw the src part for ranged attacks.
+	}
+
 	//@todo: replace this by either the use of transparency + drawing_layer::attack_indicator,
 	//or a dedicated layer
 	const drawing_layer layer = drawing_layer::footsteps;


### PR DESCRIPTION
Solves: https://github.com/wesnoth/wesnoth/issues/10403

The bug (see the red part between the two units, under the "60%"):
<img width="366" height="416" alt="image" src="https://github.com/user-attachments/assets/d5c7aa55-4d97-4e03-a05e-2c8e84e99a42" />

There are multiple ways to solve this but I do not think we need any fancy details here, just removing the bugged part looks fine to me.

<img width="942" height="478" alt="image" src="https://github.com/user-attachments/assets/a3ee04d6-5403-4b40-9cda-2a50b8357611" />

Prevents the src/source part of the UI attack arrow from being drawn when the distance between targets is greater than 1.