### PR TITLE
fix crash on opening debug unit spawn dialog

### DIFF
--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -415,10 +415,7 @@ void units_dialog::update_variation()
 // } -------------------- BUILDERS -------------------- {
 std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vector<const unit_type*>& types_list)
 {
-	auto smart_dlg = std::make_unique<units_dialog>();
-
-	// Take the raw pointer to give to callbacks as the unique_ptr will be out of scope by the time they're called.
-	auto dlg = smart_dlg.get();
+	auto dlg = std::make_unique<units_dialog>();
 
 	const auto type_gen = [](const auto& type) {
 		std::string type_name = type->type_name();
@@ -432,7 +429,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 		return type->race()->plural_name();
 	};
 
-	const auto populate_variations = [dlg](const unit_type& ut) {
+	const auto populate_variations = [dlg = dlg.get()](const unit_type& ut) {
 		// Populate variations box
 		menu_button& var_box = dlg->find_widget<menu_button>("variation_box");
 		std::vector<config> var_box_values;
@@ -484,7 +481,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 	set_column("unit_name", type_gen, sort_type::generator);
 	set_column("unit_details", race_gen, sort_type::generator);
 
-	dlg->on_modified([populate_variations, dlg, &types_list](std::size_t index) -> const auto& {
+	dlg->on_modified([populate_variations, dlg = dlg.get(), &types_list](std::size_t index) -> const auto& {
 		const unit_type* ut = types_list[index];
 
 		if (dlg->is_selected() && (static_cast<int>(index) == dlg->get_selected_index())) {
@@ -509,7 +506,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 		return *ut;
 	});
 
-	return smart_dlg;
+	return dlg;
 }
 
 std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -429,7 +429,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 		return type->race()->plural_name();
 	};
 
-	const auto populate_variations = [dlg = dlg.get()](const unit_type& ut) {
+	const auto populate_variations = [](units_dialog* dlg, const unit_type& ut) {
 		// Populate variations box
 		menu_button& var_box = dlg->find_widget<menu_button>("variation_box");
 		std::vector<config> var_box_values;
@@ -481,7 +481,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 	set_column("unit_name", type_gen, sort_type::generator);
 	set_column("unit_details", race_gen, sort_type::generator);
 
-	dlg->on_modified([populate_variations, dlg = dlg.get(), &types_list](std::size_t index) -> const auto& {
+	dlg->on_modified([populate_variations, &types_list](units_dialog* dlg, std::size_t index) -> const auto& {
 		const unit_type* ut = types_list[index];
 
 		if (dlg->is_selected() && (static_cast<int>(index) == dlg->get_selected_index())) {
@@ -491,7 +491,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 				[ut](const unit_race::GENDER& gender) { return ut->has_gender_variation(gender); });
 		}
 
-		populate_variations(*ut);
+		populate_variations(dlg, *ut);
 
 		const auto& g = dlg->gender();
 		if(ut->has_gender_variation(g)) {
@@ -550,7 +550,7 @@ std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(
 		return err_msgs_map[recruit_list[index]];
 	});
 
-	dlg->on_modified([&recruit_list](std::size_t index) -> const auto& { return *recruit_list[index]; });
+	dlg->on_modified([&recruit_list](units_dialog* dlg, std::size_t index) -> const auto& { (void)dlg;  return *recruit_list[index]; });
 
 	return dlg;
 }
@@ -679,7 +679,8 @@ std::unique_ptr<units_dialog> units_dialog::build_unit_list_dialog(std::vector<u
 		return filter_keys;
 	});
 
-	dlg->on_modified([&unit_list, &rename](std::size_t index) -> const auto& {
+	dlg->on_modified([&unit_list, &rename](units_dialog* dlg, std::size_t index) -> const auto& {
+		(void)dlg;
 		auto& unit = unit_list[index];
 		rename.set_active(!unit->unrenamable());
 		return *unit;
@@ -858,7 +859,8 @@ std::unique_ptr<units_dialog> units_dialog::build_recall_dialog(
 		return filter_keys;
 	});
 
-	dlg->on_modified([&recall_list, &rename](std::size_t index) -> const auto& {
+	dlg->on_modified([&recall_list, &rename](units_dialog* dlg, std::size_t index) -> const auto& {
+		(void)dlg;
 		const auto& unit = recall_list[index];
 		rename.set_active(!unit->unrenamable());
 		return *unit;

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -415,7 +415,10 @@ void units_dialog::update_variation()
 // } -------------------- BUILDERS -------------------- {
 std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vector<const unit_type*>& types_list)
 {
-	auto dlg = std::make_unique<units_dialog>();
+	auto smart_dlg = std::make_unique<units_dialog>();
+
+	// Take the raw pointer to give to callbacks as the unique_ptr will be out of scope by the time they're called.
+	auto dlg = smart_dlg.get();
 
 	const auto type_gen = [](const auto& type) {
 		std::string type_name = type->type_name();
@@ -429,7 +432,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 		return type->race()->plural_name();
 	};
 
-	const auto populate_variations = [&dlg](const unit_type& ut) {
+	const auto populate_variations = [dlg](const unit_type& ut) {
 		// Populate variations box
 		menu_button& var_box = dlg->find_widget<menu_button>("variation_box");
 		std::vector<config> var_box_values;
@@ -481,7 +484,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 	set_column("unit_name", type_gen, sort_type::generator);
 	set_column("unit_details", race_gen, sort_type::generator);
 
-	dlg->on_modified([populate_variations, &dlg, &types_list](std::size_t index) -> const auto& {
+	dlg->on_modified([populate_variations, dlg, &types_list](std::size_t index) -> const auto& {
 		const unit_type* ut = types_list[index];
 
 		if (dlg->is_selected() && (static_cast<int>(index) == dlg->get_selected_index())) {
@@ -506,7 +509,7 @@ std::unique_ptr<units_dialog> units_dialog::build_create_dialog(const std::vecto
 		return *ut;
 	});
 
-	return dlg;
+	return smart_dlg;
 }
 
 std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -550,7 +550,7 @@ std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(
 		return err_msgs_map[recruit_list[index]];
 	});
 
-	dlg->on_modified([&recruit_list](units_dialog* dlg, std::size_t index) -> const auto& { (void)dlg;  return *recruit_list[index]; });
+	dlg->on_modified([&recruit_list](units_dialog*, std::size_t index) -> const auto& { return *recruit_list[index]; });
 
 	return dlg;
 }
@@ -679,8 +679,7 @@ std::unique_ptr<units_dialog> units_dialog::build_unit_list_dialog(std::vector<u
 		return filter_keys;
 	});
 
-	dlg->on_modified([&unit_list, &rename](units_dialog* dlg, std::size_t index) -> const auto& {
-		(void)dlg;
+	dlg->on_modified([&unit_list, &rename](units_dialog*, std::size_t index) -> const auto& {
 		auto& unit = unit_list[index];
 		rename.set_active(!unit->unrenamable());
 		return *unit;
@@ -859,8 +858,7 @@ std::unique_ptr<units_dialog> units_dialog::build_recall_dialog(
 		return filter_keys;
 	});
 
-	dlg->on_modified([&recall_list, &rename](units_dialog* dlg, std::size_t index) -> const auto& {
-		(void)dlg;
+	dlg->on_modified([&recall_list, &rename](units_dialog*, std::size_t index) -> const auto& {
 		const auto& unit = recall_list[index];
 		rename.set_active(!unit->unrenamable());
 		return *unit;

--- a/src/gui/dialogs/units_dialog.hpp
+++ b/src/gui/dialogs/units_dialog.hpp
@@ -150,7 +150,7 @@ public:
 	void on_modified(const Func& f)
 	{
 		connect_signal<event::NOTIFY_MODIFIED>([this, f](widget& w, auto&&...) {
-			w.find_widget<unit_preview_pane>("unit_details").set_display_data(f(get_selected_index()));
+			w.find_widget<unit_preview_pane>("unit_details").set_display_data(f(this, get_selected_index()));
 		});
 	}
 


### PR DESCRIPTION
Resolves #10160

`units_dialog::build_create_dialog` captures-by-reference `dlg`, which is a local `unique_ptr`, in several callback lambdas.  `dlg` however does not outlive this function, so is no longer valid at the point the callbacks are made.  Note that it's only the "smart wrapper" around the logical `dlg` that is illegally used; the dialog instance itself is fine to use, even after the local `dlg` is (I think) _moved_ on return from the function.

This PR's solution is to have the callback lambdas capture-by-_value_ the _raw_ pointer to the dialog.  Confirmed that this addresses the issue on my Windows 10 machine.