### PR TITLE
Android/IOUtils: strip extension before copying

### DIFF
--- a/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
+++ b/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
@@ -78,7 +78,7 @@ public class IOUtils {
 					existingFile.delete();
 				}
 
-				DocumentFile newFile = targetParent.createFile(getMimeType(sourceName), sourceName);
+				DocumentFile newFile = targetParent.createFile(null, sourceName);
 				if (newFile == null) {
 					Log.e("Import/Export copy", "Cannot create file " + sourceName + " for writing.");
 					return;
@@ -102,10 +102,5 @@ public class IOUtils {
 				Log.e("Import/Export copy", "IO error", ioe);
 			}
 		}
-	}
-	
-	private static String getMimeType(String filename) {
-		String ext = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
-		return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
 	}
 }


### PR DESCRIPTION
Resolves #11073
`DocumentFile.createFile` automatically appends an extension based on the document's mimetype, so it expects the filename without the extension.