### PR TITLE
Do not consider full-heal if the unit does not advance in AI and attack_prediction

### DIFF
--- a/src/ai/default/attack.cpp
+++ b/src/ai/default/attack.cpp
@@ -61,7 +61,8 @@ void attack_analysis::analyze(const gamemap& map, unit_map& units,
 	uses_leader = false;
 
 	target_value = defend_it->cost();
-	target_value += (static_cast<double>(defend_it->experience())/
+	const unsigned int defend_experience = defend_it->can_advance() ? defend_it->experience() : 0;
+	target_value += (static_cast<double>(defend_experience)/
 	                 static_cast<double>(defend_it->max_experience()))*target_value;
 	target_starting_damage = defend_it->max_hitpoints() -
 	                         defend_it->hitpoints();
@@ -161,7 +162,8 @@ void attack_analysis::analyze(const gamemap& map, unit_map& units,
 		double cost = up->cost();
 		const bool on_village = map.is_village(m->second);
 		// Up to double the value of a unit based on experience
-		cost += (static_cast<double>(up->experience()) / up->max_experience())*cost;
+		const unsigned int up_experience = up->can_advance() ? up->experience() : 0;
+		cost += (static_cast<double>(up_experience) / up->max_experience())*cost;
 		resources_used += cost;
 		avg_losses += cost * prob_died;
 

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -2479,12 +2479,12 @@ void combatant::fight(combatant& opponent, bool levelup_considered)
 	slowed = std::min(std::accumulate(summary[1].begin(), summary[1].end(), 0.0), 1.0);
 	opponent.slowed = std::min(std::accumulate(opponent.summary[1].begin(), opponent.summary[1].end(), 0.0), 1.0);
 
-	if(u_.experience + game_config::combat_xp(opponent.u_.level) >= u_.max_experience) {
-		// We'll level up after the battle -> slow/poison will go away
+	// We'll level up after the battle and assume that full-heals -> slow/poison will go away
+	if(u_.can_advance && u_.experience + game_config::combat_xp(opponent.u_.level) >= u_.max_experience) {
 		poisoned = 0.0;
 		slowed = 0.0;
 	}
-	if(opponent.u_.experience + game_config::combat_xp(u_.level) >= opponent.u_.max_experience) {
+	if(opponent.u_.can_advance && opponent.u_.experience + game_config::combat_xp(u_.level) >= opponent.u_.max_experience) {
 		opponent.poisoned = 0.0;
 		opponent.slowed = 0.0;
 	}


### PR DESCRIPTION
Although based on the work of @soliton- which is similar to what I envisioned, this PR integrates this fix for the AI ​​managing attack behavior as well as prediction in case of use of [slow] or [poison]

Can resolve https://github.com/wesnoth/wesnoth/issues/11045 issue