### PR TITLE
HttT S30: Remove a near-duplicate string

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/30_The_Sceptre_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/30_The_Sceptre_of_Fire.cfg
@@ -1273,7 +1273,7 @@
             {DO_AT_COORDS id=Konrad ({MOVE_UNIT id=Delfador $coordX $coordY})}
             [message]
                 speaker=narrator
-                message=_"<i>The Sceptre, initially dulled from centuries of dust and debris, began to glow from its ruby’s inner fire. Dwarvish runes on the golden handle lit up in pulsating blue as Konrad’s fingers wrapped around the staff.</i>"
+                message="<i>" + _ "The Sceptre, initially dulled from centuries of dust and debris, began to glow from its ruby’s inner fire. Dwarvish runes on the golden handle lit up in pulsating blue as Konrad’s fingers wrapped around the staff." + "</i>"
             [/message]
             {OBJECT_SCEPTRE ({FILTER id=Konrad})}
             {SWITCH_KONRAD_PORTRAIT "adult" "-sceptre"}


### PR DESCRIPTION
As noticed by Antro, S30 had two variants of this, one with the markup inside, one with it outside. Make the two exactly the same, so it only needs to be translated once.