### PR TITLE
Server: Use async_wait instead of blocking on a null write (1.18)

### DIFF
--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -427,7 +427,7 @@ void server_base::coro_send_file(socket_ptr socket, const std::string& filename,
 				|| ec == boost::asio::error::try_again)
 		{
 			// We have to wait for the socket to become ready again.
-			socket->async_write_some(boost::asio::null_buffers(), yield[ec]);
+			socket->async_wait(boost::asio::socket_base::wait_type::wait_write, yield[ec]);
 			if(check_error(ec, socket)) return;
 			continue;
 		}
@@ -494,7 +494,7 @@ void server_base::coro_send_file(socket_ptr socket, const std::string& filename,
 		if(WSAGetLastError() == WSA_IO_PENDING) {
 			while(true) {
 				// The request is pending. Wait until it completes.
-				socket->async_write_some(boost::asio::null_buffers(), yield);
+				socket->async_wait(boost::asio::socket_base::wait_type::wait_write, yield);
 
 				DWORD win_ec = GetLastError();
 				if (win_ec != ERROR_IO_PENDING && win_ec != ERROR_SUCCESS)


### PR DESCRIPTION
Back-port of #11108. The warnings happen in 1.18 compilation as well.