### PR TITLE
Serialize translatable strings in simple_wml

### DIFF
--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -186,6 +186,30 @@ std::string string_span::to_string() const
 	return std::string(begin(), end());
 }
 
+t_string string_span::to_tstring() const
+{
+	return t_string::from_serialized(to_string());
+}
+
+bool string_span::is_bool() const
+{
+	return operator==("no") || operator==("yes") || operator==("off") || operator==("on") || operator==("false") || operator==("true") || operator==("0") || operator==("0.0") || operator==("0.0") || operator==("1.0");
+}
+
+bool string_span::is_int() const
+{
+	for(auto it = begin(); it < end(); ++it) {
+		if(!std::isdigit(*it)) return false;
+	}
+	return true;
+}
+
+bool string_span::is_tstring() const
+{
+	if(is_null() || empty()) return false;
+	return t_string_base::is_translatable_mark(*begin());
+}
+
 char* string_span::duplicate() const
 {
 	char* buf = new char[size() + 1];
@@ -444,6 +468,12 @@ node& node::set_attr_esc(const char* key, string_span value)
 node& node::set_attr_int(const char* key, int value)
 {
 	std::string temp = std::to_string(value);
+	return set_attr_dup(key, temp.c_str());
+}
+
+node& node::set_attr_tstring(const char* key, const t_string& value)
+{
+	std::string temp = value.to_serialized();
 	return set_attr_dup(key, temp.c_str());
 }
 

--- a/src/server/common/simple_wml.hpp
+++ b/src/server/common/simple_wml.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "exceptions.hpp"
+#include "tstring.hpp"
 
 namespace simple_wml {
 
@@ -101,6 +102,11 @@ public:
 	bool to_bool(bool default_value=false) const;
 	int to_int() const;
 	std::string to_string() const;
+	t_string to_tstring() const;
+	
+	bool is_bool() const;
+	bool is_int() const;
+	bool is_tstring() const;
 
 	//returns a duplicate of the string span in a new[] allocated buffer
 	char* duplicate() const;
@@ -151,6 +157,7 @@ public:
 	node& set_attr_esc(const char* key, string_span value);
 
 	node& set_attr_int(const char* key, int value);
+	node& set_attr_tstring(const char* key, const t_string& value);
 
 	node& add_child(const char* name);
 	node& add_child_at(const char* name, std::size_t index);
@@ -284,6 +291,14 @@ public:
 
 	node& set_attr_dup(const char* key, const char* value) {
 		return root().set_attr_dup(key, value);
+	}
+	
+	node& set_attr_int(const char* key, int value) {
+		return root().set_attr_int(key, value);
+	}
+	
+	node& set_attr_tstring(const char* key, const t_string& value) {
+		return root().set_attr_tstring(key, value);
 	}
 
 	void take_ownership_of_buffer(char* buffer) {

--- a/src/tstring.cpp
+++ b/src/tstring.cpp
@@ -341,7 +341,7 @@ t_string_base t_string_base::from_serialized(const std::string& string)
 {
 	t_string_base orig(string);
 
-	if(!string.empty() && (string[0] == TRANSLATABLE_PART || string[0] == UNTRANSLATABLE_PART)) {
+	if(!string.empty() && is_translatable_mark(string[0])) {
 		orig.translatable_ = true;
 	} else {
 		orig.translatable_ = false;
@@ -360,6 +360,10 @@ t_string_base t_string_base::from_serialized(const std::string& string)
 	}
 
 	return res;
+}
+
+bool t_string_base::is_translatable_mark(char c) {
+	return c == TRANSLATABLE_PART || c == UNTRANSLATABLE_PART;
 }
 
 std::string t_string_base::base_str() const

--- a/src/tstring.hpp
+++ b/src/tstring.hpp
@@ -118,6 +118,8 @@ public:
 	std::string base_str() const;
 
 	std::size_t hash_value() const;
+	
+	static bool is_translatable_mark(char c);
 
 private:
 	std::string value_;


### PR DESCRIPTION
This is untested and probably not yet working, but I think this is how `t_string` serialization _should_ look in `simple_wml`.

I probably need to find all the places that read and save attributes to update how they do things.