### PR TITLE
xcode/ios: separate iOS device and simulator linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,8 @@ boost_test_result.xml
 !projectfiles/Xcode/ios/build_ios_deps.sh
 projectfiles/Xcode/Headers.iOS
 projectfiles/Xcode/lib.iOS
+projectfiles/Xcode/Headers.device
+projectfiles/Xcode/lib.device
 boost_tests.log
 
 # translations

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -1391,6 +1391,10 @@
 		EC64D7671A085F2F0092EF75 /* seed_rng.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC64D75F1A085CE60092EF75 /* seed_rng.cpp */; };
 		EC669C261DFC95AF00172EED /* surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC669C251DFC95AF00172EED /* surface.cpp */; };
 		EC6C6B8B1D77CB0800807ED1 /* libpcre.1.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 91C554661D77A545002DB0C8 /* libpcre.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1130B1A10000A1D001 /* libbz2.1.0.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1230B1A10000A1D001 /* libexpat.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1330B1A10000A1D001 /* libiconv.2.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1430B1A10000A1D001 /* libz.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		EC74C11F197576F500B85A1A /* notifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC74C119197576F500B85A1A /* notifications.cpp */; };
 		EC74C120197576F500B85A1A /* open.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC74C11B197576F500B85A1A /* open.cpp */; };
 		EC8174671FB4284E00A8ED00 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0680271EA920A300EEE03B /* random.cpp */; };
@@ -1463,6 +1467,7 @@
 		F46C5DCF13A5074C00DD0816 /* commandline_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F46C5DCB13A5074C00DD0816 /* commandline_options.cpp */; };
 		F46C5DD413A5089100DD0816 /* lua_object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F46C5DD313A5089100DD0816 /* lua_object.cpp */; };
 		F480CD1F14034E6D007175D6 /* mapbuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F480CD1D14034E6D007175D6 /* mapbuilder.cpp */; };
+		46F1280130AF6D4F00B5AC11 /* liblua.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9107AE141DB32862001927B0 /* liblua.a */; platformFilters = (ios, ); };
 		F4D2A99614DAED0E00CAFF31 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D2A99514DAED0E00CAFF31 /* CoreFoundation.framework */; };
 		F4D2A9D514DAED4200CAFF31 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D2A99514DAED0E00CAFF31 /* CoreFoundation.framework */; };
 		F4D2DECB14DCA1D000CAFF31 /* client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4D2DECA14DCA1D000CAFF31 /* client.cpp */; };
@@ -1523,11 +1528,13 @@
 				46CD12BC2777A64000A59D05 /* libboost_coroutine-mt.dylib in Copy Frameworks */,
 				468A5BC1258CD8CC004A80EF /* libboost_locale-mt.dylib in Copy Frameworks */,
 				91B6220A1B76C0A600B00E0F /* libcairo.2.dylib in Copy Frameworks */,
+				4F8A5D1130B1A10000A1D001 /* libbz2.1.0.ios.dylib in Copy Frameworks */,
 				91B6220C1B76C0A600B00E0F /* libffi.8.dylib in Copy Frameworks */,
 				91B6220D1B76C0A600B00E0F /* libfontconfig.1.dylib in Copy Frameworks */,
 				46081FF22B2F1046006ACAD7 /* libwebpdemux.2.dylib in Copy Frameworks */,
 				468A5BC6258CD8D3004A80EF /* libboost_thread-mt.dylib in Copy Frameworks */,
 				91B6220E1B76C0A600B00E0F /* libfreetype.6.dylib in Copy Frameworks */,
+				4F8A5D1230B1A10000A1D001 /* libexpat.1.ios.dylib in Copy Frameworks */,
 				46515C402569CE2900084CE2 /* libssl.1.1.dylib in Copy Frameworks */,
 				91B6220F1B76C0A600B00E0F /* libglib-2.0.0.dylib in Copy Frameworks */,
 				4690FBC72884727800986A47 /* libboost_atomic-mt.dylib in Copy Frameworks */,
@@ -1545,6 +1552,7 @@
 				468A5BBF258CD8C9004A80EF /* libboost_filesystem-mt.dylib in Copy Frameworks */,
 				468A5BC0258CD8CB004A80EF /* libboost_iostreams-mt.dylib in Copy Frameworks */,
 				462311AC2D047D8300DAE465 /* libboost_charconv-mt.dylib in Copy Frameworks */,
