### PR TITLE
Fix and rename teleport tests involving unowned villages

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teleport/tunnel_source_teleport_unit_unowned.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teleport/tunnel_source_teleport_unit_unowned.cfg
@@ -4,16 +4,16 @@
 # API(s) being tested: [teleport][tunnel]
 ##
 # Actions:
-# Give side 1 units the ability to teleport but that has a tunnel defined that uses teleport_unit in its target
+# Give side 1 units the ability to teleport but that has a tunnel defined that requires the source village to be owned by side 1
 # Move side 1's leader to the edge of the map
-# Place a village next to side 1's leader and side 2's leader
+# Place a village under side 1's leader and one next to side 2's leader
 # Reduce side 1's leader's movement so that it can't reach side 2's leader without teleporting
 # Make side 1 be AI controlled since a decision needs to be made while playing to teleport from one village to another which can't otherwise be simulated
 ##
 # Expected end state:
-# Side 1's leader is not able to attack side 2's leader since the target village isn't owned by side 1
+# Side 1's leader isn't able to attack side 2's leader since the source village isn't owned by side 1
 #####
-{COMMON_KEEP_A_B_UNIT_TEST "tunnel_target_teleport_unit_fail" (
+{COMMON_KEEP_A_B_UNIT_TEST "tunnel_source_teleport_unit_unowned" (
     [event]
         name = start
 
@@ -28,11 +28,11 @@
                     (
                         [source]
                             terrain=*^V*
+                            formula="owner_side = teleport_unit.side_number"
                         [/source]
                     ) (
                         [target]
                             terrain=*^V*
-                            formula="owner_side = teleport_unit.side_number"
                         [/target]
                     ) (
                         [filter][/filter]
@@ -50,7 +50,8 @@
         [/move_unit]
 
         [terrain]
-            x,y=1,2
+            # The unowned village must be on the same hex as Alice, otherwise this instead tests that Alice can't move after capturing
+            x,y=1,1
             terrain=Dd^Vda
         [/terrain]
         [terrain]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teleport/tunnel_target_teleport_unit_unowned.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teleport/tunnel_target_teleport_unit_unowned.cfg
@@ -4,16 +4,16 @@
 # API(s) being tested: [teleport][tunnel]
 ##
 # Actions:
-# Give side 1 units the ability to teleport but that has a tunnel defined that requires the source village to be owned by side 1
+# Give side 1 units the ability to teleport but that has a tunnel defined that uses teleport_unit in its target
 # Move side 1's leader to the edge of the map
 # Place a village next to side 1's leader and side 2's leader
 # Reduce side 1's leader's movement so that it can't reach side 2's leader without teleporting
 # Make side 1 be AI controlled since a decision needs to be made while playing to teleport from one village to another which can't otherwise be simulated
 ##
 # Expected end state:
-# Side 1's leader isn't able to attack side 2's leader since the source village isn't owned by side 1
+# Side 1's leader is not able to attack side 2's leader since the target village isn't owned by side 1
 #####
-{COMMON_KEEP_A_B_UNIT_TEST "tunnel_source_teleport_unit_fail" (
+{COMMON_KEEP_A_B_UNIT_TEST "tunnel_target_teleport_unit_unowned" (
     [event]
         name = start
 
@@ -28,11 +28,11 @@
                     (
                         [source]
                             terrain=*^V*
-                            formula="owner_side = teleport_unit.side_number"
                         [/source]
                     ) (
                         [target]
                             terrain=*^V*
+                            formula="owner_side = teleport_unit.side_number"
                         [/target]
                     ) (
                         [filter][/filter]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -836,9 +836,9 @@
 0 teleport_no_tunnel
 0 teleport_adjacent_allies
 0 tunnel_filter_teleport_unit
-0 tunnel_target_teleport_unit_fail
+0 tunnel_target_teleport_unit_unowned
 0 tunnel_target_teleport_unit_succeed
-0 tunnel_source_teleport_unit_fail
+0 tunnel_source_teleport_unit_unowned
 0 tunnel_source_teleport_unit_succeed
 # attacks ability tests
 0 attacks_priority_high


### PR DESCRIPTION
The source_teleport test was broken, because the AI captures the source village. The test was passing because capturing exhausted its movement.

Rename because I want to reserve "fail" and "failed" in the names of tests for tests that return a non-PASS status.