### PR TITLE
Provide WESNOTH_VERSION_* parts (major, minor etc) as WML macros (#7752)

### DIFF
--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -54,6 +54,11 @@ void add_builtin_defines(preproc_map& target)
 #endif
 
 	target.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+
+	target.try_emplace("WESNOTH_VERSION_MAJOR", std::to_string(game_config::wesnoth_version.major_version()));
+	target.try_emplace("WESNOTH_VERSION_MINOR", std::to_string(game_config::wesnoth_version.minor_version()));
+	target.try_emplace("WESNOTH_VERSION_REVISION", std::to_string(game_config::wesnoth_version.revision_level()));
+	target.try_emplace("WESNOTH_VERSION_SPECIAL", game_config::wesnoth_version.special_version());
 }
 
 }
@@ -162,11 +167,19 @@ config config_cache::read_cache(const std::string& file_path, abstract_validator
 
 	bool is_valid = true;
 
+	//
+	// Only WESNOTH_VERSION and its variants are allowed to be non-empty.
+	//
+	static const std::set<std::string> allowed_non_empty_define_keys = {
+		"WESNOTH_VERSION",
+		"WESNOTH_VERSION_MAJOR",
+		"WESNOTH_VERSION_MINOR",
+		"WESNOTH_VERSION_REVISION",
+		"WESNOTH_VERSION_SPECIAL"
+	};
+
 	for(const auto& [key, define] : defines_map_) {
-		//
-		// Only WESNOTH_VERSION is allowed to be non-empty.
-		//
-		if((!define.value.empty() || !define.arguments.empty()) && key != "WESNOTH_VERSION") {
+		if((!define.value.empty() || !define.arguments.empty()) && allowed_non_empty_define_keys.find(key) == allowed_non_empty_define_keys.end()) {
 			is_valid = false;
 			ERR_CACHE << "Invalid preprocessor define: " << key;
 			break;

--- a/src/tests/test_config_cache.cpp
+++ b/src/tests/test_config_cache.cpp
@@ -38,6 +38,10 @@ static preproc_map setup_test_preproc_map()
 #endif
 
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("WESNOTH_VERSION_MAJOR", std::to_string(game_config::wesnoth_version.major_version()));
+	defines_map.try_emplace("WESNOTH_VERSION_MINOR", std::to_string(game_config::wesnoth_version.minor_version()));
+	defines_map.try_emplace("WESNOTH_VERSION_REVISION", std::to_string(game_config::wesnoth_version.revision_level()));
+	defines_map.try_emplace("WESNOTH_VERSION_SPECIAL", game_config::wesnoth_version.special_version());
 	return defines_map;
 }
 


### PR DESCRIPTION
Simple proposed implementation to satisfy wesnoth/wesnoth#7752.  New macros are:

`WESNOTH_VERSION_MAJOR` (e.g. "1")
`WESNOTH_VERSION_MINOR` (e.g. "19")
`WESNOTH_VERSION_REVISION` (e.g. "23")
`WESNOTH_VERSION_SPECIAL` (e.g. "dev")

Tested and found that these _can_ technically be used in `#ifver` blocks (e.g. `#ifver WESNOTH_VERSION_MINOR > 10`), though internally I think the engine sees that as a comparison between "19.0.0" and "10.0.0".

Closes #7752