### PR TITLE
Swap LoW, SoF in campaigns order

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -26,7 +26,7 @@
 [campaign]
     id=LOW
     define=CAMPAIGN_LOW
-    rank=160
+    rank=155
     start_year="19 YW"
     end_year="93 YW"
 

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -10,7 +10,7 @@
     image="data/campaigns/Sceptre_of_Fire/images/campaign_image.png"
     name= _ "The Sceptre of Fire"
     abbrev= _ "SoF"
-    rank=155
+    rank=160
     start_year="25 YW"
     end_year="40 YW"
     define="CAMPAIGN_SCEPTRE_FIRE"


### PR DESCRIPTION
LoW is before SoF chronologically, and the beginning of SoF (Landar's rebels) will make much more sense after playing LoW first.

This also gives us a second pseudo story arc: TRoW -> WoF -> LoW -> SoF. All campaigns have the same difficulty rating.