### PR TITLE
GUI2/combobox: Add value key for options

### DIFF
--- a/data/gui/themes/default/dialogs/editor_edit_unit.cfg
+++ b/data/gui/themes/default/dialogs/editor_edit_unit.cfg
@@ -683,10 +683,12 @@
 								id = "range_list"
 								definition = "default"
 								[option]
+									value = "melee"
 									label = _ "range^Melee"
 									icon = "icons/profiles/melee_attack.png"
 								[/option]
 								[option]
+									value = "ranged"
 									label = _ "range^Ranged"
 									icon = "icons/profiles/ranged_attack.png"
 								[/option]

--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -57,6 +57,7 @@
             name = "option"
             min="0"
             max="infinite"
+            {DEFAULT_KEY "value" string ""}
             {DEFAULT_KEY "label" t_string ""}
             {DEFAULT_KEY "tooltip" t_string ""}
             {DEFAULT_KEY "icon" string ""}

--- a/src/gui/dialogs/editor/edit_unit.cpp
+++ b/src/gui/dialogs/editor/edit_unit.cpp
@@ -670,14 +670,7 @@ void editor_edit_unit::store_attack() {
 	attack["type"] = find_widget<combobox>("attack_type_list").get_value();
 	attack["damage"] = find_widget<slider>("dmg_box").get_value();
 	attack["number"] = find_widget<slider>("dmg_num_box").get_value();
-	const std::string range_val = find_widget<combobox>("range_list").get_value();
-	if (range_val == "Ranged" || range_val == "ranged") {
-		attack["range"] = "ranged";
-	} else if (range_val == "Melee" || range_val == "melee") {
-		attack["range"] = "melee";
-	} else {
-		attack["range"] = range_val;
-	}
+	attack["range"] = find_widget<combobox>("range_list").get_value();
 
 	attacks_.at(selected_attack_-1) = {
 		find_widget<multimenu_button>("weapon_specials_list").get_toggle_states(),
@@ -739,14 +732,7 @@ void editor_edit_unit::add_attack() {
 	attack["type"] = find_widget<combobox>("attack_type_list").get_value();
 	attack["damage"] = find_widget<slider>("dmg_box").get_value();
 	attack["number"] = find_widget<slider>("dmg_num_box").get_value();
-	const std::string range_val = find_widget<combobox>("range_list").get_value();
-	if (range_val == "Ranged" || range_val == "ranged") {
-		attack["range"] = "ranged";
-	} else if (range_val == "Melee" || range_val == "melee") {
-		attack["range"] = "melee";
-	} else {
-		attack["range"] = range_val;
-	}
+	attack["range"] = find_widget<combobox>("range_list").get_value();
 
 	selected_attack_++;
 

--- a/src/gui/widgets/combobox.cpp
+++ b/src/gui/widgets/combobox.cpp
@@ -257,7 +257,7 @@ void combobox::handle_key_up_arrow(SDL_Keymod /*modifier*/, bool& handled)
 {
 	DBG_GUI_E << LOG_SCOPE_HEADER;
 	handled = true;
-	if (selected_ > 1) {
+	if (selected_ > 0) {
 		set_selected(selected_ - 1, true);
 	}
 }
@@ -271,19 +271,32 @@ void combobox::handle_key_down_arrow(SDL_Keymod /*modifier*/, bool& handled)
 	}
 }
 
+std::string combobox::get_preset_value(const size_t index) const
+{
+	auto row_cfg = values_[index];
+	return row_cfg.has_attribute("value") ? row_cfg["value"] : row_cfg["label"];
+}
+
 void combobox::set_values(const std::vector<::config>& values, unsigned selected)
 {
 	assert(selected < values.size());
 	assert(selected_ < values_.size());
 
-	if(values[selected]["label"] != values_[selected_]["label"]) {
-		queue_redraw();
-	}
-
 	values_ = values;
 	selected_ = selected;
 
-	text_box_base::set_value(values_[selected_]["label"]);
+	std::string new_value = get_preset_value(selected_);
+	if(text_box_base::get_value() != new_value) {
+		text_box_base::set_value(new_value);
+		queue_redraw();
+	}
+}
+
+int combobox::get_selected() const
+{
+	std::string value = text_box_base::get_value();
+	std::string last_selected = get_preset_value(selected_);
+	return value == last_selected ? selected_ : -1;
 }
 
 void combobox::set_selected(unsigned selected, bool fire_event)
@@ -297,7 +310,7 @@ void combobox::set_selected(unsigned selected, bool fire_event)
 
 	selected_ = selected;
 
-	text_box_base::set_value(values_[selected_]["label"]);
+	text_box_base::set_value(get_preset_value(selected_));
 	if (fire_event) {
 		fire(event::NOTIFY_MODIFIED, *this, nullptr);
 	}

--- a/src/gui/widgets/combobox.hpp
+++ b/src/gui/widgets/combobox.hpp
@@ -93,7 +93,12 @@ public:
 
 	void set_values(const std::vector<::config>& values, unsigned selected = 0);
 	void set_selected(unsigned selected, bool fire_event = true);
-	unsigned get_selected() const { return selected_; }
+
+	/**
+	 * Returned last selected entry's index or
+	 * -1 if typed value that does not matches any preset value.
+	 */
+	int get_selected() const;
 
 protected:
 	/* **** ***** ***** ***** layout functions ***** ***** ***** **** */
@@ -167,6 +172,12 @@ private:
 	std::vector<::config> values_;
 
 	unsigned selected_;
+
+	/**
+	 * Get the `index`-th value from the preset values that area
+	 * shown in the dropdown.
+	 */
+	std::string get_preset_value(const size_t index) const;
 
 	/**
 	 * Inherited from text_box_base.


### PR DESCRIPTION
Adds a `[option]value` key to combobox instance WML.
What's shown in the drop down are tstrings, and can vary based on language, but what the combobox returns is a value and shouldn't really be language dependent in most case.
* get_selected() will return -1 if typed value is not one of the preselected ones.
Based on combobox shortcomings found in #11050 discussion.