### PR TITLE
Title Screen: show translation name for autodetected locales

### DIFF
--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -408,21 +408,21 @@ void title_screen::update_static_labels()
 		const auto& locale = translation::get_effective_locale_info();
 		// Just assume everything is UTF-8 (it should be as long as we're called Wesnoth)
 		// and strip the charset from the Boost locale identifier.
-		const auto& boost_name = boost::algorithm::erase_first_copy(locale.name(), ".UTF-8");
-		const auto& langs = get_languages(true);
+		const auto& locale_id = boost::algorithm::erase_first_copy(locale.name(), ".UTF-8");
 
-		auto lang_def = utils::ranges::find(langs, boost_name, &language_def::localename);
-		if(lang_def != langs.end()) {
-			lang_button->set_label(lang_def->language.str());
-		} else if(boost_name == "c" || boost_name == "C") {
-			// HACK: sometimes System Default doesn't match anything on the list. If you fork
-			// Wesnoth and change the neutral language to something other than US English, you
-			// want to change this too.
+		if(locale_id == "c" || locale_id == "C") {
+			// If you fork Wesnoth and change the neutral language to something other than US English,
+			// you want to change this too.
 			lang_button->set_label("English (US)");
 		} else {
-			// If somehow the locale doesn't match a known translation, use the
-			// locale identifier as a last resort
-			lang_button->set_label(boost_name);
+			std::string lname = get_translation_name(locale_id);
+			if(!lname.empty()) {
+				lang_button->set_label(lname);
+			} else {
+				// If somehow the locale doesn't match a known locale,
+				// use the locale identifier as a last resort
+				lang_button->set_label(locale_id);
+			}
 		}
 	}
 }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -51,6 +51,9 @@ namespace {
 	std::vector<language_def> known_languages;
 	utils::string_map strings_;
 	int min_translation_percent = 80;
+	// a storage for looking up active translation name
+	// corresponding to a locale id for locale ids that Wesnoth supports.
+	std::map<std::string, std::string> translation_names;
 }
 
 bool load_strings(bool complain);
@@ -127,6 +130,12 @@ language_def::language_def(const config& cfg)
 	, rtl(cfg["dir"] == "rtl")
 	, percent(cfg["percent"].to_int())
 {
+	// entry for main language in the locale id and name map
+	translation_names.emplace(localename, language);
+
+	for(const auto& alternate : alternates) {
+		translation_names.emplace(alternate, language);
+	}
 }
 
 bool load_language_list()
@@ -167,6 +176,12 @@ std::vector<language_def> get_languages(bool all)
 
 	LOG_G << "Found " << result.size() << " sufficiently translated languages";
 	return result;
+}
+
+std::string get_translation_name(const std::string& locale_id)
+{
+	auto itor = translation_names.find(locale_id);
+	return itor != translation_names.end() ? itor->second : "";
 }
 
 int get_min_translation_percent()

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -72,6 +72,14 @@ inline auto string_table = symbol_table{};
 bool& time_locale_correct();
 
 /**
+ * @param locale_id a posix or windows locale id based on the OS,
+ *                  like "en_US" or "en-US".
+ * @return name of the translation corresponding to that locale
+ * if available, or an empty string if no such name exists.
+ */
+std::string get_translation_name(const std::string& locale_id);
+
+/**
  * Return a list of available translations.
  *
  * The list will normally be filtered with incomplete (according to


### PR DESCRIPTION
Previously, automatically detected locales will have shown the locale id if it was one of the alternatives locales for a translation. This fixes that so that the corresponding translation name is shown instead. (For example: English (GB) for en_IN, since en_IN is listed as an alternate for en_GB)

Replacement for #11231. Based on the discussions there, the TS language button label should show the active translation's name and not the name of the autodetected locale.