### PR TITLE
Fix build for CYGWIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,10 @@ set(BINARY_PREFIX "" CACHE STRING "Prefix in front of all binaries")
 ### Set the environment compiler flags.
 
 if(NOT MSVC)
+	if(CYGWIN)
+		add_compile_definitions(_GNU_SOURCE)
+	endif()
+
 	if(NOT DEFINED CXX_FLAGS_USER)
 
 		MESSAGE(STATUS "Environment compiler flags set to »${CXX_FLAGS_USER}«")
@@ -311,7 +315,7 @@ if(NOT MSVC)
 
 		if(APPLE)
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -Wl,-pie")
-		elseif(WIN32 AND MINGW)
+		elseif((WIN32 AND MINGW) OR CYGWIN)
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie")
 		else()
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie -Wl,-z,relro,-z,now")


### PR DESCRIPTION
I would like to suggest these tiny fixes for building the engine with CYGWIN.
These changes can be resumed as:

1) Some functions require to be "activated", otherwise they won't be visibile at compile time. Unlike linux and others, CYGWIN doesn't define `_GNU_SOURCE` or `_BSD_SOURCE` automatically, just for making the life easier if you may want to include also some W32API headers. So, I added the `_GNU_SOURCE`, just for CYGWIN.

2) The linker option `-z` is not supported by CYGWIN, exactly like MinGW.
There is already a test to avoid the addition of `-z` to MinGW, so I also added CYGWIN in that place.