### PR TITLE
Restore Windows tray notification functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,7 +68,7 @@ GetSources("wesnoth" wesnoth_sources)
 
 if(WIN32)
 	set(wesnoth_core_sources ${wesnoth_core_sources} log_windows.cpp)
-	#set(wesnoth_game_sources ${wesnoth_game_sources} desktop/windows_tray_notification.cpp desktop/windows_battery_info.cpp)
+	set(wesnoth_game_sources ${wesnoth_game_sources} desktop/windows_tray_notification.cpp)
 	set(wesnoth_game_sources ${wesnoth_game_sources} desktop/windows_battery_info.cpp)
 endif()
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -92,7 +92,7 @@ libwesnoth_widgets = client_env.Library("wesnoth-widgets", libwesnoth_widgets_so
 wesnoth_client_sources = GetSources("wesnoth")
 
 if env["PLATFORM"] == "win32":
-    # wesnoth_client_sources.append("desktop/windows_tray_notification.cpp")
+    wesnoth_client_sources.append("desktop/windows_tray_notification.cpp")
     wesnoth_client_sources.append("desktop/windows_battery_info.cpp")
 
 if env["PLATFORM"] == 'darwin':

--- a/src/desktop/notifications.cpp
+++ b/src/desktop/notifications.cpp
@@ -27,9 +27,9 @@
 #include "desktop/apple_notification.hpp"
 #endif
 
-// #ifdef _WIN32
-// #include "desktop/windows_tray_notification.hpp"
-// #endif
+#ifdef _WIN32
+#include "desktop/windows_tray_notification.hpp"
+#endif
 
 namespace desktop {
 
@@ -53,11 +53,7 @@ bool available()
 #endif
 }
 
-#ifdef _WIN32
-void send(const std::string&, const std::string&, type)
-#else
 void send(const std::string& owner, const std::string& message, type t)
-#endif
 {
 	// Do not show notifications when the window is visible and has focus
 	if(video::window_is_visible() && video::window_has_focus()) {
@@ -72,24 +68,24 @@ void send(const std::string& owner, const std::string& message, type t)
 	apple_notifications::send_notification(owner, message, t);
 #endif
 
-// #ifdef _WIN32
-// 	std::string notification_title;
-// 	std::string notification_message;
+#ifdef _WIN32
+	std::string notification_title;
+	std::string notification_message;
 
-// 	switch (t) {
-// 		case CHAT:
-// 			notification_title = _("Chat message");
-// 			notification_message = owner + ": " + message;
-// 			break;
-// 		case TURN_CHANGED:
-// 		case OTHER:
-// 			notification_title = owner;
-// 			notification_message = message;
-// 			break;
-// 	}
+	switch (t) {
+		case CHAT:
+			notification_title = _("Chat message");
+			notification_message = owner + ": " + message;
+			break;
+		case TURN_CHANGED:
+		case OTHER:
+			notification_title = owner;
+			notification_message = message;
+			break;
+	}
 
-// 	windows_tray_notification::show(notification_title, notification_message);
-// #endif
+	windows_tray_notification::show(notification_title, notification_message);
+#endif
 }
 #endif //end #else (defined(HAVE_LIBDBUS) || defined(_WIN32))
 

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -41,12 +41,16 @@ void windows_tray_notification::destroy_tray_icon()
 
 bool windows_tray_notification::message_hook(const MSG& msg)
 {
-	if (msg.lParam == NIN_BALLOONUSERCLICK) {
+	switch(msg.lParam) {
+	case NIN_BALLOONUSERCLICK:
 		switch_to_wesnoth_window();
 		destroy_tray_icon();
-	} else if (msg.lParam == NIN_BALLOONTIMEOUT) {
+		return true;
+
+	case NIN_BALLOONTIMEOUT:
 		destroy_tray_icon();
-	}
+		return true;
+
 	// Scenario: More than one notification arrives before the time-out triggers the tray icon destruction.
 	// Problem: Events seem to be triggered differently in SDL 2.0. For the example of two notifications arriving at once:
 	//	1. Balloon created for first notification
@@ -59,11 +63,17 @@ bool windows_tray_notification::message_hook(const MSG& msg)
 	// I could not find the matching definition for 0x0200 in the headers, but this message value is received when the mouse cursor is over the tray icon.
 	// Drawback: The tray icon can still get 'stuck' if the user does not move the mouse cursor over the tray icon.
 	//	Also, accidental destruction of the tray icon can occur if the user moves the mouse cursor over the tray icon before the balloon for a single notification has expired.
-	else if (msg.lParam == 0x0200 && !message_reset) {
-		destroy_tray_icon();
-	}
+	case 0x0200:
+		if(message_reset) {
+			return false;
+		}
 
-	return false;
+		destroy_tray_icon();
+		return true;
+
+	default:
+		return false;
+	}
 }
 
 bool windows_tray_notification::create_tray_icon()

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -15,8 +15,6 @@
 
 #include "desktop/windows_tray_notification.hpp"
 
-#include <SDL3/SDL_syswm.h>
-
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
@@ -41,16 +39,12 @@ void windows_tray_notification::destroy_tray_icon()
 	}
 }
 
