### PR TITLE
TSG S06b: Make the hint about the turn limit translatable

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/06b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06b_The_Tides_of_War.cfg
@@ -3,6 +3,12 @@
 # Ethiliel arrives at dawn
 #define TURN_LIMIT
 13#enddef
+#define TURN_LIMIT_HINT_OBJECTIVE
+    [objective]
+        description= _ "Survive until reinforcements arrive on turn 13, then defeat Mal M’Brin"
+        condition=win
+    [/objective]
+#enddef
 
 [scenario]
     id=06b_The_Tides_of_War
@@ -504,10 +510,7 @@
         #############################
         [objectives]
             side=1
-            [objective]
-                description= _ "Survive until reinforcements arrive on turn {TURN_LIMIT}, then defeat Mal M’Brin"
-                condition=win
-            [/objective]
+            {TURN_LIMIT_HINT_OBJECTIVE}
             [objective]
                 description= _ "The town cellars are breached"
                 condition=lose
@@ -1053,6 +1056,7 @@
     [/event]
 [/scenario]
 
+#undef TURN_LIMIT_HINT_OBJECTIVE
 #undef TURN_LIMIT
 #undef TURN_WARNING
 #undef PEBBLES_DIALOGUE_SWITCH


### PR DESCRIPTION
Macros in translatable strings make the string untranslatable.

Review note: I'm not sure this is a good coding style, but it's simpler than storing the value in a variable and then using the variable in the string. It gives the exact number to the translators, without asking them to provide unnecessary versions of the string for other numbers.