### PR TITLE
fix missing languages due to 32-bit mask used on >60-element list

### DIFF
--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -76,7 +76,9 @@ void language_selection::shown_filter_callback()
 	listbox& list = find_widget<listbox>("language_list");
 
 	if(show_all_toggle.get_value_bool()) {
-		list.set_row_shown(boost::dynamic_bitset<>{langs_.size(), ~0UL});
+		boost::dynamic_bitset<> mask;
+		mask.resize(langs_.size(), true);
+		list.set_row_shown(mask);
 	} else {
 		list.set_row_shown(complete_langs_);
 	}


### PR DESCRIPTION
The `boost::dynamic_bitset` constructor previously called did not populate the bitset entirely with 1s, instead only populating the first 32 bits (`unsigned long` seems only 32-bit in the Windows build).  The submitted approach bypasses that constructor overload in favour of `boost::dynamic_bitset::resize`.  This fixes the issue (in at least the x64 Debug build) on my Windows 10 machine.

This request is to address: wesnoth/wesnoth#11112