-void windows_tray_notification::handle_system_event(const SDL_Event& event)
+bool windows_tray_notification::message_hook(const MSG& msg)
 {
-	if (event.syswm.msg->msg.win.msg != WM_TRAYNOTIFY) {
-		return;
-	}
-
-	if (event.syswm.msg->msg.win.lParam == NIN_BALLOONUSERCLICK) {
+	if (msg.lParam == NIN_BALLOONUSERCLICK) {
 		switch_to_wesnoth_window();
 		destroy_tray_icon();
-	} else if (event.syswm.msg->msg.win.lParam == NIN_BALLOONTIMEOUT) {
+	} else if (msg.lParam == NIN_BALLOONTIMEOUT) {
 		destroy_tray_icon();
 	}
 	// Scenario: More than one notification arrives before the time-out triggers the tray icon destruction.
@@ -65,9 +59,11 @@ void windows_tray_notification::handle_system_event(const SDL_Event& event)
 	// I could not find the matching definition for 0x0200 in the headers, but this message value is received when the mouse cursor is over the tray icon.
 	// Drawback: The tray icon can still get 'stuck' if the user does not move the mouse cursor over the tray icon.
 	//	Also, accidental destruction of the tray icon can occur if the user moves the mouse cursor over the tray icon before the balloon for a single notification has expired.
-	else if (event.syswm.msg->msg.win.lParam == 0x0200 && !message_reset) {
+	else if (msg.lParam == 0x0200 && !message_reset) {
 		destroy_tray_icon();
 	}
+
+	return false;
 }
 
 bool windows_tray_notification::create_tray_icon()
@@ -171,15 +167,8 @@ void windows_tray_notification::adjust_length(std::string& title, std::string& m
 
 HWND windows_tray_notification::get_window_handle()
 {
-	SDL_SysWMinfo wmInfo;
-	SDL_VERSION(&wmInfo.version);
-	SDL_Window* window = video::get_window();
-	// SDL 1.2 keeps track of window handles internally whereas SDL 2.0 allows the caller control over which window to use
-	if (!window || SDL_GetWindowWMInfo (window, &wmInfo) != SDL_TRUE) {
-		return nullptr;
-	}
-
-	return wmInfo.info.win.window;
+	auto props = SDL_GetWindowProperties(video::get_window());
+	return static_cast<HWND>(SDL_GetPointerProperty(props, SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr));
 }
 
 void windows_tray_notification::switch_to_wesnoth_window()

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -44,6 +44,8 @@ public:
 	* window if the notification popup was clicked by user.
 	*
 	* @param msg Windows message payload.
+	*
+	* @return True if the message was handled.
 	*/
 	static bool message_hook(const MSG& msg);
 
@@ -66,7 +68,4 @@ private:
 	explicit windows_tray_notification();
 	windows_tray_notification(const windows_tray_notification& w);
 	windows_tray_notification& operator=(const windows_tray_notification& w);
-
-public:
-	static constexpr uint32_t tray_message = WM_TRAYNOTIFY;
 };

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <SDL3/SDL.h>
 #include <string>
 //forces to call Unicode winapi functions instead of ASCII (default)
 #ifndef UNICODE
@@ -44,9 +43,9 @@ public:
 	* Frees resources when a notification disappears, switches user to the wesnoth
 	* window if the notification popup was clicked by user.
 	*
-	* @param event System event.
+	* @param msg Windows message payload.
 	*/
-	static void handle_system_event(const SDL_Event& event);
+	static bool message_hook(const MSG& msg);
 
 private:
 	static NOTIFYICONDATA* nid;
@@ -67,4 +66,7 @@ private:
 	explicit windows_tray_notification();
 	windows_tray_notification(const windows_tray_notification& w);
 	windows_tray_notification& operator=(const windows_tray_notification& w);
+
+public:
+	static constexpr uint32_t tray_message = WM_TRAYNOTIFY;
 };

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -26,9 +26,9 @@
 #include "utils/general.hpp"
 #include "video.hpp"
 
-// #if defined _WIN32
-// #include "desktop/windows_tray_notification.hpp"
-// #endif
+#ifdef _WIN32
+#include "desktop/windows_tray_notification.hpp"
+#endif
 
 #include <algorithm>
 #include <cassert>
@@ -668,15 +668,6 @@ void pump()
 		}
 #endif
 
