### PR TITLE
improve minimap performance on large maps (and fix crash)

### DIFF
--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -52,7 +52,7 @@ std::function<rect(rect)> prep_minimap_for_rendering(
 	const bool preferences_minimap_unit_coding    = prefs::get().minimap_movement_coding();
 
 	auto get_scale = [&](){
-		const int size_max = std::max(map.h(), map.w())
+		const int size_max = std::max(map.h(), map.w());
 		if(!preferences_minimap_draw_terrain || !preferences_minimap_terrain_coding) {
 			return 4;
 		} else if(size_max > 60) {


### PR DESCRIPTION
Fixes #11061

the scale was changed fom 8 to 24 at some point to make it look better on small maps, this commit changes it back to 8 for large maps.