### PR TITLE
wmlparser3: add workaround to preprocessor bug

### DIFF
--- a/data/tools/wesnoth/wmlparser3.py
+++ b/data/tools/wesnoth/wmlparser3.py
@@ -523,6 +523,10 @@ class Parser:
             # No tag, must be an attribute.
             else:
                 self.handle_attribute(line)
+        elif self.attribute_state_without_equals:
+            if not line == b"=":
+                raise WMLError(self, "Expected =, got " + line)
+            self.attribute_state_without_equals = False 
         else:
             for i, segment in enumerate(line.split(b"+")):
                 segment = segment.lstrip(b" \t")
@@ -567,6 +571,11 @@ class Parser:
         if assign >= 0:
             remainder = line[assign + 1:]
             line = line[:assign]
+            self.attribute_state_without_equals = False
+        else:
+            # workaround for c++ bug, = comes in next line instead of current
+            self.attribute_state_without_equals = True
+            # after fix, should raise WMLError(self, "Expected equals sign (=) after attribute.")
 
         self.commas = 0
         self.temp_key_nodes = []
@@ -584,6 +593,9 @@ class Parser:
         def add_text(segment):
             segment = segment.rstrip()
             if not segment: return
+            # workaround for c++ bug, attribute and equals are preprocessed to different lines
+            if self.attribute_state_without_equals and segment.starts_with("="):
+                segment = segment[1:]
             n = len(self.temp_key_nodes)
             maxsplit = n - self.commas - 1
             if maxsplit < 0: maxsplit = 0


### PR DESCRIPTION
@soliton- discovered that `{QUANTITY blade 70 50 30}` expands to
```
þline 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
þline 8 core/macros/utils.cfg 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
    

    þline 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
þtextdomain wesnoth
bladeþline 10 core/macros/utils.cfg 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
þtextdomain wesnoth
=þline 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
þtextdomain wesnoth
70þline 10 core/macros/utils.cfg 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
þtextdomain wesnoth

þline 1 C:\Users\Ravana\AppData\Local\Temp\wmlparser_kqh8ylkw.cfg
```
where blade and = are on separate lines. wmlparser3 is not prepared for that.

According to WML rules = is not allowed to be on separate line from attribute name.
```
wml_attribute = [textdomain] , wml_key_sequence , '=' , wml_value , ?newline? ;
wml_key_sequence = wml_name , {',' , wml_name} ;
wml_name = wml_id_char , {wml_id_char} ;
wml_id_char = ?letter? | ?digit? | '_' ;
```

This is not intended to be merged without further discussion. Ideally c++ bug is also fixed, and then https://github.com/ProditorMagnus/Ageless-for-1-14/commit/764fcdb3f46984f8f49b149364c007103ddb0c8d#diff-070d9748c4a1affce6c74dc8292df3863236634cd49f9e80235f2a96288c611cR570 can be applied instead.