### PR TITLE
Fix handling of << in quotes

### DIFF
--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1127,7 +1127,7 @@ bool preprocessor_data::get_chunk()
 			put(in_.get());
 			pop_token();
 		}
-	} else if(c == '<' && in_.peek() == '<') {
+	} else if(token.type != token_desc::token_type::string && c == '<' && in_.peek() == '<') {
 		in_.get();
 		push_token(token_desc::token_type::verbatim);
 		put('<');


### PR DESCRIPTION
<< should not mean anything in quotes.

This fixes cases like `key="<<"` erroring or `key="<<" {MACRO} ">>"` not expanding the macro.