### PR TITLE
CMAKE: Fix install commands for server directory on CYGWIN/MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,9 +628,19 @@ if(ENABLE_APPDATA_FILE AND ENABLE_GAME)
 endif()
 
 if(ENABLE_SERVER AND FIFO_DIR)
-	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory \$ENV{DESTDIR}/${FIFO_DIR})")
+	# Copy and remove the slash at the end, if it exists
+	string(REGEX REPLACE "/$" "" DEST_FIFO_DIR "$ENV{DESTDIR}")
+
+	# Copy and remove the slash on the beginning, if it exists
+	string(REGEX REPLACE "^/" "" TEMP_FIFO_DIR "${FIFO_DIR}")
+
+	# Combine and build destination directory
+	set(DEST_FIFO_DIR "${DEST_FIFO_DIR}/${TEMP_FIFO_DIR}")
+	message("-- Setting DEST_FIFO_DIR: ${DEST_FIFO_DIR}")
+
+	install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_FIFO_DIR})")
 	if(SERVER_UID AND SERVER_GID)
-		install(CODE "execute_process(COMMAND chown ${SERVER_UID}:${SERVER_GID} \$ENV{DESTDIR}/${FIFO_DIR})")
+		install(CODE "execute_process(COMMAND chown ${SERVER_UID}:${SERVER_GID} ${DEST_FIFO_DIR})")
 	endif()
 endif()
 


### PR DESCRIPTION
After compiling wesnoth for CYGWIN or for native Windows with MSYS2 (which inherits the same Bash for the task), I executed the installation with `ninja install`, but this error is shown on the console:
```
Error creating directory "//var/run/wesnothd".
```
It looks like that the "//" on the beginning of a path is not tolerated on Windows.
So, I did a simple fix into `CMakeLists.txt` for assembling a `${SERVER_DIR}` variable without this defect.
After doing this fix, the installation has been completed successfully.