### PR TITLE
TSG S06a: Fix the quotation marks in a new hint string

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/06a_Vengeance.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06a_Vengeance.cfg
@@ -516,7 +516,7 @@ then survive until turns run out"
                     [/objective]
                     {IS_LAST_SCENARIO}
                     [note]
-                        description= _"To 'reach Westin', move any unit adjacent to an ally"
+                        description= _"To ‘reach Westin’, move any unit adjacent to an ally"
                     [/note]
                 [/objectives]
             [/then]


### PR DESCRIPTION
This is one of the strings that got an exception to the string-freeze to get it into 1.19.24, it was added after the most recent pot-update.