### PR TITLE
steam: Avoid overwriting LD_LIBRARY_PATH

### DIFF
--- a/utils/dockerbuilds/steamrt/start.sh
+++ b/utils/dockerbuilds/steamrt/start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 gamedir=${0%/*}
 cd "$gamedir" || exit
-LD_LIBRARY_PATH=$gamedir/lib exec ./wesnoth "$@"
+LD_LIBRARY_PATH="$gamedir/lib${LD_LIBRARY_PATH:+":$LD_LIBRARY_PATH"}" exec ./wesnoth "$@"


### PR DESCRIPTION
LD_LIBRARY_PATH is used by the steam runtime so overwriting it breaks some use cases.

Fixes #10601.