### PR TITLE
ios/filesystem: restore the iCloud Drive save root and finish the iOS filesystem pass

### DIFF
--- a/projectfiles/Xcode/Info-iOS.plist
+++ b/projectfiles/Xcode/Info-iOS.plist
@@ -26,6 +26,18 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>(C) 2003-2026 by The Battle for Wesnoth Project</string>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.$(PRODUCT_BUNDLE_IDENTIFIER)</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>Wesnoth</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiresFullScreen</key>

--- a/projectfiles/Xcode/Resources/Wesnoth.entitlements
+++ b/projectfiles/Xcode/Resources/Wesnoth.entitlements
@@ -4,9 +4,23 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		46081FF22B2F1046006ACAD7 /* libwebpdemux.2.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 46081FF02B2F103E006ACAD7 /* libwebpdemux.2.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		46081FF42B2F11F3006ACAD7 /* libsharpyuv.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46081FF32B2F11F3006ACAD7 /* libsharpyuv.0.dylib */; platformFilters = (macos, ); };
 		46081FF52B2F11FF006ACAD7 /* libsharpyuv.0.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 46081FF32B2F11F3006ACAD7 /* libsharpyuv.0.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F2BFC30E661C4E648BED7C6E /* apple_icloud.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3EB25CAA9644806AE9E4E61 /* apple_icloud.mm */; };
 		460CA6D52143362800B89741 /* apple_version.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46F54C26211DFB7200374A1C /* apple_version.mm */; };
 		460D898624DC7831000B1ABC /* game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 460D897824DC7830000B1ABC /* game.cpp */; };
 		460D898724DC7831000B1ABC /* ban.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 460D897C24DC7830000B1ABC /* ban.cpp */; };
@@ -1668,6 +1669,8 @@
 		460D89B524DC7862000B1ABC /* addon_utils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = addon_utils.hpp; path = ../../src/server/campaignd/addon_utils.hpp; sourceTree = SOURCE_ROOT; };
 		46181DCD2119F73A00908BC2 /* apple_battery_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = apple_battery_info.hpp; path = ../../src/desktop/apple_battery_info.hpp; sourceTree = "<group>"; };
 		46181DCE2119F73A00908BC2 /* apple_battery_info.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = apple_battery_info.mm; path = ../../src/desktop/apple_battery_info.mm; sourceTree = "<group>"; };
+		E760D1242C254B5DA4D3CF22 /* apple_icloud.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = apple_icloud.hpp; path = ../../src/desktop/apple_icloud.hpp; sourceTree = "<group>"; };
+		B3EB25CAA9644806AE9E4E61 /* apple_icloud.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = apple_icloud.mm; path = ../../src/desktop/apple_icloud.mm; sourceTree = "<group>"; };
 		46181DD02119F74C00908BC2 /* battery_info.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = battery_info.hpp; sourceTree = "<group>"; };
 		46181DD12119F74C00908BC2 /* battery_info.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = battery_info.cpp; sourceTree = "<group>"; };
 		461DC52B241F836200B9DD10 /* lua_color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lua_color.cpp; sourceTree = "<group>"; };
@@ -3183,6 +3186,8 @@
 			children = (
 				46181DCD2119F73A00908BC2 /* apple_battery_info.hpp */,
 				46181DCE2119F73A00908BC2 /* apple_battery_info.mm */,
+				E760D1242C254B5DA4D3CF22 /* apple_icloud.hpp */,
+				B3EB25CAA9644806AE9E4E61 /* apple_icloud.mm */,
 				F40A13BD1A3AA56800C4D071 /* apple_notification.hpp */,
 				F40A13BB1A3A88BA00C4D071 /* apple_notification.mm */,
 				46F54C28211DFB9100374A1C /* apple_version.hpp */,
@@ -5350,6 +5355,9 @@
 							com.apple.HardenedRuntime = {
 								enabled = 1;
 							};