+				4F8A5D1330B1A10000A1D001 /* libiconv.2.ios.dylib in Copy Frameworks */,
 				468A5BC3258CD8CF004A80EF /* libboost_regex-mt.dylib in Copy Frameworks */,
 				915C68F51DF1F90F00594B07 /* libintl.8.dylib in Copy Frameworks */,
 				4674EEA124CD207F007C18CE /* libgio-2.0.0.dylib in Copy Frameworks */,
@@ -1564,6 +1572,7 @@
 				46081FEF2B2F0FFD006ACAD7 /* libpcre2-8.0.dylib in Copy Frameworks */,
 				4674EE9D24CD1E64007C18CE /* libfribidi.0.dylib in Copy Frameworks */,
 				91A41F901CA22A98008B10D5 /* libreadline.8.2.dylib in Copy Frameworks */,
+				4F8A5D1430B1A10000A1D001 /* libz.1.ios.dylib in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2852,6 +2861,10 @@
 		EC5C243018EF07B4001FA499 /* libpangoft2-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpangoft2-1.0.0.dylib"; path = "lib/libpangoft2-1.0.0.dylib"; sourceTree = "<group>"; };
 		EC5C243118EF07B4001FA499 /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.16.dylib; path = lib/libpng16.16.dylib; sourceTree = "<group>"; };
 		EC5C243A18EF07B4001FA499 /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = /usr/lib/libz.1.dylib; sourceTree = "<absolute>"; };
+		4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.ios.dylib; path = lib/libbz2.1.0.dylib; sourceTree = "<group>"; };
+		4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libexpat.1.ios.dylib; path = lib/libexpat.1.dylib; sourceTree = "<group>"; };
+		4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.2.ios.dylib; path = lib/libiconv.2.dylib; sourceTree = "<group>"; };
+		4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.ios.dylib; path = lib/libz.1.dylib; sourceTree = "<group>"; };
 		EC5C70BB19EEB54900432CF4 /* filesystem_common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filesystem_common.cpp; sourceTree = "<group>"; };
 		EC5C70C019EEB58300432CF4 /* mp_ui_alerts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mp_ui_alerts.cpp; sourceTree = "<group>"; };
 		EC64D75F1A085CE60092EF75 /* seed_rng.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = seed_rng.cpp; sourceTree = "<group>"; };
@@ -3004,6 +3017,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				46F1280130AF6D4F00B5AC11 /* liblua.a in Frameworks */,
 				468A5BAF258CD3F8004A80EF /* libboost_random-mt.dylib in Frameworks */,
 				46406DF1230DA73E0069492E /* Security.framework in Frameworks */,
 				ECA9E7471CA20AA800A947D6 /* libreadline.8.2.dylib in Frameworks */,
@@ -6763,6 +6777,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"LOCALEDIR=\\\"translations\\\"",
@@ -6775,7 +6790,6 @@
 					"LUA_USE_MACOSX=1",
 					"LUA_USE_IOS=1",
 					"HAVE_LIBPNG=1",
-					"HAVE_HISTORY=1",
 					"XML_STATIC=1",
 					"PCRE2_STATIC=1",
 				);
@@ -6792,18 +6806,20 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				"HEADER_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(PROJECT_DIR)/../../src",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/SDL2",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/cairo",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/glib-2.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/harfbuzz",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/pango-1.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib/glib-2.0/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/SDL2",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/cairo",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/glib-2.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/harfbuzz",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/pango-1.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib/glib-2.0/include",
 				);
 				INFOPLIST_FILE = Info.plist;
 				"INFOPLIST_FILE[sdk=iphone*]" = "Info-iOS.plist";
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -6811,9 +6827,14 @@
 				LD_CLASSIC_1400 = "";
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib",
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
 				);
 				LLVM_LTO = YES_THIN;
 				OTHER_CFLAGS = (
@@ -6833,7 +6854,6 @@
 					"$(LD_CLASSIC_$(XCODE_VERSION_MAJOR))",
 				);
 				"OTHER_LDFLAGS[sdk=iphone*]" = (
-					"-llua",
 					"-lboost_atomic",
 					"-lboost_charconv",
 					"-lboost_chrono",
@@ -6874,7 +6894,6 @@
 					"-lwebp",
 					"-lsharpyuv",
 					"-lSDL2_mixer",
-					"-lSDL2",
 					"-lSDL2main",
 					"-lvorbisfile",
 					"-lvorbis",
@@ -7039,6 +7058,7 @@
 					"$(inherited)",
 					"LUA_USE_IOS=1",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-include",
@@ -7046,6 +7066,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = lua;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 			};
 			name = SignedRelease;
 		};
