### PR TITLE
fix savegame dates not being translated to current language

### DIFF
--- a/src/format_time_summary.cpp
+++ b/src/format_time_summary.cpp
@@ -117,7 +117,7 @@ std::string format_time_summary(const std::chrono::system_clock::time_point& t)
 #endif
 	// TODO: make sure this doesn't result in #1709 coming back
 	assert(!format_string.empty());
-	return chrono::format_local_timestamp(t, format_string);
+	return translation::translate_timestamp(chrono::get_local_timestamp(t), format_string);
 }
 
 } // namespace utils

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -573,4 +573,12 @@ const boost::locale::info& get_effective_locale_info()
 {
 	return std::use_facet<boost::locale::info>(get_manager().get_locale());
 }
+
+std::string translate_timestamp(time_t time, std::string_view format)
+{
+	std::ostringstream ss;
+	ss.imbue(get_manager().get_locale());
+	ss << bl::as::ftime(format.data()) << time;
+	return ss.str();
+}
 }

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -91,6 +91,9 @@ namespace translation
 	 * default language" is represented by an empty string.
 	 */
 	const boost::locale::info& get_effective_locale_info();
+
+	/** Translates the passed timestamp and returns it in the requested format. */
+	std::string translate_timestamp(time_t time, std::string_view format = "%F %T");
 }
 
 //#define _(String) translation::dsgettext(GETTEXT_DOMAIN,String)

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -1102,7 +1102,7 @@ static std::string format_addon_time(const std::chrono::system_clock::time_point
 		// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
 		: _("%B %d %Y, %H:%M");
 
-	return chrono::format_local_timestamp(time, format);
+	return translation::translate_timestamp(chrono::get_local_timestamp(time), format);
 }
 
 void addon_manager::on_addon_select()

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -249,7 +249,7 @@ std::string save_info::format_time_local() const
 		// Format for your locale.
 		: _("%a %b %d %Y, %H:%M");
 
-	return chrono::format_local_timestamp(modified(), format);
+	return translation::translate_timestamp(chrono::get_local_timestamp(modified()), format);
 }
 
 std::string save_info::format_time_summary() const

--- a/src/serialization/chrono.hpp
+++ b/src/serialization/chrono.hpp
@@ -59,6 +59,14 @@ inline auto serialize_timestamp(const std::chrono::system_clock::time_point& tim
 	return std::chrono::system_clock::to_time_t(time);
 }
 
+inline auto get_local_timestamp(const std::chrono::system_clock::time_point& time)
+{
+	auto as_time_t = std::chrono::system_clock::to_time_t(time);
+	return mktime(std::localtime(&as_time_t));
+}
+
+// CAUTION: This does NOT return a language-localized string.  To achieve that,
+//          use translation::translate_timestamp with chrono::get_local_timestamp.
 inline auto format_local_timestamp(const std::chrono::system_clock::time_point& time, std::string_view format = "%F %T")
 {
 	std::ostringstream ss;


### PR DESCRIPTION
Translate date strings in Load Game and Add-ons Manager dialogs.  Fixes #11139.  Tested on Windows 10 and Ubuntu 26.