### PR TITLE
Add player_category enum to playmp_controller

### DIFF
--- a/src/playmp_controller.hpp
+++ b/src/playmp_controller.hpp
@@ -19,6 +19,13 @@
 #include "playsingle_controller.hpp"
 
 struct mp_game_metadata;
+
+enum class player_category {
+    friend_player,  
+    ignore,
+    offender         
+};
+
 class playmp_controller : public playsingle_controller
 {
 public:
@@ -94,4 +101,7 @@ private:
 	/// Information about our connection to the multiplayer server.
 	/// null when we are not connected to the multiplayer server
 	mp_game_metadata* mp_info_;
+
+	std::map<std::string, player_category> player_categories_;
+
 };


### PR DESCRIPTION
Added a third multiplayer player category offender to complement friend and ignore. Also added player_categories_ map in playmp_controller.hpp to track category per player.