### PR TITLE
Help: Right align columns with percentages

### DIFF
--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -792,7 +792,7 @@ std::string unit_topic_generator::operator()() const {
 
 	std::stringstream().swap(table_ss);
 	table_ss << markup::tag_attr("row",
-		{ {"bgcolor", "table_header"} },
+		{{ "bgcolor", "table_header" }},
 		markup::tag("col", markup::bold(_("Attack Type"))),
 		markup::tag("col", markup::bold(_("Resistance"))));
 
@@ -813,7 +813,7 @@ std::string unit_topic_generator::operator()() const {
 		table_ss << markup::tag_attr("row",
 			{{ "bgcolor", (odd_row ? "table_row1" : "table_row2") }},
 			markup::tag("col", markup::img(type_icon), ' ', lang_type),
-			markup::tag("col", markup::span_color(color, resist)));
+			markup::tag_attr("col", {{ "halign", "right" }}, markup::span_color(color, resist)));
 
 		odd_row = !odd_row;
 	}
@@ -881,7 +881,7 @@ std::string unit_topic_generator::operator()() const {
 			// Defense  -  range: +10 % .. +70 %
 			// passing false to select the more saturated red-to-green scale
 			color_t def_color = game_config::red_to_green(m.defense, false);
-			row_ss << markup::tag("col", markup::span_color(def_color, m.defense, "%"));
+			row_ss << markup::tag_attr("col", {{ "halign", "right"}}, markup::span_color(def_color, m.defense, "%"));
 
 			// Movement  -  range: 1 .. 5, movetype::UNREACHABLE=impassable
 			row_ss << markup::tag("col", format_mp_entry(type_.movement(), m.movement_cost));


### PR DESCRIPTION
Resolves #11159 

This aligns the percentages visually, avoiding the visual issues presented in #11159.

<img width="429" height="654" alt="Screenshot from 2026-05-08 20-52-01" src="https://github.com/user-attachments/assets/aac14f75-d426-4dcc-bed1-032b6d198734" />

[ignore the coloring, my display is set to low constrast]