@@ -7064,6 +7085,7 @@
 					"LUA_USE_IOS=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-include",
@@ -7071,6 +7093,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = lua;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 			};
 			name = Debug;
 		};
@@ -7088,6 +7111,7 @@
 					"$(inherited)",
 					"LUA_USE_IOS=1",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-include",
@@ -7095,6 +7119,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = lua;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 			};
 			name = Release;
 		};
@@ -7307,6 +7332,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -7321,7 +7347,6 @@
 					"LUA_USE_MACOSX=1",
 					"LUA_USE_IOS=1",
 					"HAVE_LIBPNG=1",
-					"HAVE_HISTORY=1",
 					"LOAD_REVISION=1",
 					"XML_STATIC=1",
 					"PCRE2_STATIC=1",
@@ -7339,18 +7364,20 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				"HEADER_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(PROJECT_DIR)/../../src",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/SDL2",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/cairo",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/glib-2.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/harfbuzz",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/pango-1.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib/glib-2.0/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/SDL2",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/cairo",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/glib-2.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/harfbuzz",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/pango-1.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib/glib-2.0/include",
 				);
 				INFOPLIST_FILE = Info.plist;
 				"INFOPLIST_FILE[sdk=iphone*]" = "Info-iOS.plist";
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -7358,9 +7385,14 @@
 				LD_CLASSIC_1400 = "";
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib",
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
 				);
 				OTHER_CFLAGS = (
 					"-Wall",
@@ -7379,7 +7411,6 @@
 					"$(LD_CLASSIC_$(XCODE_VERSION_MAJOR))",
 				);
 				"OTHER_LDFLAGS[sdk=iphone*]" = (
-					"-llua",
 					"-lboost_atomic",
 					"-lboost_charconv",
 					"-lboost_chrono",
@@ -7420,7 +7451,6 @@
 					"-lwebp",
 					"-lsharpyuv",
 					"-lSDL2_mixer",
-					"-lSDL2",
 					"-lSDL2main",
 					"-lvorbisfile",
 					"-lvorbis",
@@ -7506,6 +7536,7 @@
 				ENABLE_HARDENED_RUNTIME = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"LOCALEDIR=\\\"translations\\\"",
@@ -7518,7 +7549,6 @@
 					"LUA_USE_MACOSX=1",
 					"LUA_USE_IOS=1",
 					"HAVE_LIBPNG=1",
-					"HAVE_HISTORY=1",
 					"XML_STATIC=1",
 					"PCRE2_STATIC=1",
 				);
