### PR TITLE
DiD, THoT: swap campaign selection order

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/_main.cfg
+++ b/data/campaigns/Descent_Into_Darkness/_main.cfg
@@ -6,7 +6,7 @@
 # wmlscope: set export=no
 [campaign]
     id=Descent_into_Darkness
-    rank=100
+    rank=80
     year="389 YW"
     icon="data/campaigns/Descent_Into_Darkness/images/units/dark-mage.png~RC(magenta>red)"
     background="data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_intro_03.webp"

--- a/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/_main.cfg
@@ -30,7 +30,7 @@
     name= _ "The Hammer of Thursagan"
     image="data/campaigns/The_Hammer_of_Thursagan/images/campaign_image.png"
     abbrev= _ "THoT"
-    rank=80
+    rank=100
     start_year="550 YW"
     end_year="551 YW"
     define=CAMPAIGN_THE_HAMMER_OF_THURSAGAN


### PR DESCRIPTION
The current order puts DiD right before EI, which I'm worried may lead first-time EI players to think it's a DiD sequel.