### PR TITLE
Tools: always use absolute paths when symlinking

### DIFF
--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -45,8 +45,8 @@ def shell_out(wesnoth_exe, com):
 
 def symlink(f, t, name):
     if os.path.exists(os.path.join(f, name + ".cfg")):
-        os.symlink(os.path.join(f, name + ".cfg"), os.path.join(t, name + ".cfg"))
-    os.symlink(os.path.join(f, name), os.path.join(t, name))
+        os.symlink(os.path.abspath(os.path.join(f, name + ".cfg")), os.path.join(t, name + ".cfg"))
+    os.symlink(os.path.abspath(os.path.join(f, name)), os.path.join(t, name))
 
 def rm_symlink(f, name):
     if os.path.exists(os.path.join(f, name + ".cfg")):


### PR DESCRIPTION
Basically I was wondering why `data/tools/wmlunits` can find the add-ons I passed to it via `-a` but cannot parse anything from them.

Turns out I provided relative paths, which is directly used in the symlinks, which are obviously invalid as long as the working directly does not happen to be the add-on directory.