### PR TITLE
AToTB S02: Better po hint about the group smelling of death

### DIFF
--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -387,6 +387,8 @@ Besides... I want my brother back."
 
         [message]
             speaker=Nil-Galion
+            # po: For 1.21, this will be clarified to "...as the group with the prisoner passed us..."
+            # po: The semicolon onwards is also likely to be replaced with "Remember your brother as he was, trust that he is not the prisoner, and know that the prisoner’s fate will be revenge as dire as you could wish."
             message= _ "We heard the sounds of battle three days ago, but the foul reek of death was unmistakable as the prisoner passed us; if your brother really is the prisoner then he is also a necromancer. Remember your brother as we all hope he was, and know that the prisoner’s fate will be revenge as dire as you could wish.
 
 Either way, nothing will be gained by your intrusion into our woods. Now advance no further, for we will defend our land."


### PR DESCRIPTION
There's a smell of death from (the group with) the prisoner, but that clarification in brackets is omitted - this should be easy reading rather than cryptic hint in a mystery novel. Add a PO hint for the translators, with the intention to amend the English for 1.21.

Reported in the forums in [https://r.wesnoth.org/p693712](https://r.wesnoth.org/p693712) and the message below that one.