@@ -7535,18 +7565,20 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				"HEADER_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(PROJECT_DIR)/../../src",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/SDL2",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/cairo",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/glib-2.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/harfbuzz",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/include/pango-1.0",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib/glib-2.0/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/SDL2",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/cairo",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/glib-2.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/harfbuzz",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/include/pango-1.0",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib/glib-2.0/include",
 				);
 				INFOPLIST_FILE = Info.plist;
 				"INFOPLIST_FILE[sdk=iphone*]" = "Info-iOS.plist";
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -7554,9 +7586,14 @@
 				LD_CLASSIC_1400 = "";
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/arm64-ios-simulator-wesnoth/lib",
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
 				);
 				LLVM_LTO = YES_THIN;
 				OTHER_CFLAGS = (
@@ -7576,7 +7613,6 @@
 					"$(LD_CLASSIC_$(XCODE_VERSION_MAJOR))",
 				);
 				"OTHER_LDFLAGS[sdk=iphone*]" = (
-					"-llua",
 					"-lboost_atomic",
 					"-lboost_charconv",
 					"-lboost_chrono",
@@ -7617,7 +7653,6 @@
 					"-lwebp",
 					"-lsharpyuv",
 					"-lSDL2_mixer",
-					"-lSDL2",
 					"-lSDL2main",
 					"-lvorbisfile",
 					"-lvorbis",

--- a/projectfiles/Xcode/ios/build_ios_deps.sh
+++ b/projectfiles/Xcode/ios/build_ios_deps.sh
@@ -2,18 +2,23 @@
 
 root_dir=$(cd "$(dirname "$0")/../../.." && pwd)
 ios_tag=${IOS_TAG:-v0.0.1}
-ios_triplet=${IOS_TRIPLET:-arm64-ios-simulator-wesnoth}
 ios_deployment_target=${IOS_DEPLOYMENT_TARGET:-15.0}
+
+ios_sim_triplet=${IOS_SIM_TRIPLET:-arm64-ios-simulator-wesnoth}
+ios_device_triplet=${IOS_DEVICE_TRIPLET:-arm64-ios-wesnoth}
+ios_build_simulator_deps=${IOS_BUILD_SIMULATOR_DEPS:-1}
+ios_build_device_deps=${IOS_BUILD_DEVICE_DEPS:-1}
 
 manifest_root="$root_dir/projectfiles/Xcode/ios/vcpkg"
 ios_deps_base="$root_dir/projectfiles/Xcode/temp/iOSCompileStuff-${ios_tag}"
-vcpkg_install_root="$ios_deps_base/vcpkg_installed"
-ios_prefix="$ios_deps_base/${ios_triplet}"
+vcpkg_install_base="$ios_deps_base/vcpkg_installed"
 vcpkg_root=${VCPKG_ROOT:-$root_dir/projectfiles/Xcode/temp/vcpkg-ios}
 overlay_ports_root="$ios_deps_base/overlay-ports"
 gettext_overlay_port="$overlay_ports_root/gettext-libintl"
 gettext_port_patch="$manifest_root/patches/gettext-libintl-ios.patch"
 
+sim_prefix="$ios_deps_base/${ios_sim_triplet}"
+device_prefix="$ios_deps_base/${ios_device_triplet}"
 ios_activate_xcode_links=${IOS_ACTIVATE_XCODE_LINKS:-1}
 
 need_cmd() {
@@ -23,14 +28,168 @@ need_cmd() {
 	fi
 }
 
-create_dylib_shim() {
-	dylib_name=$1
-	archive_name=$2
-	if [ ! -f "$ios_prefix/lib/$archive_name" ]; then
-		echo "Warning: missing $archive_name for shim $dylib_name, using empty archive" >&2
-		archive_name=$(basename "$empty_archive")
+prepare_gettext_overlay() {
+	echo "==> Preparing gettext-libintl overlay from the current vcpkg port"
+	rm -rf "$gettext_overlay_port"
+	mkdir -p "$overlay_ports_root"
+	rsync -a "$vcpkg_root/ports/gettext-libintl/" "$gettext_overlay_port/"
+	git -C "$gettext_overlay_port" apply "$gettext_port_patch"
+}
+
+install_triplet() {
+	triplet_name=$1
+	install_root="$vcpkg_install_base/$triplet_name"
+	echo "==> Installing iOS dependencies via vcpkg for $triplet_name"
+	"$vcpkg_root/vcpkg" install \
+		--x-manifest-root="$manifest_root" \
+		--triplet="$triplet_name" \
+		--x-install-root="$install_root" \
+		--overlay-triplets="$manifest_root/triplets" \
+		--overlay-ports="$overlay_ports_root"
+}
+
+sync_prefix_from_vcpkg() {
+	triplet_name=$1
+	prefix_dir=$2
+	install_root="$vcpkg_install_base/$triplet_name"
+
+	mkdir -p "$prefix_dir/include" "$prefix_dir/lib"
+
+	# Sync vcpkg-managed headers/libs into the Xcode iOS dependency prefix.
+	rsync -a --delete "$install_root/$triplet_name/include/" "$prefix_dir/include/"
+	rsync -a --delete "$install_root/$triplet_name/lib/" "$prefix_dir/lib/"
+}
+
+create_empty_archive_for_prefix() {
+	prefix_dir=$1
+	sdk_name=$2
+	min_flag=$3
+
+	empty_archive="$prefix_dir/lib/libwesnoth-empty.a"
+	if [ ! -f "$empty_archive" ]; then
+		sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+		safe_triplet=$(basename "$prefix_dir")
+		empty_c="$ios_deps_base/wesnoth-empty-${safe_triplet}.c"
+		empty_o="$ios_deps_base/wesnoth-empty-${safe_triplet}.o"
+		echo "void wesnoth_empty_symbol(void) {}" >"$empty_c"
+		"$(xcrun --sdk "$sdk_name" -f clang)" \
+			-arch arm64 \
+			-isysroot "$sdk_path" \
+			"$min_flag" \
+			-c "$empty_c" \
+			-o "$empty_o"
+		ar -rcs "$empty_archive" "$empty_o"
+		rm -f "$empty_c" "$empty_o"
 	fi
-	ln -sfn "$archive_name" "$ios_prefix/lib/$dylib_name"
+	echo "$empty_archive"
+}
+
+create_dylib_shim() {
+	prefix_dir=$1
+	sdk_name=$2
+	min_flag=$3
+	empty_archive_name=$4
+	dylib_name=$5
+	archive_name=$6
+
+	archive_path="$prefix_dir/lib/$archive_name"
+	if [ ! -f "$archive_path" ]; then
+		echo "Warning: missing $archive_name for shim $dylib_name, using empty archive" >&2
+		archive_path="$prefix_dir/lib/$empty_archive_name"
+	fi
+
+	sdk_path=$(xcrun --sdk "$sdk_name" --show-sdk-path)
+	clang_bin=$(xcrun --sdk "$sdk_name" -f clang)
+
+	# Generate a real dylib shim so Xcode copy-framework steps can bitcode-strip it.
+	"$clang_bin" \
+		-dynamiclib \
+		-arch arm64 \
+		-isysroot "$sdk_path" \
+		"$min_flag" \
+		-Wl,-all_load \
+		"$archive_path" \
+		-Wl,-undefined,dynamic_lookup \
+		-install_name "@rpath/$dylib_name" \
+		-o "$prefix_dir/lib/$dylib_name"
+}
+
+create_all_shims_for_prefix() {
+	prefix_dir=$1
+	sdk_name=$2
+	min_flag=$3
+	empty_archive_name=$(basename "$4")
+
+	# The existing Xcode project file still has Frameworks / Copy Frameworks refs
+	# that point at explicit .dylib filenames. Generate compatibility dylibs from
+	# the static archives for those refs.
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_atomic-mt.dylib" "libboost_atomic.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_charconv-mt.dylib" "libboost_charconv.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_chrono-mt.dylib" "libboost_chrono.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_context-mt.dylib" "libboost_context.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_coroutine-mt.dylib" "libboost_coroutine.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_filesystem-mt.dylib" "libboost_filesystem.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_iostreams-mt.dylib" "libboost_iostreams.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_locale-mt.dylib" "libboost_locale.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_prg_exec_monitor-mt.dylib" "libboost_prg_exec_monitor.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_program_options-mt.dylib" "libboost_program_options.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_random-mt.dylib" "libboost_random.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_regex-mt.dylib" "libboost_regex.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_system-mt.dylib" "libboost_system.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_thread-mt.dylib" "libboost_thread.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_timer-mt.dylib" "libboost_timer.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libboost_unit_test_framework-mt.dylib" "libboost_unit_test_framework.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libbz2.1.0.dylib" "libbz2.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libcairo.2.dylib" "libcairo.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libcrypto.1.1.dylib" "libcrypto.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libexpat.1.dylib" "libexpat.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libffi.8.dylib" "libffi.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libfontconfig.1.dylib" "libfontconfig.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libfreetype.6.dylib" "libfreetype.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libfribidi.0.dylib" "libfribidi.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libgio-2.0.0.dylib" "libgio-2.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libglib-2.0.0.dylib" "libglib-2.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libgmodule-2.0.0.dylib" "libgmodule-2.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libgobject-2.0.0.dylib" "libgobject-2.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libgraphite2.3.dylib" "libgraphite2.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libgthread-2.0.0.dylib" "libgthread-2.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libharfbuzz.0.dylib" "libharfbuzz.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libiconv.2.dylib" "libiconv.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libintl.8.dylib" "libintl.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libogg.0.dylib" "libogg.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpango-1.0.0.dylib" "libpango-1.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpangocairo-1.0.0.dylib" "libpangocairo-1.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpangoft2-1.0.0.dylib" "libpangoft2-1.0.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpcre.1.dylib" "libpcre.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpcre2-8.0.dylib" "libpcre2-8.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpixman-1.0.dylib" "libpixman-1.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libpng16.16.dylib" "libpng16.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libreadline.8.2.dylib" "libreadline.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libSDL2-2.0.0.dylib" "libSDL2.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libSDL2_image-2.0.0.dylib" "libSDL2_image.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libSDL2_mixer-2.0.0.dylib" "libSDL2_mixer.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libsharpyuv.0.dylib" "libsharpyuv.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libssl.1.1.dylib" "libssl.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libvorbis.0.dylib" "libvorbis.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libvorbisfile.dylib" "libvorbisfile.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libwebp.7.dylib" "libwebp.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libwebpdemux.2.dylib" "libwebpdemux.a"
+	create_dylib_shim "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive_name" "libz.1.dylib" "libz.a"
+}
+
+build_prefix() {
+	triplet_name=$1
+	prefix_dir=$2
+	sdk_name=$3
+	min_flag=$4
+
+	install_triplet "$triplet_name"
+	sync_prefix_from_vcpkg "$triplet_name" "$prefix_dir"
+
+	empty_archive=$(create_empty_archive_for_prefix "$prefix_dir" "$sdk_name" "$min_flag")
+	create_all_shims_for_prefix "$prefix_dir" "$sdk_name" "$min_flag" "$empty_archive"
+
+	echo "==> iOS dependency prefix ready: $prefix_dir"
 }
 
 need_cmd git
@@ -53,106 +212,39 @@ if [ ! -f "$gettext_port_patch" ]; then
 	exit 1
 fi
 
-echo "==> Preparing gettext-libintl overlay from the current vcpkg port"
-rm -rf "$gettext_overlay_port"
-mkdir -p "$overlay_ports_root"
-rsync -a "$vcpkg_root/ports/gettext-libintl/" "$gettext_overlay_port/"
-git -C "$gettext_overlay_port" apply "$gettext_port_patch"
+prepare_gettext_overlay
 
-echo "==> Installing iOS simulator dependencies via vcpkg"
-"$vcpkg_root/vcpkg" install \
-	--x-manifest-root="$manifest_root" \
-	--triplet="$ios_triplet" \
-	--x-install-root="$vcpkg_install_root" \
-	--overlay-triplets="$manifest_root/triplets" \
-	--overlay-ports="$overlay_ports_root"
-
-mkdir -p "$ios_prefix/include" "$ios_prefix/lib"
-
-# Sync vcpkg-managed headers/libs into the Xcode iOS dependency prefix.
-rsync -a --delete "$vcpkg_install_root/$ios_triplet/include/" "$ios_prefix/include/"
-rsync -a --delete "$vcpkg_install_root/$ios_triplet/lib/" "$ios_prefix/lib/"
-
-sdk_path=$(xcrun --sdk iphonesimulator --show-sdk-path)
-
-# Framework file refs in the legacy Xcode project still point at .dylib filenames.
-# Generate compatibility symlinks to static archives for iOS simulator linking.
-empty_archive="$ios_prefix/lib/libwesnoth-empty.a"
-if [ ! -f "$empty_archive" ]; then
-	empty_c="$ios_deps_base/wesnoth-empty.c"
-	empty_o="$ios_deps_base/wesnoth-empty.o"
-	echo "void wesnoth_empty_symbol(void) {}" >"$empty_c"
-	"$(xcrun --sdk iphonesimulator -f clang)" \
-		-arch arm64 \
-		-isysroot "$sdk_path" \
-		-mios-simulator-version-min="${ios_deployment_target}" \
-		-c "$empty_c" \
-		-o "$empty_o"
-	ar -rcs "$empty_archive" "$empty_o"
-	rm -f "$empty_c" "$empty_o"
+if [ "$ios_build_simulator_deps" = "1" ]; then
+	build_prefix "$ios_sim_triplet" "$sim_prefix" "iphonesimulator" "-mios-simulator-version-min=${ios_deployment_target}"
 fi
 
-create_dylib_shim "libboost_atomic-mt.dylib" "libboost_atomic.a"
-create_dylib_shim "libboost_charconv-mt.dylib" "libboost_charconv.a"
-create_dylib_shim "libboost_chrono-mt.dylib" "libboost_chrono.a"
-create_dylib_shim "libboost_context-mt.dylib" "libboost_context.a"
-create_dylib_shim "libboost_coroutine-mt.dylib" "libboost_coroutine.a"
-create_dylib_shim "libboost_filesystem-mt.dylib" "libboost_filesystem.a"
-create_dylib_shim "libboost_iostreams-mt.dylib" "libboost_iostreams.a"
-create_dylib_shim "libboost_locale-mt.dylib" "libboost_locale.a"
-create_dylib_shim "libboost_prg_exec_monitor-mt.dylib" "libboost_prg_exec_monitor.a"
-create_dylib_shim "libboost_program_options-mt.dylib" "libboost_program_options.a"
-create_dylib_shim "libboost_random-mt.dylib" "libboost_random.a"
-create_dylib_shim "libboost_regex-mt.dylib" "libboost_regex.a"
-create_dylib_shim "libboost_system-mt.dylib" "libboost_system.a"
-create_dylib_shim "libboost_thread-mt.dylib" "libboost_thread.a"
-create_dylib_shim "libboost_timer-mt.dylib" "libboost_timer.a"
-create_dylib_shim "libboost_unit_test_framework-mt.dylib" "libboost_unit_test_framework.a"
-create_dylib_shim "libbz2.1.0.dylib" "libbz2.a"
-create_dylib_shim "libcairo.2.dylib" "libcairo.a"
-create_dylib_shim "libcrypto.1.1.dylib" "libcrypto.a"
-create_dylib_shim "libexpat.1.dylib" "libexpat.a"
-create_dylib_shim "libffi.8.dylib" "libffi.a"
-create_dylib_shim "libfontconfig.1.dylib" "libfontconfig.a"
-create_dylib_shim "libfreetype.6.dylib" "libfreetype.a"
-create_dylib_shim "libfribidi.0.dylib" "libfribidi.a"
-create_dylib_shim "libgio-2.0.0.dylib" "libgio-2.0.a"
-create_dylib_shim "libglib-2.0.0.dylib" "libglib-2.0.a"
-create_dylib_shim "libgmodule-2.0.0.dylib" "libgmodule-2.0.a"
-create_dylib_shim "libgobject-2.0.0.dylib" "libgobject-2.0.a"
-create_dylib_shim "libgraphite2.3.dylib" "libgraphite2.a"
-create_dylib_shim "libgthread-2.0.0.dylib" "libgthread-2.0.a"
-create_dylib_shim "libharfbuzz.0.dylib" "libharfbuzz.a"
-create_dylib_shim "libiconv.2.dylib" "libiconv.a"
-create_dylib_shim "libintl.8.dylib" "libintl.a"
-create_dylib_shim "libogg.0.dylib" "libogg.a"
-create_dylib_shim "libpango-1.0.0.dylib" "libpango-1.0.a"
-create_dylib_shim "libpangocairo-1.0.0.dylib" "libpangocairo-1.0.a"
-create_dylib_shim "libpangoft2-1.0.0.dylib" "libpangoft2-1.0.a"
-create_dylib_shim "libpcre.1.dylib" "libpcre.a"
-create_dylib_shim "libpcre2-8.0.dylib" "libpcre2-8.a"
-create_dylib_shim "libpixman-1.0.dylib" "libpixman-1.a"
-create_dylib_shim "libpng16.16.dylib" "libpng16.a"
-create_dylib_shim "libreadline.8.2.dylib" "libreadline.a"
-create_dylib_shim "libSDL2-2.0.0.dylib" "libSDL2.a"
-create_dylib_shim "libSDL2_image-2.0.0.dylib" "libSDL2_image.a"
-create_dylib_shim "libSDL2_mixer-2.0.0.dylib" "libSDL2_mixer.a"
-create_dylib_shim "libsharpyuv.0.dylib" "libsharpyuv.a"
-create_dylib_shim "libssl.1.1.dylib" "libssl.a"
-create_dylib_shim "libvorbis.0.dylib" "libvorbis.a"
-create_dylib_shim "libvorbisfile.dylib" "libvorbisfile.a"
-create_dylib_shim "libwebp.7.dylib" "libwebp.a"
-create_dylib_shim "libwebpdemux.2.dylib" "libwebpdemux.a"
-create_dylib_shim "libz.1.dylib" "libz.a"
+if [ "$ios_build_device_deps" = "1" ]; then
+	build_prefix "$ios_device_triplet" "$device_prefix" "iphoneos" "-miphoneos-version-min=${ios_deployment_target}"
+fi
 
-echo "==> Linking convenience iOS include/lib symlinks"
-ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_triplet}/include" "$root_dir/projectfiles/Xcode/Headers.iOS"
-ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_triplet}/lib" "$root_dir/projectfiles/Xcode/lib.iOS"
+if [ "$ios_build_simulator_deps" = "1" ]; then
+	echo "==> Linking convenience simulator include/lib symlinks"
+	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_sim_triplet}/include" "$root_dir/projectfiles/Xcode/Headers.iOS"
+	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_sim_triplet}/lib" "$root_dir/projectfiles/Xcode/lib.iOS"
+fi
+
+if [ "$ios_build_device_deps" = "1" ]; then
+	echo "==> Linking convenience device include/lib symlinks"
+	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_device_triplet}/include" "$root_dir/projectfiles/Xcode/Headers.device"
+	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_device_triplet}/lib" "$root_dir/projectfiles/Xcode/lib.device"
+fi
 
 if [ "$ios_activate_xcode_links" = "1" ]; then
 	echo "==> Activating iOS dependency symlinks for the Xcode project"