-#ifdef _WIN32
-// TODO SDL3: needs to be replaced with https://wiki.libsdl.org/SDL3/SDL_SetWindowsMessageHook
-// syswm stuff has been removed overall, so windows_tray_notification::handle_system_event is also generally invalid
-		// case SDL_SYSWMEVENT: {
-		// 	windows_tray_notification::handle_system_event(event);
-		// 	break;
-		// }
-#endif
-
 		case SDL_EVENT_QUIT: {
 			quit_confirmation::quit_to_desktop();
 			continue; // this event is already handled.
@@ -798,5 +789,23 @@ void call_in_main_thread(const std::function<void(void)>& f)
 	// Block until execution is complete in the main thread. Rethrows any exceptions.
 	fdata.finished.get_future().wait();
 }
+
+#ifdef _WIN32
+bool handle_windows_message([[maybe_unused]] void* userdata, MSG* msg)
+{
+	if(!msg) {
+		return false;
+	}
+
+	switch(msg->message) {
+	case windows_tray_notification::tray_message:
+		return windows_tray_notification::message_hook(*msg);
+
+	default:
+		// Continue further processing
+		return true;
+	}
+}
+#endif
 
 } // end events namespace

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -793,18 +793,12 @@ void call_in_main_thread(const std::function<void(void)>& f)
 #ifdef _WIN32
 bool handle_windows_message([[maybe_unused]] void* userdata, MSG* msg)
 {
-	if(!msg) {
+	if(!msg || windows_tray_notification::message_hook(*msg)) {
 		return false;
 	}
 
-	switch(msg->message) {
-	case windows_tray_notification::tray_message:
-		return windows_tray_notification::message_hook(*msg);
-
-	default:
-		// Continue further processing
-		return true;
-	}
+	// Continue further processing
+	return true;
 }
 #endif
 

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -20,6 +20,11 @@
 #include <list>
 #include <functional>
 
+#ifdef _WIN32
+// Win32 API forward declaration (full definition in WinUser.h)
+typedef struct tagMSG MSG;
+#endif
+
 //our user-defined double-click event type
 #define TIMER_EVENT (SDL_EVENT_USER + 1)
 #define HOVER_REMOVE_POPUP_EVENT (SDL_EVENT_USER + 2)
@@ -191,6 +196,23 @@ bool is_touch(const SDL_MouseMotionEvent& event);
 
 /** Discards all input events. */
 void discard_input();
+
+#ifdef _WIN32
+/**
+ * Callback passed to SDL_SetWindowsMessageHook.
+ *
+ * Handles anything which interacts with the Windows event loop.
+ * Currently, this is limited to interactions with taskbar toast
+ * notifications.
+ *
+ * @param userdata    Arbitrary userdata passed to SDL_SetWindowsMessageHook.
+ * @param msg         A pointer to a Win32 event structure to process.
+ *
+ * @returns           Whether the Windows event loop should continue
+ *                    processing this message.
+ */
+bool handle_windows_message(void* userdata, MSG* msg);
+#endif
 
 }
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1027,6 +1027,10 @@ int main(int argc, char** argv)
 		SDL_SetEventEnabled(SDL_EVENT_FINGER_UP, false);
 #endif
 
+#ifdef _WIN32
+		SDL_SetWindowsMessageHook(&events::handle_windows_message, nullptr);
+#endif
+
 		// declare this here so that it will always be at the front of the event queue.
 		events::event_context global_context;
 		const int res = do_gameloop(cmdline_opts);


### PR DESCRIPTION
Partially addresses #11262. The notifications show up as expected, but for some reason the tray icon will not disappear and the app isn't receiving any messages when hovering over or clicking the icon. Cannot tell if this is a bug in our code or SDL.