### PR TITLE
Make [message] tag's speaker key accept arbitrarily-ordered list (#11197)

### DIFF
--- a/data/lua/wml/message.lua
+++ b/data/lua/wml/message.lua
@@ -215,14 +215,23 @@ local function get_speaker(cfg)
 	local speaker
 	local context = wesnoth.current.event_context
 
-	if cfg.speaker == "narrator" then
-		speaker = "narrator"
-	elseif cfg.speaker == "unit" then
-		speaker = wesnoth.units.get(context.x1 or 0, context.y1 or 0)
-	elseif cfg.speaker == "second_unit" then
-		speaker = wesnoth.units.get(context.x2 or 0, context.y2 or 0)
-	elseif cfg.speaker ~= nil then
-		speaker = wesnoth.units.get(cfg.speaker)
+	if cfg.speaker ~= nil then
+		-- search the provided list (in order) for the first matching unit
+		for _,speaker_id in ipairs(tostring(cfg.speaker):split()) do
+			if speaker_id == "narrator" then
+				speaker = "narrator"
+			elseif cfg.speaker == "unit" then
+				speaker = wesnoth.units.get(context.x1 or 0, context.y1 or 0)
+			elseif cfg.speaker == "second_unit" then
+				speaker = wesnoth.units.get(context.x2 or 0, context.y2 or 0)
+			else
+				speaker = wesnoth.units.get(speaker_id)
+			end
+			-- break on first match
+			if speaker ~= nil then
+				break
+			end
+		end
 	else
 		speaker = wesnoth.units.find_on_map(cfg)[1]
 	end

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -721,7 +721,7 @@
 		max=infinite
 		super="$filter_unit"
 		{INSERT_TAG}
-		{SIMPLE_KEY speaker string}
+		{SIMPLE_KEY speaker string_list}
 		{SIMPLE_KEY message s_t_string}
 		{SIMPLE_KEY male_message s_t_string}
 		{SIMPLE_KEY female_message s_t_string}


### PR DESCRIPTION
PR to support preference-ordered `speaker` value list as ~requested under wesnoth/wesnoth#11197.  This implementation has not been extensively tested.  It is also likely to slightly degrade performance in all cases (due to `speaker` now being a list of strings rather than a single string), and has not been optimised at all (it just performs an entirely separate lookup for each list element).  I argue that this is acceptable as `[message]` is very much in user time so slow code should never be noticeable.

This submission ~~needs to be tested~~has been tested against the regression risk identified under #11197 ~~before leaving draft status~~:

17_Crossroads.cfg around line 515:
```
        [message]
            speaker=Lisar,Yrogin
            message=_"This isn’t over. Keep up the fight!"
        [/message]
```

The above appears to be the only place that a comma is used in the value for `speaker` (in built-in scenarios).

Closes #11197