### PR TITLE
Add mctom's undead_siege to core

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 ### Campaigns
 ### Editor
 ### Multiplayer
+   * Added new "Undead Siege" song by Tomek Szczęsny.
 ### Lua API
 ### Packaging
 ### Terrain

--- a/copyrights.csv
+++ b/copyrights.csv
@@ -95,7 +95,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2025/09/12,data/core/music/three-sheets.ogg,CC BY-SA 4.0,Scott Buckley,,,837abbfb54372ad89b0c246d6cba21c8
 2013/12/08,data/core/music/transience.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,8a6a9633dc4ef7189fcde14e73e08d32
 2013/12/08,data/core/music/traveling_minstrels.ogg,GNU GPL v2+,Mattias Westlund(West),,,f178fe0f414a44ae45ed5f2488f66a55
-2026/05/01,data/core/music/undead_siege.ogg,CC BY-SA 4.0,Tomek Szczęsny(mctom),,,91d193836c296dfc933431b54c951d1c
+2026/05/01,data/core/music/undead_siege.ogg,CC BY-SA 4.0,Tomek Szczęsny(mctom),,,2c4f3eb89c84bf86be59ee52036aa7ef
 2013/12/08,data/core/music/underground.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,2fc3df12c3314ea77754d66ba9c16e74
 2013/12/08,data/core/music/vengeful.ogg,GNU GPL v2+,Jeremy Nicoll(jeremy2/eltiare),,,1b66479bd170d252de79ef84fce9f869
 2010/05/11,data/core/music/victory.ogg,GNU GPL v2+,Timothy Pinkham(TimothyP),,,c6d1aaa37812c87fa6c2821adeb88f0f

--- a/copyrights.csv
+++ b/copyrights.csv
@@ -95,6 +95,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2025/09/12,data/core/music/three-sheets.ogg,CC BY-SA 4.0,Scott Buckley,,,837abbfb54372ad89b0c246d6cba21c8
 2013/12/08,data/core/music/transience.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,8a6a9633dc4ef7189fcde14e73e08d32
 2013/12/08,data/core/music/traveling_minstrels.ogg,GNU GPL v2+,Mattias Westlund(West),,,f178fe0f414a44ae45ed5f2488f66a55
+2026/05/01,data/core/music/undead_siege.ogg,CC BY-SA 4.0,Tomek Szczęsny(mctom),,,91d193836c296dfc933431b54c951d1c
 2013/12/08,data/core/music/underground.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,2fc3df12c3314ea77754d66ba9c16e74
 2013/12/08,data/core/music/vengeful.ogg,GNU GPL v2+,Jeremy Nicoll(jeremy2/eltiare),,,1b66479bd170d252de79ef84fce9f869
 2010/05/11,data/core/music/victory.ogg,GNU GPL v2+,Timothy Pinkham(TimothyP),,,c6d1aaa37812c87fa6c2821adeb88f0f

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg
@@ -841,9 +841,7 @@
         [/delay]
         {MOVE_UNIT id=Angarthing 38 22}
 
-        [delay]
-            time=2000
-        [/delay]
+        {FADE_MUSIC_OUT 2000}
 
         [sound]
             name=rumble.ogg
@@ -910,6 +908,9 @@
         {LIMIT_RECRUITS 2 Draug   ({ON_DIFFICULTY4 0 1 1 1})}
         {LIMIT_RECRUITS 2 Banebow ({ON_DIFFICULTY4 0 0 1 1})}
 #endif
+
+        {REPLACE_SCENARIO_MUSIC undead_siege.ogg}
+        {FADE_MUSIC_IN 0}
 
         [objectives]
             [objective]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/02_The_Fall.cfg
@@ -8,6 +8,7 @@
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC the_dangerous_symphony.ogg}
+    {EXTRA_SCENARIO_MUSIC undead_siege.ogg}
     {EXTRA_SCENARIO_MUSIC battle.ogg}
 
     [story]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
@@ -9,8 +9,8 @@
     turns=32
     {DEFAULT_SCHEDULE}
 
-    {SCENARIO_MUSIC knolls.ogg}
-    {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
+    {SCENARIO_MUSIC the_city_falls.ogg}
+    {EXTRA_SCENARIO_MUSIC undead_siege.ogg}
     {EXTRA_SCENARIO_MUSIC battle.ogg}
 
     # No story part

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
@@ -9,7 +9,7 @@
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC elvish-theme.ogg}
-    {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
+    {EXTRA_SCENARIO_MUSIC undead_siege.ogg}
     {EXTRA_SCENARIO_MUSIC battle.ogg}
 
     # No story part

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -9,8 +9,10 @@
     turns=unlimited
     {DEFAULT_SCHEDULE}
 
-    {SCENARIO_MUSIC knalgan_theme.ogg}
+    {SCENARIO_MUSIC undead_siege.ogg}
+    {EXTRA_SCENARIO_MUSIC knalgan_theme.ogg}
     {EXTRA_SCENARIO_MUSIC vengeful.ogg}
+    {EXTRA_SCENARIO_MUSIC undead_siege.ogg} # repeated twice, since this is a rare track
     {EXTRA_SCENARIO_MUSIC battle.ogg}
     {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
 

--- a/data/core/macros/sound-utils.cfg
+++ b/data/core/macros/sound-utils.cfg
@@ -141,6 +141,11 @@
         ms_before=12000
         append=yes
     [/music]
+    [music]
+        name=undead_siege.ogg
+        ms_before=12000
+        append=yes
+    [/music]
 #enddef
 
 #define DEFAULT_MUSIC_PLAYLIST
@@ -329,6 +334,11 @@
     [music]
         name=underground.ogg
         title= _ "Underground"
+        ms_before=12000
+        append=yes
+    [/music]
+    [music]
+        name=undead_siege.ogg
         ms_before=12000
         append=yes
     [/music]


### PR DESCRIPTION
Related: https://github.com/wesnoth/resources/pull/8

This PR adds Tomek Szczęsny (mctom)'s new "Undead Siege" song to two campaigns and our default playlist.

@tomek-szczesny, you'll notice I also added this song to a few non-undead scenarios in TRoW. To help specific campaigns or places feel unique, I've been trying to concentrate new songs in a few campaigns rather than spreading them infrequently across many campaigns. That said, if you'd prefer we use this song in undead scenarios only, I have no problem removing it from those non-undead TRoW scenarios.

Requesting a review from @Hejnewar, as our default playlist is MP content.
