### PR TITLE
editor_edit_unit.cfg: fix incorrect range value assignment

### DIFF
--- a/src/gui/dialogs/editor/edit_unit.cpp
+++ b/src/gui/dialogs/editor/edit_unit.cpp
@@ -670,15 +670,13 @@ void editor_edit_unit::store_attack() {
 	attack["type"] = find_widget<combobox>("attack_type_list").get_value();
 	attack["damage"] = find_widget<slider>("dmg_box").get_value();
 	attack["number"] = find_widget<slider>("dmg_num_box").get_value();
-	{
-		const std::string range_val = find_widget<combobox>("range_list").get_value();
-		if (range_val == "Ranged" || range_val == "ranged") {
-			attack["range"] = "ranged";
-		} else if (range_val == "Melee" || range_val == "melee") {
-			attack["range"] = "melee";
-		} else {
-			attack["range"] = range_val;
-		}
+	const std::string range_val = find_widget<combobox>("range_list").get_value();
+	if (range_val == "Ranged" || range_val == "ranged") {
+		attack["range"] = "ranged";
+	} else if (range_val == "Melee" || range_val == "melee") {
+		attack["range"] = "melee";
+	} else {
+		attack["range"] = range_val;
 	}
 
 	attacks_.at(selected_attack_-1) = {
@@ -741,15 +739,13 @@ void editor_edit_unit::add_attack() {
 	attack["type"] = find_widget<combobox>("attack_type_list").get_value();
 	attack["damage"] = find_widget<slider>("dmg_box").get_value();
 	attack["number"] = find_widget<slider>("dmg_num_box").get_value();
-	{
-		const std::string range_val = find_widget<combobox>("range_list").get_value();
-		if (range_val == "Ranged" || range_val == "ranged") {
-			attack["range"] = "ranged";
-		} else if (range_val == "Melee" || range_val == "melee") {
-			attack["range"] = "melee";
-		} else {
-			attack["range"] = range_val;
-		}
+	const std::string range_val = find_widget<combobox>("range_list").get_value();
+	if (range_val == "Ranged" || range_val == "ranged") {
+		attack["range"] = "ranged";
+	} else if (range_val == "Melee" || range_val == "melee") {
+		attack["range"] = "melee";
+	} else {
+		attack["range"] = range_val;
 	}
 
 	selected_attack_++;


### PR DESCRIPTION
**What does this Pull request do?**
- Fixes a **bug** in the unit type creator/editor inside the editor
- when making the unit type's attacks, the range is given as Melee or Ranged. Now, wesnoth core only recognizes `range=melee` or `range=ranged `. 
- The values of `range=Melee `and `range=Ranged` are not correct and will result in the attack having a not-recognized range value.
- Also it is not supposed to be translated either. Since translated values for Melee and Ranged wont be correct either.

Note: also tried adding option id=melee or id=ranged to the .cfg but that did not work so this change was the most minimal solution. The combobox widget in Wesnoth is designed to return the visible label.