### PR TITLE
Campaign dialog: make the hyperlink to the changelog clickable

### DIFF
--- a/data/gui/themes/default/dialogs/campaign_dialog.cfg
+++ b/data/gui/themes/default/dialogs/campaign_dialog.cfg
@@ -223,6 +223,7 @@ _"campaign_landing^Welcome to Wesnoth v1.20" + "</b></big>
 " + _"campaign_landing^<span color='#e1e119' style='italic'>Winds of Fate</span> has been rebalanced with much lower recall costs, redesigned wildlife spawners and AI, and a much larger mid-campaign battle. Several characters and dialogue sequences were changed for better continuity with other campaigns." + "
 
 " + _"campaign_landing^For a full list of changes, consult our official changelog at https://www.wesnoth.org/start/1.20/"
+										link_aware = true
 										use_markup = true
 										wrap = true
 									[/label]


### PR DESCRIPTION
Not a string change, just a missing link_aware=true.

The page it leads to is currently a [404 - Burin The Lost](https://www.wesnoth.org/start/1.20/) page, but matches the pattern for [1.16](https://www.wesnoth.org/start/1.16/) and [1.18](https://www.wesnoth.org/start/1.18/).