### PR TITLE
[1.18] CMake compatibility with both 1.67 and 1.89 (boost-system)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,21 @@ option(ENABLE_MYSQL "Enable building MP/add-ons servers with mysql support" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 
-set(BOOST_VERSION "1.67")
+# The next line is the minimum version of Boost. The version that's actually found will be put in Boost_VERSION.
+set(MIN_USABLE_BOOST_VERSION "1.67")
+set(BOOST_REQ_COMPONENTS iostreams program_options regex thread random coroutine locale filesystem graph)
+
+if(ENABLE_TESTS)
+	list(APPEND BOOST_REQ_COMPONENTS unit_test_framework)
+endif()
+
+find_package(Boost ${MIN_USABLE_BOOST_VERSION} REQUIRED CONFIG COMPONENTS ${BOOST_REQ_COMPONENTS}
+	OPTIONAL_COMPONENTS charconv process system)
+
+# Boost System became header-only with a stub library in 1.69, and the library was removed in 1.89.
+if(${Boost_VERSION} VERSION_LESS "1.69" AND NOT boost_system_DIR)
+	message(FATAL_ERROR "Old version of Boost, but couldn't find the boost_system component")
+endif()
 
 if(NOT WIN32)
 	set(Lua_FIND_VERSION_MAJOR 5)
@@ -93,7 +107,6 @@ if(APPLE)
 	find_library(SECURITY_LIBRARY Security REQUIRED)
 endif()
 
-find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph)
 find_package(ICU REQUIRED COMPONENTS data i18n uc)
 
 # no, gettext executables are not required when NLS is deactivated
@@ -543,10 +556,6 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	pkg_check_modules(PANGOCAIRO REQUIRED pangocairo>=1.44.0)
 	pkg_check_modules(PANGO REQUIRED pango>=1.44.0)
 	pkg_check_modules(LIBREADLINE readline)
-endif()
-
-if(ENABLE_TESTS)
-	find_package( Boost ${BOOST_VERSION} REQUIRED COMPONENTS unit_test_framework )
 endif()
 
 if(ENABLE_GAME)

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,8 @@
 ### User interface
 ### WML Engine
 ### Miscellaneous and Bug Fixes
-
+  * CMake build system:
+     * Make Boost::system optional with boost 1.69 or later (necessary for compatibility with 1.89 and later).
 ## Version 1.18.7
 ### Translations
    * Updated translations: Bengali, Chinese (Simplified), Czech, French, Hungarian, Portuguese (Brazil)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -237,6 +237,20 @@ if(ENABLE_GAME)
 		add_executable(wesnoth wesnoth.cpp)
 	endif()
 
+	set(BOOST_LIBS
+		Boost::iostreams
+		Boost::program_options
+		Boost::regex
+		Boost::random
+		Boost::coroutine
+		Boost::locale
+		Boost::filesystem
+	)
+
+	if(boost_system_DIR)
+		list(APPEND BOOST_LIBS Boost::system)
+	endif()
+
 	target_link_libraries(wesnoth
 		wesnoth-common
 		${WIDGETS_LIB}
@@ -245,14 +259,7 @@ if(ENABLE_GAME)
 		${game-external-libs}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
+		${BOOST_LIBS}
 		Fontconfig::Fontconfig
 		SDL2::SDL2
 		SDL2::SDL2main
@@ -335,20 +342,27 @@ if(ENABLE_SERVER)
 		target_link_libraries(wesnothd mariadbclientpp)
 	endif()
 
+	set(BOOST_LIBS
+		Boost::iostreams
+		Boost::program_options
+		Boost::regex
+		Boost::random
+		Boost::coroutine
+		Boost::locale
+		Boost::filesystem
+	)
+
+	if(boost_system_DIR)
+		list(APPEND BOOST_LIBS Boost::system)
+	endif()
+
 	target_link_libraries(wesnothd
 		wesnoth-common
 		${common-external-libs}
 		${MYSQL_LIBS}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
+		${BOOST_LIBS}
 	)
 	if(MSVC)
 		target_link_options(wesnothd PRIVATE /WX)
@@ -375,13 +389,7 @@ if(ENABLE_CAMPAIGN_SERVER)
 		target_link_libraries(campaignd mariadbclientpp)
 	endif()
 
-	target_link_libraries(
-		campaignd
-		wesnoth-common
-		${common-external-libs}
-		${MYSQL_LIBS}
-		OpenSSL::Crypto
-		OpenSSL::SSL
+	set(BOOST_LIBS
 		Boost::iostreams
 		Boost::program_options
 		Boost::regex
@@ -390,6 +398,20 @@ if(ENABLE_CAMPAIGN_SERVER)
 		Boost::coroutine
 		Boost::locale
 		Boost::filesystem
+	)
+
+	if(boost_system_DIR)
+		list(APPEND BOOST_LIBS Boost::system)
+	endif()
+
+	target_link_libraries(
+		campaignd
+		wesnoth-common
+		${common-external-libs}
+		${MYSQL_LIBS}
+		OpenSSL::Crypto
+		OpenSSL::SSL
+		${BOOST_LIBS}
 	)
 	if(MSVC)
 		target_link_options(campaignd PRIVATE /WX)


### PR DESCRIPTION
The boost-system component became header-only in 1.69, and the stub library was removed in 1.90. For the Wesnoth's stable branch, support both.

Includes every simplification to CMakeLists.txt's Boost handling which I saw in the master branch.