### PR TITLE
TDG S08, S10: delay spell selection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 ### Campaigns
    * Heir to the Throne
      * S03 "Blackwater Port": added a secondary, coastal entry point for this scenario, so Konrad can make better use of Merfolk if he has them.
+   * The Deceivers Gambit
+     * S08 "Ruins of Saurgrath", S10 "Houses of the Dead": spell selection is now delayed until Delfador learns what kind of enemies he's fighting.
 ### Editor
 ### Multiplayer
 ### Lua API

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/08_Ruins_of_Saurgrath.cfg
@@ -336,9 +336,8 @@
         # DELFADOR
         #############################
         {RECALL_XY Delfador 18 24}
-        #         {STORE_SKILLS}
-        #         {VARIABLE skill_fireball3 yes} # start with a generic l3 fireball and no other skills
-        #         {FIRE_EVENT refresh_delfador_skills}
+        {STORE_SKILLS}
+        {FIRE_EVENT refresh_delfador_skills}
 
         {RECALL_COMPANION 17 26}
 
@@ -403,7 +402,6 @@
 
         {VARIABLE unlock_dancing_daggers yes}
         {VARIABLE unlock_contingency     yes}
-        {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
     [/event]
 
     #############################
@@ -552,8 +550,9 @@
         [/allow_extra_recruit]
         {VARIABLE poachers_were_recruited yes}
 
-        #         {UNSTORE_SKILLS} # restore the skills we chose in S07
-        #         {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
+        # restore the default skills we chose in S07, then let Delfador reselect them
+        {UNSTORE_SKILLS}
+        {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
         {FIRE_EVENT play_main_scenario}
     [/event]
 
@@ -580,31 +579,36 @@
         [/message]
         {MODIFY_UNIT id=$companion_id side 11} # don't let Delfador kill Lynyan
 
-        [objectives]
-            [objective]
-                description= _ "Defeat the bandits"
-                condition=win
-            [/objective]
-            [objective]
-                description= _ "Death of Delfador"
-                condition=lose
-            [/objective]
-            {TURNS_RUN_OUT}
-            [gold_carryover]
-                carryover_percentage,bonus=40,yes
-            [/gold_carryover]
-        [/objectives]
+        # wait until an enemy moves before we reselect spells,
+        # so it's clear that this is happening on the enemies' turn
+        [event]
+            name=moveto
+            # the player won't see this move if they have "skip enemy moves" turned on, so delay a moment to guarantee the new unit position is seen
+            # we do a similar thing in S08
+            {DELAY 500}
 
-        # if the player hasn't yet picked spells, give them a chance to do so now (since the poachers attack immediately)
-        {IF} {VARIABLE_CONDITIONAL wait_to_select_spells equals yes} {THEN(
+            # restore the default skills we chose in S07, then let Delfador reselect them
+            {UNSTORE_SKILLS}
             {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
-        )} {/IF}
+            # it's possible for the player to not trigger this until after poachers have already attacked.
+            # better to just trigger it immediately (before objectives show up) so we're consistent
+            {FIRE_EVENT mousemove}
 
-        #         {UNSTORE_SKILLS}
-        #         {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
-        #         {FIRE_EVENT mousemove}
-        #         # it's possible for the player to not trigger this until after poachers have already attacked.
-        #         # better to just trigger it immediately (before objectives show up) so we're consistent
+            [objectives]
+                [objective]
+                    description= _ "Defeat the bandits"
+                    condition=win
+                [/objective]
+                [objective]
+                    description= _ "Death of Delfador"
+                    condition=lose
+                [/objective]
+                {TURNS_RUN_OUT}
+                [gold_carryover]
+                    carryover_percentage,bonus=40,yes
+                [/gold_carryover]
+            [/objectives]
+        [/event]
     [/event]
     [event]
         name=last breath

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/10_Houses_of_the_Dead.cfg
@@ -80,7 +80,13 @@
     [event]
         name=prestart
         {PLACE_IMAGE "items/bones.png" 11 29}
-        {GENERIC_UNIT 3 (Giant Rat) 11 29} {GUARDIAN}
+        {GENERIC_UNIT 3 (Giant Rat) 11 29} {GUARDIAN} {ROLE easy_rat}
+        [event]
+            name=unit misses
+            # make sure the rat won't ever dodge more than 1 attack, so that it doesn't become annoying
+            {FILTER_SECOND role=easy_rat}
+            {FORCE_CHANCE_TO_HIT id=Delfador role=easy_rat 100 ()}
+        [/event]
         [unit]
             {SINGLEUNITWML_OMARANTH}
             x,y,facing,animate=6,31,se,yes
@@ -106,6 +112,8 @@
             variable=stored_delfador
             x,y,animate=1,32,yes
         [/unstore_unit]
+        {STORE_SKILLS}
+        {FIRE_EVENT refresh_delfador_skills}
         {MODIFY_UNIT id=Delfador facing ne}
         {CLEAR_VARIABLE stored_delfador}
         [heal_unit]
@@ -150,11 +158,6 @@
                 description= _ "In this scenario, you can neither gain nor spend gold."
             [/note]
         [/objectives]
-
-        #         {STORE_SKILLS}
-        #         {VARIABLE skill_fireball3 yes} # start with a generic l3 fireball and no other skills
-        #         {FIRE_EVENT refresh_delfador_skills}
-        {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
     [/event]
 
     ###########################################################################
@@ -210,7 +213,7 @@
             message=_"A drakish tomb? This looks ominous..."
         [/message]
         [event]
-            name=new turn
+            name=side 2 turn
             {SOUND zombie-attack.wav}
 
             {COFFIN_EMERGE 11 22 "Walking Corpse"}
@@ -227,9 +230,18 @@
             # spawn him out of sight, and have him run straight towards Delfador
             {NAMED_UNIT 2 Wraith 27 16 Aethyr "" (facing=sw)} {ADD_MODIFICATION({TRAIT_LOYAL_HERO_NOSLOT})}
 
-            #             {UNSTORE_SKILLS} # restore the skills we chose in S09
-            #             {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
-            #             {FIRE_EVENT mousemove}
+            # wait until an enemy moves before we reselect spells,
+            # so it's clear that this is happening on the enemies' turn
+            [event]
+                name=moveto
+                # the player won't see this move if they have "skip enemy moves" turned on, so delay a moment to guarantee the new unit position is seen
+                # we do a similar thing in S08
+                {DELAY 500}
+
+                {UNSTORE_SKILLS} # restore the skills we chose in S09
+                {RESELECT_SKILLS_AFTER_OBJECTIVES () ()}
+                {FIRE_EVENT mousemove}
+            [/event]
         [/event]
     [/event]
 


### PR DESCRIPTION
There's no benefit to picking spells immediately in these scenarios, so wait until the player learns more about what kind of enemy they're going to fight before we allow them to choose spells.