### PR TITLE
10764 fix zoomed out load crash

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -774,8 +774,12 @@ surface get_lighted_image(const image::locator& i_locator, const std::vector<lig
 	// not cached yet, generate it
 	surface res = apply_light(get_surface(i_locator, HEXED).clone(), ls);
 
+	// lvar may no longer be valid as apply_light can reenter this function
+	// and mutate lit_surfaces_; get a new reference before updating
+	lit_surface_variants& reacquired_lvar = lit_surfaces_.access_in_cache(i_locator);
+
 	// record the lighted surface in the corresponding variants cache
-	lvar[ls] = res;
+	reacquired_lvar[ls] = res;
 	return res;
 }
 


### PR DESCRIPTION
`get_lighted_image` gets a cache reference (`lvar`), then returns the requested surface.  If the surface is not already held, it is generated before return.  In certain cases (such as that observed under wesnoth/wesnoth#10764), this generation seems to invalidate the locally-held cache reference, leading to an access violation crash when it is used to update the cache.

The submitted change forces reacquisition of the cache reference after generation and before cache update.  With these changes, I can no longer reproduce the crash detailed under wesnoth/wesnoth#10764 on my Windows 10 machine (in at least x64 Debug).