### PR TITLE
Tools: fix "wiki output" mode

### DIFF
--- a/data/tools/unit_tree/wiki_output.py
+++ b/data/tools/unit_tree/wiki_output.py
@@ -25,7 +25,7 @@ def main():
 
     all_campaigns = {}
     sys.stderr.write("Parsing campaigns...\n")
-    wesnoth.parser.parse_text("{campaigns}", ",".join(base_defines))
+    wesnoth.parser.parse_text("{themes}{campaigns}", ",".join(base_defines))
     campaigns = wesnoth.parser.get_all(tag = "campaign")
     for campaign in campaigns:
         campaign_defines = base_defines[:]


### PR DESCRIPTION
The tool `data/tools/wmlunits` has an obscure mode `-W` that outputs a MediaWiki-style output. Which does not actually run on modern versions of Wesnoth data and Python 3.

This patch makes it at least runs.

Comments on details: a `unit` with `name = None` appears in at least two campaigns, the first being `Northern Rebirth`. Just hiding that `unit` seems the reasonable solution.

`x.encode("utf8") + "\n"` is only valid in Python 2, I guess I am the first person to try to run this script ever since the scripts get updated to Python 3.

Anyways, this is more a by-product of my misplaced curiosity...