### PR TITLE
Fix wrappers for LUA headers to be C++ compliant

### DIFF
--- a/src/lua/wrapper_lauxlib.h
+++ b/src/lua/wrapper_lauxlib.h
@@ -8,10 +8,18 @@
     #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(HAVE_SYSTEM_LUA)
     #include "lauxlib.h"
 #else
     #include "modules/lua/lauxlib.h"
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 constexpr int luaL_buffersize = LUAL_BUFFERSIZE;

--- a/src/lua/wrapper_lua.h
+++ b/src/lua/wrapper_lua.h
@@ -6,10 +6,18 @@
     #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(HAVE_SYSTEM_LUA)
     #include "lua.h"
 #else
     #include "modules/lua/lua.h"
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #if defined(__clang__)

--- a/src/lua/wrapper_lualib.h
+++ b/src/lua/wrapper_lualib.h
@@ -6,10 +6,18 @@
     #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(HAVE_SYSTEM_LUA)
     #include "lualib.h"
 #else
     #include "modules/lua/lualib.h"
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #if defined(__clang__)


### PR DESCRIPTION
I tried to build wesnoth for MinGW and CYGWIN.
When linking the final executables, I got thousand of errors because it could not find all functions provided by LUA library.
I have seen that the headers of libLUA are made for C sources.
If you want to use them with C++, then you need to use `extern "C" {` keyword.

Attached patch fixes the issue.