-	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_triplet}/include" "$root_dir/projectfiles/Xcode/Headers"
-	ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_triplet}/lib" "$root_dir/projectfiles/Xcode/lib"
+	if [ "$ios_build_simulator_deps" = "1" ]; then
+		ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_sim_triplet}/include" "$root_dir/projectfiles/Xcode/Headers"
+		ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_sim_triplet}/lib" "$root_dir/projectfiles/Xcode/lib"
+	elif [ "$ios_build_device_deps" = "1" ]; then
+		ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_device_triplet}/include" "$root_dir/projectfiles/Xcode/Headers"
+		ln -sfn "temp/iOSCompileStuff-${ios_tag}/${ios_device_triplet}/lib" "$root_dir/projectfiles/Xcode/lib"
+	fi
 fi
 
-echo "==> iOS simulator dependency prefix ready: $ios_prefix"
+echo "==> Done. Built triplets:"
+[ "$ios_build_simulator_deps" = "1" ] && echo "    - $ios_sim_triplet"
+[ "$ios_build_device_deps" = "1" ] && echo "    - $ios_device_triplet"

--- a/projectfiles/Xcode/ios/vcpkg/triplets/arm64-ios-wesnoth.cmake
+++ b/projectfiles/Xcode/ios/vcpkg/triplets/arm64-ios-wesnoth.cmake
@@ -1,0 +1,8 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME iOS)
+set(VCPKG_OSX_SYSROOT iphoneos)
+
+# Force autotools ports to treat iOS device as cross-compilation.
+set(VCPKG_MAKE_BUILD_TRIPLET "--build=aarch64-apple-darwin" "--host=aarch64-apple-ios")


### PR DESCRIPTION
#### Part 3 of 6.

This PR continues the iOS bring-up by splitting simulator and device linkage paths in the Xcode project while keeping desktop targets unchanged.

Included in this PR:
- add an iOS device vcpkg triplet (`arm64-ios-wesnoth`) alongside the existing simulator triplet
- update `build_ios_deps.sh` to build and sync separate simulator/device dependency prefixes
- switch iOS Xcode header/library/framework search paths to use `$(WESNOTH_IOS_TRIPLET)` instead of a hard-coded simulator prefix
- gate `Cocoa`, `curl`, and `readline` off iOS linkage and keep them on desktop targets
- make `liblua` an explicit iOS build artifact and adjust iOS runtime/copy-framework linkage for launch-time dylib resolution
- add `.gitignore` entries for device-side convenience links (`Headers.device`, `lib.device`)

To verify the changes locally, run:
- `./projectfiles/Xcode/ios/build_ios_deps.sh`
- build `The Battle for Wesnoth` in Xcode for:
  - an iOS simulator destination
  - a physical iOS device destination
  
Next up is **Part 4 of 6** – iOS shell integration, focused on launcher/runtime behavior on device while keeping desktop behavior unchanged.