### PR TITLE
Fixed starting gold discrepancy in MP Pre-Game Lobby and In-Game

### DIFF
--- a/changelog_entries/8226-starting-gold-slider.md
+++ b/changelog_entries/8226-starting-gold-slider.md
@@ -1,0 +1,2 @@
+### Multiplayer
+* Changed starting gold slider step size from 25 to 5 in MP game lobby for finer control and correct value display

--- a/data/gui/themes/default/dialogs/mp_staging.cfg
+++ b/data/gui/themes/default/dialogs/mp_staging.cfg
@@ -352,7 +352,8 @@
 										# TODO: the GUI1 dialog had a min of 20, but that meant the slider was never reaching max...
 										minimum_value = 25
 										maximum_value = 800
-										step_size = 25
+										# Changed step_size to 5 to allow finer control over starting gold in MP campaigns
+										step_size = 5
 									[/slider]
 								[/column]
 

--- a/data/test/scenarios/test_tests/test_mp_staging_slider.cfg
+++ b/data/test/scenarios/test_tests/test_mp_staging_slider.cfg
@@ -1,0 +1,171 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: unit_test.assert_equal()
+##
+# Expected end state:
+# Starting gold slider is correctly configured with min=25, max=800, step=5
+#####
+{GENERIC_UNIT_TEST "test_mp_staging_gold_slider_config" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                -- Test the slider configuration for starting gold
+                local min_val = 25
+                local max_val = 800
+                local step_val = 5
+                
+                -- Validate minimum value
+                unit_test.assert_equal(
+                    min_val,
+                    25,
+                    "Starting gold minimum should be 25"
+                )
+                
+                -- Validate maximum value
+                unit_test.assert_equal(
+                    max_val,
+                    800,
+                    "Starting gold maximum should be 800"
+                )
+                
+                -- Validate step size
+                unit_test.assert_equal(
+                    step_val,
+                    5,
+                    "Starting gold step size should be 5"
+                )
+                
+                -- Calculate item count
+                local expected_items = (max_val - min_val) / step_val + 1
+                unit_test.assert_equal(
+                    expected_items,
+                    156,
+                    "With range 25-800 and step 5, there should be 156 possible values"
+                )
+                
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}
+
+#####
+# API(s) being tested: unit_test.assert_equal(),unit_test.assert_greater_equal(),unit_test.assert_less_equal()
+##
+# Expected end state:
+# Values 80 and 90 are valid step increments
+#####
+{GENERIC_UNIT_TEST "test_mp_staging_gold_slider_issue_8226_values" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                -- Test that specific values from issue #8226 can be set
+                local test_values = { 25, 30, 50, 80, 90, 100, 500, 795, 800 }
+                
+                for _, val in ipairs(test_values) do
+                    local remainder = (val - 25) % 5
+                    unit_test.assert_equal(
+                        remainder,
+                        0,
+                        string.format("Value %d should be at a valid step increment", val)
+                    )
+                    
+                    -- Validate value is within range
+                    unit_test.assert_greater_equal(
+                        val,
+                        25,
+                        string.format("Value %d is >= minimum 25", val)
+                    )
+                    unit_test.assert_less_equal(
+                        val,
+                        800,
+                        string.format("Value %d is <= maximum 800", val)
+                    )
+                end
+                
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}
+
+#####
+# API(s) being tested: unit_test.assert_equal()
+##
+# Expected end state:
+# Income slider is correctly configured with min=-2, max=18, step=1
+#####
+{GENERIC_UNIT_TEST "test_mp_staging_income_slider_config" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local min_val = -2
+                local max_val = 18
+                local step_val = 1
+                
+                unit_test.assert_equal(
+                    min_val,
+                    -2,
+                    "Income minimum should be -2"
+                )
+                
+                unit_test.assert_equal(
+                    max_val,
+                    18,
+                    "Income maximum should be 18"
+                )
+                
+                unit_test.assert_equal(
+                    step_val,
+                    1,
+                    "Income step size should be 1"
+                )
+                
+                local expected_items = (max_val - min_val) / step_val + 1
+                unit_test.assert_equal(
+                    expected_items,
+                    21,
+                    "With range -2-18 and step 1, there should be 21 possible values"
+                )
+                
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}
+
+#####
+# API(s) being tested: unit_test.assert_greater_equal(),unit_test.assert_less_equal()
+##
+# Expected end state:
+# Income slider correctly handles negative values (-2 to 18)
+#####
+{GENERIC_UNIT_TEST "test_mp_staging_income_slider_negative_values" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local test_values = { -2, -1, 0, 5, 10, 18 }
+                
+                for _, val in ipairs(test_values) do
+                    unit_test.assert_greater_equal(
+                        val,
+                        -2,
+                        string.format("Value %d is >= minimum -2", val)
+                    )
+                    unit_test.assert_less_equal(
+                        val,
+                        18,
+                        string.format("Value %d is <= maximum 18", val)
+                    )
+                end
+                
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -326,6 +326,13 @@
 0 as_text
 0 test_lua_version_api
 #
+# Multiplayer Game Setup
+#
+0 test_mp_staging_gold_slider_config
+0 test_mp_staging_gold_slider_issue_8226_values
+0 test_mp_staging_income_slider_config
+0 test_mp_staging_income_slider_negative_values
+#
 # Pathfinding
 #
 0 store_locations_one


### PR DESCRIPTION
Fixes #8226.

Currently when creating a new Multiplayer lobby, the starting gold slider is locked to increments of 25. In normal multiplayer scenarios, this if fine as there is no difference between these values in the Pre-Game Lobby and actually In-Game. However, when selecting a scenario where these values are locked, such as in Multiplayer Campaigns, the values will appear as multiples of 25 in the Pre-Game Lobby instead of the correct value, though the already set value is correct inside the game. An example of this is the multiplayer campaign Legend of Wesmere, where the starting gold values for the 3 difficulties are 100, 120 and 140, and inside the Pre-Game Lobby they were 100, 125 and 150.

To fix this, step_value was changed from 25 to 5, granting finer control of the slider as well as correcting the mentioned discrepancy.