### PR TITLE
Fix unit filter ignoring sole attribute if [variables] (bug #11211)

### DIFF
--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -711,7 +711,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 					/* Check if the filter only cares about variables.
 					   If so, no need to serialize the whole unit. */
 					config::all_children_itors ci = fwml.all_children_range();
-					if (fwml.all_children_count() == 1 && fwml.attribute_count() == 1 && ci.front().key == "variables") {
+					if (fwml.all_children_count() == 1 && fwml.attribute_count() == 0 && ci.front().key == "variables") {
 						return args.u.variables().matches(ci.front().cfg);
 					} else {
 						config ucfg;


### PR DESCRIPTION
When deciding whether to apply the "[variables]-only" optimisation, the unit filter does not do so unless the filter contains exactly one attribute.  This optimisation should only be applied where it contains exactly no attributes, and importantly should _not_ be applied if it contains _any_ attributes.

This implementation causes the below unit filter to be correctly applied (that is, only be applied to units of type "Swordsman" **and** with the "some_variable" variable set to "yes", rather than only the latter):

```
            [filter]
				[filter_wml]
					type="Swordsman"
					[variables]
						some_variable=yes
					[/variables]
				[/filter_wml]
            [/filter]
```

This request is to address: wesnoth/wesnoth#11211