### PR TITLE
xcode/macos: add glib subsystem overlay

### DIFF
--- a/projectfiles/Xcode/macos/build_macos_deps
+++ b/projectfiles/Xcode/macos/build_macos_deps
@@ -32,6 +32,7 @@ triplets_dir="${script_dir}/triplets"
 temp_dir="${xcode_dir}/temp"
 vcpkg_root="${temp_dir}/${vcpkg_repo_name}"
 overlay_ports_root="${temp_dir}/overlay-ports"
+glib_overlay_port="${overlay_ports_root}/glib"
 pango_overlay_port="${overlay_ports_root}/pango"
 boost_unordered_overlay_port="${overlay_ports_root}/boost-unordered"
 install_root_base="${temp_dir}/vcpkg-installed-macos"
@@ -150,7 +151,7 @@ need_cmd() {
 }
 
 vcpkg_checkout_has_baseline() {
-	# We archive the pango overlay directly from ${vcpkg_baseline}, so a reused
+	# We archive overlay ports directly from ${vcpkg_baseline}, so a reused
 	# temp checkout has to contain that commit before we can proceed.
 	git -C "${vcpkg_root}" merge-base --is-ancestor "${vcpkg_baseline}" HEAD
 }
@@ -226,6 +227,25 @@ install_triplet() {
 		sleep "${retry_delay_seconds}"
 		attempt=$((attempt + 1))
 	done
+}
+
+prepare_glib_overlay() {
+	local overlay_extract_root overlay_archive_path glib_overlay_relative
+
+	overlay_extract_root="${overlay_ports_root}/.glib-baseline"
+	overlay_archive_path="${overlay_extract_root}/glib-port.tar"
+	rm -rf "${glib_overlay_port}" || die "Failed to remove ${glib_overlay_port}."
+	rm -rf "${overlay_extract_root}" || die "Failed to remove ${overlay_extract_root}."
+	mkdir -p "${overlay_ports_root}" || die "Failed to create ${overlay_ports_root}."
+	mkdir -p "${overlay_extract_root}" || die "Failed to create ${overlay_extract_root}."
+	git -C "${vcpkg_root}" archive --format=tar "${vcpkg_baseline}" "ports/glib" > "${overlay_archive_path}" \
+		|| die "Failed to archive glib from vcpkg baseline ${vcpkg_baseline}. Remove ${vcpkg_root} and rerun the script."
+	tar -xf "${overlay_archive_path}" -C "${overlay_extract_root}" || die "Failed to extract ${overlay_archive_path}."
+	mv "${overlay_extract_root}/ports/glib" "${glib_overlay_port}" || die "Failed to move the extracted glib overlay into ${glib_overlay_port}."
+	rm -rf "${overlay_extract_root}" || die "Failed to remove ${overlay_extract_root}."
+	glib_overlay_relative="${glib_overlay_port#"${root_dir}"/}"
+	git -C "${root_dir}" apply --directory="${glib_overlay_relative}" "${script_dir}/patches/glib-macos-subsystem.patch" \
+		|| die "Failed to apply ${script_dir}/patches/glib-macos-subsystem.patch to ${glib_overlay_relative}."
 }
 
 prepare_pango_overlay() {
@@ -497,6 +517,9 @@ ensure_vcpkg_checkout \
 
 echo "==> Bootstrapping vcpkg ..."
 "${vcpkg_root}/bootstrap-vcpkg.sh" -disableMetrics || die "Failed to bootstrap vcpkg under ${vcpkg_root}."
+
+echo "==> Preparing glib overlay port ..."
+prepare_glib_overlay
 
 echo "==> Preparing pango overlay port ..."
 prepare_pango_overlay

--- a/projectfiles/Xcode/macos/patches/glib-macos-subsystem.patch
+++ b/projectfiles/Xcode/macos/patches/glib-macos-subsystem.patch
@@ -1,0 +1,40 @@
+diff --git a/portfile.cmake b/portfile.cmake
+--- a/portfile.cmake
++++ b/portfile.cmake
+@@ -42,6 +42,28 @@ if(VCPKG_HOST_IS_WINDOWS)
+     vcpkg_list(APPEND ADDITIONAL_BINARIES "sh = ['${CMAKE_COMMAND}', '-E', 'false']")
+ endif()
+ 
++if(VCPKG_TARGET_IS_OSX)
++    execute_process(
++        COMMAND uname -m
++        OUTPUT_VARIABLE _glib_macos_host_arch
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++        COMMAND_ERROR_IS_FATAL ANY
++    )
++
++    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
++        set(_glib_macos_target_arch "x86_64")
++    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
++        set(_glib_macos_target_arch "arm64")
++    endif()
++
++    if(DEFINED _glib_macos_target_arch
++        AND NOT _glib_macos_host_arch STREQUAL _glib_macos_target_arch)
++        set(_glib_macos_cross_file "${CMAKE_CURRENT_LIST_DIR}/macos-cross.ini")
++        set(VCPKG_MESON_CROSS_FILE_RELEASE "${_glib_macos_cross_file}")
++        set(VCPKG_MESON_CROSS_FILE_DEBUG "${_glib_macos_cross_file}")
++    endif()
++endif()
++
+ vcpkg_configure_meson(
+     SOURCE_PATH "${SOURCE_PATH}"
+     LANGUAGES ${LANGUAGES}
+diff --git a/macos-cross.ini b/macos-cross.ini
+new file mode 100644
+--- /dev/null
++++ b/macos-cross.ini
+@@ -0,0 +1,3 @@
++[host_machine]
++# GLib 2.88 calls host_machine.subsystem(), which Meson cannot infer for Darwin cross builds.
++subsystem = 'macos'


### PR DESCRIPTION
Adds a temporary macOS GLib overlay for the vcpkg baseline bump in #11241.

GLib 2.88 calls `host_machine.subsystem()`, but vcpkg's generated Meson cross file for macOS cross-arch builds includes `system = 'darwin'` without a `subsystem`, causing:

```text
ERROR: Subsystem not defined or could not be autodetected.
```

The overlay adds a small Meson cross file with `subsystem = 'macos'` for cross-arch macOS GLib builds.

Tested:
- `bash -n projectfiles/Xcode/macos/build_macos_deps`
- `git diff --check`
- verified the GLib overlay patch applies against vcpkg baseline `99a97de...`
- verified a minimal Meson repro fails without `subsystem` and passes with `subsystem = 'macos'`