### PR TITLE
Language: support specifying names for alternative locales

### DIFF
--- a/data/languages/bn_BD.cfg
+++ b/data/languages/bn_BD.cfg
@@ -5,5 +5,6 @@
     windows_locale=bn-BD
     alternates=bn_IN
     windows_alternates=bn-IN
+    alternate_names="বাংলা (ভারত)"
     percent=62
 [/locale]

--- a/data/languages/en_GB.cfg
+++ b/data/languages/en_GB.cfg
@@ -3,6 +3,7 @@
     locale=en_GB
     windows_locale=en-GB
     alternates=en_AG, en_AU, en_BW, en_IE, en_IN, en_NG, en_NZ, en_SG, en_ZA, en_ZW
+    alternate_names="English (Antigua and Barbuda), English (Australia), English (Botswana), English (Ireland), English (India), English (Nigeria), English (New Zealand), English (Singapore), English (South Africa), English (Zimbabwe)"
     windows_alternates=en-AG, en-AU, en-BW, en-IE, en-IN, en-NG, en-NZ, en-SG, en-ZA, en-ZW
     percent=99
 [/locale]

--- a/data/schema/languages.cfg
+++ b/data/schema/languages.cfg
@@ -24,7 +24,7 @@
             {SIMPLE_KEY sort_name string}
             {SIMPLE_KEY alternates locale_list}
             {SIMPLE_KEY windows_locale string}
-            {SIMPLE_KEY windows_alternates string}
+            {SIMPLE_KEY windows_alternates string_list}
             {SIMPLE_KEY alternate_names string_list}
         [/tag]
     [/tag]

--- a/data/schema/languages.cfg
+++ b/data/schema/languages.cfg
@@ -25,6 +25,7 @@
             {SIMPLE_KEY alternates locale_list}
             {SIMPLE_KEY windows_locale string}
             {SIMPLE_KEY windows_alternates string}
+            {SIMPLE_KEY alternate_names string_list}
         [/tag]
     [/tag]
 [/wml_schema]

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -409,20 +409,21 @@ void title_screen::update_static_labels()
 		// Just assume everything is UTF-8 (it should be as long as we're called Wesnoth)
 		// and strip the charset from the Boost locale identifier.
 		const auto& boost_name = boost::algorithm::erase_first_copy(locale.name(), ".UTF-8");
-		const auto& langs = get_languages(true);
 
-		auto lang_def = utils::ranges::find(langs, boost_name, &language_def::localename);
-		if(lang_def != langs.end()) {
-			lang_button->set_label(lang_def->language.str());
-		} else if(boost_name == "c" || boost_name == "C") {
+		if(boost_name == "c" || boost_name == "C") {
 			// HACK: sometimes System Default doesn't match anything on the list. If you fork
 			// Wesnoth and change the neutral language to something other than US English, you
 			// want to change this too.
 			lang_button->set_label("English (US)");
 		} else {
-			// If somehow the locale doesn't match a known translation, use the
-			// locale identifier as a last resort
-			lang_button->set_label(boost_name);
+			std::string lname = get_locale_display_name(boost_name);
+			if(!lname.empty()) {
+				lang_button->set_label(lname);
+			} else {
+				// If somehow the locale doesn't match a known translation, use the
+				// locale identifier as a last resort
+				lang_button->set_label(boost_name);
+			}
 		}
 	}
 }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -51,6 +51,9 @@ namespace {
 	std::vector<language_def> known_languages;
 	utils::string_map strings_;
 	int min_translation_percent = 80;
+	// a storage for looking up locale name corresponding to a locale id
+	// for locale ids that Wesnoth supports
+	std::map<std::string, std::string> locale_names;
 }
 
 bool load_strings(bool complain);
@@ -116,6 +119,18 @@ language_def::language_def(const config& cfg)
 	, rtl(cfg["dir"] == "rtl")
 	, percent(cfg["percent"].to_int())
 {
+	// entry for main language in the locale id and name map
+	locale_names.emplace(localename, language);
+
+	if(cfg.has_attribute("alternate_names")) {
+		auto alternate_names = utils::split(cfg["alternate_names"]);
+		for(size_t i = 0; i < std::min(alternates.size(), alternate_names.size()); i++) {
+			std::string lname = alternate_names[i];
+			if(!lname.empty()) {
+				locale_names.emplace(alternates[i], lname);
+			}
+		}
+	}
 }
 
 bool load_language_list()
@@ -156,6 +171,12 @@ std::vector<language_def> get_languages(bool all)
 
 	LOG_G << "Found " << result.size() << " sufficiently translated languages";
 	return result;
+}
+
+std::string get_locale_display_name(const std::string& locale_id)
+{
+	auto itor = locale_names.find(locale_id);
+	return itor != locale_names.end() ? itor->second : "";
 }
 
 int get_min_translation_percent()

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -70,6 +70,13 @@ inline auto string_table = symbol_table{};
 bool& time_locale_correct();
 
 /**
+ * @param locale_id a posix locale id, like "en_US"
+ * @return a human-friendly name of the given locale_id,
+ * if available, else return an empty string
+ */
+std::string get_locale_display_name(const std::string& locale_id);
+
+/**
  * Return a list of available translations.
  *
  * The list will normally be filtered with incomplete (according to


### PR DESCRIPTION
* Adds `[locale]alternative_names` key to specify names for locale ids specified in `alternates`.
* Stores known locale id and names pairs in a global map. That map is used to query the name for the current locale's name to show it in the titlescreen language button.

For now, I've only added `alternative_names` for the following languages, but I can add more if needed, or the translators can add them as well.
- [x] English
- [x] Bengali

Example: (my PC's default lang is `en_IN`)
**Before**
<img width="100" height="57" alt="Screenshot from 2026-05-18 20-17-41" src="https://github.com/user-attachments/assets/501bb2b0-8c00-46d0-ba7e-ac24453c3531" />
**After**
<img width="160" height="73" alt="Screenshot from 2026-05-18 19-26-47" src="https://github.com/user-attachments/assets/446c607e-abb2-40ff-b9d8-f061dd96162f" />