### PR TITLE
Preferences: Restore display sizes in SDL3

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -762,9 +762,9 @@ std::vector<point> get_available_resolutions(const bool include_current)
 
 	const int display_index = window->get_display_index();
 
-	int modes;
-	SDL_GetFullscreenDisplayModes(display_index, &modes);
-	if(modes <= 0) {
+	int mode_count = 0;
+	SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(display_index, &mode_count);
+	if(mode_count <= 0 || !modes) {
 		PLAIN_LOG << "No modes supported";
 		return result;
 	}
@@ -775,6 +775,19 @@ std::vector<point> get_available_resolutions(const bool include_current)
 	// pop up as a display mode of its own.
 	SDL_Rect bounds;
 	SDL_GetDisplayBounds(display_index, &bounds);
+
+	for(int i = 0; i < mode_count; i++) {
+		const SDL_DisplayMode* mode = modes[i];
+		if(!mode || (mode->w > bounds.w && mode->h > bounds.h)) {
+			continue;
+		}
+
+		if(mode->w >= min_res.x && mode->h >= min_res.y) {
+			result.emplace_back(mode->w, mode->h);
+		}
+	}
+
+	SDL_free(modes);
 
 	if(!utils::contains(result, min_res)) {
 		result.push_back(min_res);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -773,17 +773,15 @@ std::vector<point> get_available_resolutions(const bool include_current)
 
 	// The maximum size to which this window can be set. For some reason this won't
 	// pop up as a display mode of its own.
-	SDL_Rect bounds;
+	rect bounds;
 	SDL_GetDisplayBounds(display_index, &bounds);
 
-	for(int i = 0; i < mode_count; i++) {
-		const SDL_DisplayMode* mode = modes[i];
-		if(!mode || (mode->w > bounds.w && mode->h > bounds.h)) {
-			continue;
-		}
+	for(SDL_DisplayMode* mode : utils::span(modes, mode_count)) {
+		assert(mode);
+		point size{mode->w, mode->h};
 
-		if(mode->w >= min_res.x && mode->h >= min_res.y) {
-			result.emplace_back(mode->w, mode->h);
+		if(min_res <= size && size <= bounds.size()) {
+			result.push_back(size);
 		}
 	}
 


### PR DESCRIPTION
Resolves #11263.

Also restores filtering by `min_res` and `bounds` as per SDL2-based implementation.

From what I understand, `SDL_free` is not necessary in the 'no modes' case, because `modes` should be `nullptr` in this case.