### PR TITLE
Bump vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "wesnoth-dependencies",
   "version": "0.0.1",
-  "builtin-baseline": "52f93a645e9f4d4141c32f5bab12575278548367",
+  "builtin-baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
This pulls in sdl3-mixer, which is the last package we need for #8638.