### PR TITLE
Server: Use async_wait instead of blocking on a null write

### DIFF
--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -433,7 +433,7 @@ void server_base::coro_send_file(const socket_ptr& socket, const std::string& fi
 				|| ec == boost::asio::error::try_again)
 		{
 			// We have to wait for the socket to become ready again.
-			socket->async_write_some(boost::asio::null_buffers(), yield[ec]);
+			socket->async_wait(boost::asio::socket_base::wait_type::wait_write, yield[ec]);
 			if(check_error(ec, socket)) return;
 			continue;
 		}
@@ -500,7 +500,7 @@ void server_base::coro_send_file(const socket_ptr& socket, const std::string& fi
 		if(WSAGetLastError() == WSA_IO_PENDING) {
 			while(true) {
 				// The request is pending. Wait until it completes.
-				socket->async_write_some(boost::asio::null_buffers(), yield);
+				socket->async_wait(boost::asio::socket_base::wait_type::wait_write, yield);
 
 				DWORD win_ec = GetLastError();
 				if (win_ec != ERROR_IO_PENDING && win_ec != ERROR_SUCCESS)


### PR DESCRIPTION
`null_buffers` was deprecated since boost 1.66. Current minimum boost for Wesnoth is 1.70.

https://github.com/wesnoth/wesnoth/blob/208fc3737387b6e903dc2471b52815383b1e63a7/CMakeLists.txt#L56

(Even 1.18 branch has it set to 1.67.)

I needed to make this change in order to compile #11092 without errors on MSVC. I'm not familiar with `boost::asio`, so please advise if there's a better way of doing this.