+							com.apple.iCloud = {
+								enabled = 1;
+							};
 						};
 					};
 					B5BB6B4A0F890FBA00444FBF = {
@@ -5452,6 +5460,7 @@
 				B54AC6D80FEA9EB5006F6FBD /* ai.cpp in Sources */,
 				46F92E632174F6A400602C1C /* window.cpp in Sources */,
 				B5599B830EC62181008DD061 /* animated.cpp in Sources */,
+				F2BFC30E661C4E648BED7C6E /* apple_icloud.mm in Sources */,
 				F40A13BC1A3A88BA00C4D071 /* apple_notification.mm in Sources */,
 				91AF55DF2848472F007A7652 /* draw.cpp in Sources */,
 				EC218E9C1A1064F4007C910C /* application_lua_kernel.cpp in Sources */,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ if(APPLE)
 	set(wesnoth_game_sources
 		${wesnoth_game_sources}
 		desktop/apple_battery_info.mm
+		desktop/apple_icloud.mm
 		desktop/apple_notification.mm
 		desktop/apple_version.mm
 		desktop/apple_video.mm

--- a/src/desktop/apple_icloud.hpp
+++ b/src/desktop/apple_icloud.hpp
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2026 - 2026
+	Copyright (C) 2026
 	by Neil Hiddink
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 

--- a/src/desktop/apple_icloud.hpp
+++ b/src/desktop/apple_icloud.hpp
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2026
+	Copyright (C) 2026 - 2026
 	by Neil Hiddink
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 

--- a/src/desktop/apple_icloud.hpp
+++ b/src/desktop/apple_icloud.hpp
@@ -1,0 +1,28 @@
+/*
+	Copyright (C) 2026
+	by Neil Hiddink
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "utils/optional_fwd.hpp"
+
+#include <string>
+
+namespace desktop {
+namespace apple {
+
+utils::optional<std::string> get_icloud_drive_documents_dir();
+
+} // end namespace apple
+} // end namespace desktop

--- a/src/desktop/apple_icloud.mm
+++ b/src/desktop/apple_icloud.mm
@@ -1,0 +1,78 @@
+/*
+	Copyright (C) 2026
+	by Neil Hiddink
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#ifdef __APPLE__
+
+#include "apple_icloud.hpp"
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IOS
+
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+
+namespace desktop {
+namespace apple {
+
+utils::optional<std::string> get_icloud_drive_documents_dir()
+{
+	__block NSString* documents_path = nil;
+
+	@autoreleasepool {
+		NSString* bundle_identifier = [[NSBundle mainBundle] bundleIdentifier];
+		if(bundle_identifier.length == 0) {
+			return utils::nullopt;
+		}
+
+		NSString* container_identifier = [@"iCloud." stringByAppendingString:bundle_identifier];
+
+		dispatch_sync(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+			@autoreleasepool {
+				NSURL* container_url =
+					[[NSFileManager defaultManager] URLForUbiquityContainerIdentifier:container_identifier];
+				if(container_url != nil) {
+					NSURL* documents_url = [container_url URLByAppendingPathComponent:@"Documents" isDirectory:YES];
+					documents_path = [documents_url path];
+				}
+			}
+		});
+
+		if(documents_path.length == 0) {
+			return utils::nullopt;
+		}
+
+		return std::string([documents_path UTF8String]);
+	}
+}
+
+} // end namespace apple
+} // end namespace desktop
+
+#else
+
+namespace desktop {
+namespace apple {
+
+utils::optional<std::string> get_icloud_drive_documents_dir()
+{
+	return utils::nullopt;
+}
+
+} // end namespace apple
+} // end namespace desktop
+
+#endif
+#endif

--- a/src/desktop/apple_icloud.mm
+++ b/src/desktop/apple_icloud.mm
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2026 - 2026
+	Copyright (C) 2026
 	by Neil Hiddink
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 

--- a/src/desktop/apple_icloud.mm
+++ b/src/desktop/apple_icloud.mm
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2026
+	Copyright (C) 2026 - 2026
 	by Neil Hiddink
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 

--- a/src/desktop/apple_icloud.mm
+++ b/src/desktop/apple_icloud.mm
@@ -22,34 +22,30 @@
 #if TARGET_OS_IOS
 
 #import <Foundation/Foundation.h>
-#import <dispatch/dispatch.h>
 
 namespace desktop {
 namespace apple {
 
 utils::optional<std::string> get_icloud_drive_documents_dir()
 {
-	__block NSString* documents_path = nil;
-
 	@autoreleasepool {
 		NSString* bundle_identifier = [[NSBundle mainBundle] bundleIdentifier];
 		if(bundle_identifier.length == 0) {
 			return utils::nullopt;
 		}
 
+		if([[NSFileManager defaultManager] ubiquityIdentityToken] == nil) {
+			return utils::nullopt;
+		}
+
 		NSString* container_identifier = [@"iCloud." stringByAppendingString:bundle_identifier];
+		NSURL* container_url =
+			[[NSFileManager defaultManager] URLForUbiquityContainerIdentifier:container_identifier];
+		if(container_url == nil) {
+			return utils::nullopt;
+		}
 
-		dispatch_sync(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-			@autoreleasepool {
-				NSURL* container_url =
-					[[NSFileManager defaultManager] URLForUbiquityContainerIdentifier:container_identifier];
-				if(container_url != nil) {
-					NSURL* documents_url = [container_url URLByAppendingPathComponent:@"Documents" isDirectory:YES];
-					documents_path = [documents_url path];
-				}
-			}
-		});
-
+		NSString* documents_path = [[container_url URLByAppendingPathComponent:@"Documents" isDirectory:YES] path];
 		if(documents_path.length == 0) {
 			return utils::nullopt;
 		}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -680,9 +680,13 @@ const std::string& get_version_path_suffix()
 	}
 #endif
 
+static constexpr char legacy_ios_userdata_dir_name[] = ".wesnoth1.13";
+
 std::string filesystem::detail::legacy_ios_saves_dir(const std::string& sdl_pref_path)
 {
-	return (bfs::path(sdl_pref_path) / ".wesnoth1.13" / "saves").string();
+	// Historical iWesnoth builds stored saves under <SDL prefs>/.wesnoth1.13/saves.
+	// Keep that literal suffix so we can find and migrate those legacy saves.
+	return (bfs::path(sdl_pref_path) / legacy_ios_userdata_dir_name / "saves").string();
 }
 
 std::vector<filesystem::detail::ios_legacy_save_migration> filesystem::detail::find_legacy_ios_save_migrations(
@@ -725,6 +729,9 @@ std::vector<filesystem::detail::ios_legacy_save_migration> filesystem::detail::f
 #if defined(WESNOTH_BOOST_OS_IOS)
 static std::string get_default_ios_user_data_dir()
 {
+	// Prefer the app's ubiquity Documents container when it is available.
+	// That path remains locally accessible offline; if iCloud Drive is unavailable,
+	// fall back to the local SDL preferences directory.
 	if(const auto icloud_documents_dir = desktop::apple::get_icloud_drive_documents_dir()) {
 		LOG_FS << "Using iCloud Drive userdata directory: " << *icloud_documents_dir;
 		return *icloud_documents_dir;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -22,6 +22,7 @@
 #include "filesystem.hpp"
 
 #include "config.hpp"
+#include "desktop/apple_icloud.hpp"
 #include "game_config_view.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
@@ -679,6 +680,168 @@ const std::string& get_version_path_suffix()
 	}
 #endif
 
+std::string filesystem::detail::legacy_ios_saves_dir(const std::string& sdl_pref_path)
+{
+	return (bfs::path(sdl_pref_path) / ".wesnoth1.13" / "saves").string();
+}
+
+std::vector<filesystem::detail::ios_legacy_save_migration> filesystem::detail::find_legacy_ios_save_migrations(
+	const std::string& sdl_pref_path,
+	const std::string& current_saves_dir)
+{
+	std::vector<ios_legacy_save_migration> migrations;
+	if(sdl_pref_path.empty() || current_saves_dir.empty()) {
+		return migrations;
+	}
+
+	const bfs::path legacy_saves_dir = legacy_ios_saves_dir(sdl_pref_path);
+	if(!bfs::is_directory(legacy_saves_dir)) {
+		return migrations;
+	}
+
+	error_code ec;
+	bfs::directory_iterator end;
+	for(bfs::directory_iterator it(legacy_saves_dir, ec); it != end; it.increment(ec)) {
+		if(ec) {
+			ERR_FS << "Unable to enumerate legacy iOS saves at " << legacy_saves_dir.string() << ": " << ec.message();
+			return {};
+		}
+
+		if(!bfs::is_regular_file(it->path())) {
+			continue;
+		}
+
+		const bfs::path target = bfs::path(current_saves_dir) / it->path().filename();
+		if(bfs::exists(target)) {
+			continue;
+		}
+
+		migrations.push_back({it->path().string(), target.string()});
+	}
+
+	return migrations;
+}
+
+#if defined(WESNOTH_BOOST_OS_IOS)
+static std::string get_default_ios_user_data_dir()
+{
+	if(const auto icloud_documents_dir = desktop::apple::get_icloud_drive_documents_dir()) {
+		LOG_FS << "Using iCloud Drive userdata directory: " << *icloud_documents_dir;
+		return *icloud_documents_dir;
+	}
+
+	char* sdl_pref_path = SDL_GetPrefPath("wesnoth.org", "iWesnoth");
+	if(sdl_pref_path) {
+		std::string fallback_path = sdl_pref_path;
+		SDL_free(sdl_pref_path);
+		WRN_FS << "iCloud Drive userdata directory unavailable; falling back to local SDL prefs at " << fallback_path;
+		return fallback_path;
+	}
+
+	WRN_FS << "iCloud Drive userdata directory unavailable and SDL_GetPrefPath failed; falling back to ~/.wesnoth" << get_version_path_suffix();
+	return "~/.wesnoth" + get_version_path_suffix();
+}
+
+static void migrate_legacy_ios_saves()
+{
+	char* sdl_pref_path = SDL_GetPrefPath("wesnoth.org", "iWesnoth");
+	if(!sdl_pref_path) {
+		return;
+	}
+
+	const std::string pref_path = sdl_pref_path;
+	SDL_free(sdl_pref_path);
+
+	const bfs::path legacy_saves_dir = filesystem::detail::legacy_ios_saves_dir(pref_path);
+	const auto migrations = filesystem::detail::find_legacy_ios_save_migrations(pref_path, get_saves_dir());
+	if(migrations.empty()) {
+		return;
+	}
+
+	bool migrated_any = false;
+	error_code ec;
+	for(const auto& migration : migrations) {
+		bfs::copy_file(migration.source, migration.target, bfs::copy_option::none, ec);
+		if(ec) {
+			ERR_FS << "Unable to copy legacy iOS save " << migration.source << " to " << migration.target << ": " << ec.message();
+			ec.clear();
+			continue;
+		}
+
+		bfs::remove(migration.source, ec);
+		if(ec) {
+			WRN_FS << "Copied legacy iOS save but could not remove source " << migration.source << ": " << ec.message();
+			ec.clear();
+		}
+
+		migrated_any = true;
+	}
+
+	if(migrated_any) {
+		LOG_FS << "Migrated legacy iOS saves from " << legacy_saves_dir.string() << " to " << get_saves_dir();
+	}
+
+	if(bfs::is_directory(legacy_saves_dir) && bfs::is_empty(legacy_saves_dir, ec)) {
+		bfs::remove(legacy_saves_dir, ec);
+		if(ec) {
+			WRN_FS << "Unable to remove empty legacy iOS save directory " << legacy_saves_dir.string() << ": " << ec.message();
+		}
+	}
+}
+
+static void migrate_ios_save_directory_layout()
+{
+	const bfs::path saves_dir = bfs::path(get_saves_dir());
+	const bfs::path sync_saves_dir = bfs::path(get_sync_dir()) / "saves";
+
+	if(saves_dir == sync_saves_dir || !bfs::is_directory(sync_saves_dir)) {
+		return;
+	}
+
+	bool migrated_any = false;
+	error_code ec;
+	bfs::directory_iterator end;
+	bfs::directory_iterator it(sync_saves_dir, ec);
+	if(ec) {
+		ERR_FS << "Unable to inspect legacy iOS save directory at " << sync_saves_dir.string() << ": " << ec.message();
+		return;
+	}
+
+	for(; it != end; it.increment(ec)) {
+		if(ec) {
+			ERR_FS << "Unable to enumerate legacy iOS save directory at " << sync_saves_dir.string() << ": " << ec.message();
+			return;
+		}
+
+		const bfs::path source = it->path();
+		const bfs::path target = saves_dir / source.filename();
+		if(bfs::exists(target)) {
+			continue;
+		}
+
+		bfs::rename(source, target, ec);
+		if(ec) {
+			ERR_FS << "Unable to migrate iOS save " << source.string() << " to " << target.string() << ": " << ec.message();
+			ec.clear();
+			continue;
+		}
+
+		migrated_any = true;
+	}
+
+	if(migrated_any) {
+		LOG_FS << "Migrated iOS saves from " << sync_saves_dir.string() << " to " << saves_dir.string();
+	}
+
+	if(bfs::is_empty(sync_saves_dir, ec)) {
+		bfs::remove(sync_saves_dir, ec);
+		if(ec) {
+			WRN_FS << "Unable to remove empty legacy iOS save directory " << sync_saves_dir.string() << ": " << ec.message();
+		}
+	}
+}
+#endif
+
 
 static void setup_user_data_dir()
 {
@@ -706,6 +869,11 @@ static void setup_user_data_dir()
 	create_directory_if_missing(get_saves_dir());
 	create_directory_if_missing(get_wml_persist_dir());
 	create_directory_if_missing(get_logs_dir());
+
+#if defined(WESNOTH_BOOST_OS_IOS)
+	migrate_legacy_ios_saves();
+	migrate_ios_save_directory_layout();
+#endif
 
 	if(file_exists(get_unsynced_prefs_file()) && !file_exists(get_synced_prefs_file())) {
 		copy_file(get_unsynced_prefs_file(), get_synced_prefs_file());
@@ -751,16 +919,10 @@ void set_user_data_dir(std::string newprefdir)
 	if(newprefdir.empty()) {
 #ifdef _WIN32
 		newprefdir = "~/Wesnoth" + get_version_path_suffix();
+#elif defined(WESNOTH_BOOST_OS_IOS)
+		newprefdir = get_default_ios_user_data_dir();
 #elif defined(__APPLE__)
 		newprefdir = "~/Library/Application Support/Wesnoth_"+get_version_path_suffix();
-#elif defined(WESNOTH_BOOST_OS_IOS)
-		char* sdl_pref_path = SDL_GetPrefPath("wesnoth.org", "iWesnoth");
-		if(sdl_pref_path) {
-			newprefdir = std::string(sdl_pref_path);
-			SDL_free(sdl_pref_path);
-		} else {
-			newprefdir = "~/.wesnoth" + get_version_path_suffix();
-		}
 #elif defined(__ANDROID__)
 		newprefdir = SDL_AndroidGetExternalStoragePath();
 #else

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -761,7 +761,7 @@ static void migrate_legacy_ios_saves()
 	bool migrated_any = false;
 	error_code ec;
 	for(const auto& migration : migrations) {
-		bfs::copy_file(migration.source, migration.target, bfs::copy_option::none, ec);
+		bfs::copy_file(migration.source, migration.target, bfs::copy_options::none, ec);
 		if(ec) {
 			ERR_FS << "Unable to copy legacy iOS save " << migration.source << " to " << migration.target << ": " << ec.message();
 			ec.clear();

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -221,6 +221,22 @@ std::string get_exe_path();
 std::string get_exe_dir();
 std::string get_wesnothd_name();
 
+namespace detail
+{
+
+struct ios_legacy_save_migration
+{
+	std::string source;
+	std::string target;
+};
+
+std::string legacy_ios_saves_dir(const std::string& sdl_pref_path);
+std::vector<ios_legacy_save_migration> find_legacy_ios_save_migrations(
+	const std::string& sdl_pref_path,
+	const std::string& current_saves_dir);
+
+} // namespace detail
+
 bool make_directory(const std::string& dirname);
 bool delete_directory(const std::string& dirname, const bool keep_pbl = false);
 bool delete_file(const std::string& filename);

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -24,6 +24,10 @@
 
 #include <boost/algorithm/string.hpp>
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 static lg::log_domain log_filesystem("filesystem");
 #define LOG_FS LOG_STREAM(info, log_filesystem)
 #define ERR_FS LOG_STREAM(err, log_filesystem)
@@ -192,7 +196,12 @@ std::string get_sync_dir()
 
 std::string get_saves_dir()
 {
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	// Preserve the historical iOS save layout so existing iCloud Drive saves remain visible.
+	const std::string dir_path = get_user_data_dir() + "/saves";
+#else
 	const std::string dir_path = get_sync_dir() + "/saves";
+#endif
 	return get_dir(dir_path);
 }
 

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -21,6 +21,8 @@
 #include "log.hpp"
 #include "utils/optional_reference.hpp"
 
+#include <boost/filesystem.hpp>
+
 #if 0
 namespace {
 
@@ -305,6 +307,41 @@ BOOST_AUTO_TEST_CASE( test_blacklist_pattern_list )
 	blacklist_pattern_list none({}, {});
 	BOOST_CHECK(!none.match_file("something.exe"));
 	BOOST_CHECK(!none.match_dir("temp"));
+}
+
+BOOST_AUTO_TEST_CASE( test_ios_legacy_saves_dir_helper )
+{
+	const boost::filesystem::path sdl_pref_path("/tmp/wesnoth-ios");
+	const boost::filesystem::path expected = sdl_pref_path / ".wesnoth1.13" / "saves";
+	BOOST_CHECK_EQUAL(filesystem::detail::legacy_ios_saves_dir(sdl_pref_path.string()), expected.string());
+}
+
+BOOST_AUTO_TEST_CASE( test_ios_legacy_save_migration_plan )
+{
+	namespace bfs = boost::filesystem;
+
+	const bfs::path temp_root = bfs::temp_directory_path() / bfs::unique_path("wesnoth-ios-%%%%-%%%%");
+	const bfs::path sdl_pref_path = temp_root / "prefs";
+	const bfs::path legacy_saves_dir(filesystem::detail::legacy_ios_saves_dir(sdl_pref_path.string()));
+	const bfs::path current_saves_dir = temp_root / "userdata" / "saves";
+
+	bfs::create_directories(legacy_saves_dir);
+	bfs::create_directories(current_saves_dir);
+
+	write_file((legacy_saves_dir / "carryover.gz").string(), "save-a");
+	write_file((legacy_saves_dir / "existing.gz").string(), "save-b");
+	write_file((current_saves_dir / "existing.gz").string(), "save-c");
+	bfs::create_directories(legacy_saves_dir / "subdir");
+
+	const auto migrations = filesystem::detail::find_legacy_ios_save_migrations(
+		sdl_pref_path.string(),
+		current_saves_dir.string());
+
+	BOOST_REQUIRE_EQUAL(migrations.size(), 1u);
+	BOOST_CHECK_EQUAL(bfs::path(migrations.front().source), legacy_saves_dir / "carryover.gz");
+	BOOST_CHECK_EQUAL(bfs::path(migrations.front().target), current_saves_dir / "carryover.gz");
+
+	bfs::remove_all(temp_root);
 }
 
 

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -312,6 +312,7 @@ BOOST_AUTO_TEST_CASE( test_blacklist_pattern_list )
 BOOST_AUTO_TEST_CASE( test_ios_legacy_saves_dir_helper )
 {
 	const boost::filesystem::path sdl_pref_path("/tmp/wesnoth-ios");
+	// The migration target is the historical iWesnoth saves layout.
 	const boost::filesystem::path expected = sdl_pref_path / ".wesnoth1.13" / "saves";
 	BOOST_CHECK_EQUAL(filesystem::detail::legacy_ios_saves_dir(sdl_pref_path.string()), expected.string());
 }

--- a/src/tls_root_store.cpp
+++ b/src/tls_root_store.cpp
@@ -106,21 +106,15 @@ void load_tls_root_certs(boost::asio::ssl::context &ctx)
 	SSL_CTX_set_cert_store(ctx.native_handle(), store);
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
 	// iOS does not expose system trust anchors to third-party apps, so use
-	// the bundled CA bundle under the game data path.
+	// the packaged CA bundle from the app's certificates directory.
+	// The Xcode target copies cacert.pem into <app bundle>/certificates/.
 	const std::string cert_bundle = game_config::path + "/certificates/cacert.pem";
-	const std::string data_cert_bundle = game_config::path + "/data/certificates/cacert.pem";
 	boost::system::error_code ec;
 	ctx.load_verify_file(cert_bundle, ec);
 	if(ec) {
-		WRN_NW << "Failed to load bundled CA bundle '" << cert_bundle << "': " << ec.message();
-		ctx.load_verify_file(data_cert_bundle, ec);
-		if(ec) {
-			WRN_NW << "Failed to load bundled CA bundle '" << data_cert_bundle << "': " << ec.message()
-			       << "; falling back to default verify paths.";
-			ctx.set_default_verify_paths();
-		} else {
-			LOG_NW << "Loaded bundled CA bundle '" << data_cert_bundle << "'";
-		}
+		WRN_NW << "Failed to load bundled CA bundle '" << cert_bundle << "': " << ec.message()
+		       << "; falling back to default verify paths.";
+		ctx.set_default_verify_paths();
 	} else {
 		LOG_NW << "Loaded bundled CA bundle '" << cert_bundle << "'";
 	}

--- a/src/tls_root_store.cpp
+++ b/src/tls_root_store.cpp
@@ -104,7 +104,9 @@ void load_tls_root_certs(boost::asio::ssl::context &ctx)
 
 	CFRelease(certs);
 	SSL_CTX_set_cert_store(ctx.native_handle(), store);
-#elif (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(__ANDROID__)
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+	ctx.load_verify_file(game_config::path + "/data/certificates/cacert.pem");
+#elif defined(__ANDROID__)
 	ctx.load_verify_file(game_config::path + "/certificates/cacert.pem");
 #else
 	ctx.set_default_verify_paths();

--- a/src/tls_root_store.cpp
+++ b/src/tls_root_store.cpp
@@ -105,7 +105,25 @@ void load_tls_root_certs(boost::asio::ssl::context &ctx)
 	CFRelease(certs);
 	SSL_CTX_set_cert_store(ctx.native_handle(), store);
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
-	ctx.load_verify_file(game_config::path + "/data/certificates/cacert.pem");
+	// iOS does not expose system trust anchors to third-party apps, so use
+	// the bundled CA bundle under the game data path.
+	const std::string cert_bundle = game_config::path + "/certificates/cacert.pem";
+	const std::string data_cert_bundle = game_config::path + "/data/certificates/cacert.pem";
+	boost::system::error_code ec;
+	ctx.load_verify_file(cert_bundle, ec);
+	if(ec) {
+		WRN_NW << "Failed to load bundled CA bundle '" << cert_bundle << "': " << ec.message();
+		ctx.load_verify_file(data_cert_bundle, ec);
+		if(ec) {
+			WRN_NW << "Failed to load bundled CA bundle '" << data_cert_bundle << "': " << ec.message()
+			       << "; falling back to default verify paths.";
+			ctx.set_default_verify_paths();
+		} else {
+			LOG_NW << "Loaded bundled CA bundle '" << data_cert_bundle << "'";
+		}
+	} else {
+		LOG_NW << "Loaded bundled CA bundle '" << cert_bundle << "'";
+	}
 #elif defined(__ANDROID__)
 	ctx.load_verify_file(game_config::path + "/certificates/cacert.pem");
 #else


### PR DESCRIPTION
Part 6 of 6.

This PR is intentionally narrow and finishes the iOS filesystem pass. It restores iCloud Drive as the preferred iOS save root, preserves the historical iOS saves layout, and keeps the small iOS-specific filesystem follow-ups needed to make that path behave cleanly. It does not attempt broader UI work, multiplayer changes, or a larger refactor of cross-platform filesystem behavior. Reviews should focus on iOS userdata root selection, legacy save migration, iCloud container handling, and the small CA-bundle fallback tied to the iOS data path.

Included in this PR:
- restore iCloud Drive as the preferred iOS userdata root
- preserve the historical iOS saves layout and migrate legacy saves out of the old SDL preferences path
- resolve iCloud ubiquity state on the main thread
- update the legacy migration helper to the current Boost `copy_file` API
- try the bundled data certificate path as an iOS fallback
- add filesystem coverage for the legacy-save planning helper

To verify changes locally:
- build, install, and launch the app on an iOS simulator or device
- verify saves prefer the iCloud Drive container when it is available
- verify legacy saves under the old SDL preferences location are migrated into the iOS save root
- verify the app falls back to the local prefs path when iCloud is unavailable
- verify the simulator build still compiles with the current Boost dependency set
- verify the add-ons TLS path still succeeds when the certificate bundle is resolved from the app data path