### PR TITLE
WoF S6: all new map

### DIFF
--- a/changelog_entries/wof-s06-new-map.md
+++ b/changelog_entries/wof-s06-new-map.md
@@ -1,0 +1,3 @@
+### Campaigns
+   * Winds of Fate
+     * S06 "Landfall": all new map of Elense Island and surrounding river delta by Dalas.

--- a/data/campaigns/Winds_of_Fate/maps/06_Landfall.map
+++ b/data/campaigns/Winds_of_Fate/maps/06_Landfall.map
@@ -1,43 +1,39 @@
-Ww, Ww, Ww, Ww, Ww, Gs, Gs^Fmf, Gs^Fp, Gs^Fmf, Gs^Fmf, Ss, Ss, Gs^Fmf, Gg, Gg, Gg, Gg, Re, Gg, Gg, Ss, Gg, Re, Gg, Gg, Ss, Ss
-Ww, Ww, Ww, Ww, Ww, Gs, Gs^Fmf, Gs^Fmf, Gs^Fmf, Gs^Fp, Ss, Ss, Gs^Fmf, Gg, Gg, Gg, Gs, Re, Gg, Gg, Ss, Gg, Re, Gg, Gs^Vh, Ss, Ss
-Ww, Ww, Ww, Ww, Ds, Ds, Gs, Gs^Fp, Gs^Fmf, Ss, Ss, Gs^Fmf, Gs^Fmf, Gg, Gg, Gg, Re, Re, Gs^Vh, Ss, Ss, Gg, Gs, Gs, Gg, Ss, Ss
-Wo, Wo, Ww, Ww, Ds, Ds, Gs, Gs, Gg, Gg, Ss, Gg, Gg, Gg, Gg, Re, Gs, Gg, Gg, Ss, Ss, Ss, Gg, Re, Re, Gg, Gg
-Wo, Wo, Ww, Ww, Ww, Ds, Gs, Gs, Ss, Ss, Gg, Ss, Ss, Gg, Ww, Re, Ww, Ww, Ww, Ss, Gg, Gg, Gg, Gs, Gs, Gg, Gg
-Wo, Wo, Wo, Ww, Ww, Gs, Gs, Gg, Ss, Ss, Gg, Gg, Ww, Ww, Ww, Ww^Bw|, Ww, Wo, Wo, Ww, Gg, Gg, Re, Re, Gg, Gg, Gg
-Wo, Wo, Wo, Ww, Ww, Gs, Gs, Gg, Gg, Ss, Ww, Ww, Wo, Wo, Ww, Ww^Bw|, Gg, Ww, Ww, Ww, Ww^Bw/, Re, Gg, Gg, Gg, Gs^Fmf, Gs^Fmf
-Wo, Wo, Wo, Ww, Ww, Ww, Gs, Gg, Gg, Ww, Wo, Wo, Ww, Ww, Ce, Re, Ce, Ww, Ww^Bw/, Ww^Bw/, Ww, Ww, Ww, Ss, Gg, Gs^Fmf, Gs^Fp
-Wo, Wo, Wo, Ww, Ww, Ww, Gs, Gs^Vh, Ww, Ww, Ww, Ww, Ds, Gg, Gs, Re, Re, Re, Gg, Ww, Ww, Wo, Wo, Ww, Ww, Ww, Ww
-Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww^Bw\, Ds, Gg, Re^Vh, Re, Gs^Fdf, Gg, Gg, Gg, Gg, Ww, Ww, Wo, Wo, Ww, Ww
-Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ds, Re, Re, Re, Re, Gs, Gs^Fdf, Gg, Gg, Gg, Gg^Fdf, Gg^Fdf, Ww, Ww, Wo, Wo
-Wo, Wo, Wo, Wo, Ww, Ww, Ww^Bw\, Ww, Gg, Ww, Ww, Ds, Gg, Gg, Gs, Re, Re^Cov, Gg, Gs, Gs, Gg, Gg, Ds, Ww, Ww, Wo, Wo
-Wo, Wo, Wo, Wo, Ww, Ww, Ds, Ds, Gg, Gg, Ww, Ww, Ce, Gg, Re^Cov, Ce, Ce, Ce, Re^Cov, Gg, Gg, Gg, Ds, Ww, Wo, Wo, Wo
-Wo, Wo, Wo, Ww, Ww, Ww, Ds, Re, Re, Re^Vh, Gg, Ww, Re, Re, Ce, Ce, 2 Ket, Ce, Ce, Gs, Gg, Ds, Ww, Ww, Ww, Ww, Ww
-Wo, Wo, Wo, Ww, Ww, Ww, Ds, Gg, Re, Re, Re, Ww^Bw/, Ce, Gs, Re^Cov, Ce, Ce, Ce, Re^Cov, Gs^Vh, Gg, Ds, Ww, Wo, Ww, Ww, Ww
-Wo, Wo, Wo, Ww, Ww, Ww, Ds, Re, Gg, Re, Gg, Ww, Gg, Gg, Gs^Vh, Ce, Re^Cov, Ce, Gs^Fdf, Gg, Gg, Ww, Wo, Ww, Gg, Gg, Gg
-Wo, Wo, Wo, Ww, Ww, Ww^Bw/, Ww, Ds, Ds, Gg, Ww, Ww, Gg^Fdf, Gg^Fdf, Gg, Gs, Gg, Re, Re, Gs, Re, Ww, Ww, Ww, Gg, Gg, Gg
-Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Gg, Ww, Ww, Ww, Gg^Fdf, Gg, Gg, Re, Re, Re^Vh, Re, Gg, Ww^Bw\, Ww^Bw\, Gg, Gg, Gg^Vh, Gg
-Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Ww^Bw/, Ds, Re, Re, Gg, Re, Gg, Gg, Ds, Ww, Ww, Re, Re, Gg, Gg
-Wo, Wo, Wo, Wo, Ww, Ww, Gs, Ww, Ww, Ww, Wo, Ww, Ww, Ds, Ds, Gg, Ce, Re, Ce, Ds, Ww, Ww, Ww, Gg, Re, Gg, Gg
-Wo, Wo, Wo, Ww, Ww, Ww, Gs, Gs, Gg, Ww, Wo, Ww, Ww, Ww, Ww, Gg, Ww, Ww^Bw|, Ww, Ww, Ww, Ww, Gg, Gg, Re, Gg, Gg
-Wo, Wo, Ww, Ww, Gs, Gs, Gs^Fdf, Gg, Gg, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww^Bw|, Ww, Ww, Gg, Gg, Gg, Gg, Re, Gg, Gg
-Wo, Wo, Ww, Ww, Gs, Gs^Fmf, Gs^Fmf, Gg, Gg, Gg, Gg^Efm, Gg, Gg, Ww, Gg, Ww, Gg, Re, Gg, Gg, Gg, Gg, Gg, Gg, Re, Gg, Gg
-Wo, Wo, Ww, Ww, Gs, Gs^Fdf, Gs^Fdf, Gg, Gg, Gg, Gg, Gg^Efm, Gg, Gg, Gg, Gg, Gg, Re, Gg, Gg, Gg, Gg, Gg, Re, Gg, Gg, Gg
-Wo, Wo, Wo, Ww, Gs, Gs, Gs, Gg, Gg, Gg, Gg, Gg, Gg^Efm, Gg, Gg^Efm, Gg, Gg, Re, Re, Gg, Gg, Gg, Gg, Re, Gg, Gs^Fmf, Gs^Fmf
-Wo, Wo, Wo, Ww, Ww, Gs, Gs, Gs, Gs^Fdf, Gs^Fdf, Gs^Fmf, Gg, Gg, Gg, Gg^Vh, Gg, Gs^Fdf, Gs^Fdf, Re, Gg, Gg, Gg, Gg, Re, Gs^Fdf, Gs^Fdf, Gs^Fdf
-Wo, Wo, Ww, Ww, Ww^Bw\, Ds, Gs, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gs^Fmf, Gg, Gs^Fdf, Gg, Gg, Gg, Gg, Gs^Fdf, Re, Gs^Fdf, Gs^Fdf, Gg^Vh, Gg, Re, Gg, Gs^Fdf, Gs^Fmf
-Wo, Wo, Ww, Ww, Ds, Ds, Gs, Gs^Vh, Gs^Fmf, Gs^Fmf, Gs^Fdf, Gs^Fmf, Gs^Fmf, Gg, Gg^Efm, Gg, Gg, Gg, Re, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gg, Re, Gg, Gg, Re^Gvs
-Wo, Wo, Ww, Ww, Ds, Re, Re, Gs^Fdf, Gs, Gs^Fmf, Gg, Gg, Re, Re, Re, Re, Re, Re, Gg, Re, Re, Re, Re, Re, Gg, Re^Gvs, Re^Gvs
-Wo, Wo, Ww, Ww, Gs, Gs, Gs, Gs^Fdf, Gs^Fdf, Gs^Fmf, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gg, Gg, Gg, Gg^Efm, Re^Gvs, Gg, Re, Gs^Fmf, Gs^Fmf, Gs^Fdf, Gs^Fmf, Gg, Gg
-Wo, Wo, Ww, Ds, Ds, Gs, Gs, Gs, Re^Gvs, Gg, Gg, Gg, Gg^Efm, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Re, Gg, Gg, Gg, Gs^Fmf, Gs^Fdf, Gs^Fmf
-Wo, Wo, Ww, Ww, Ds, Gs, Re^Gvs, Re^Gvs, Re^Gvs, Gg^Efm, Gg, Gg^Efm, Gg, Hh, Mm, Mm, Mm, Re^Gvs, Gs, Gg^Efm, Re, Gg, Gg, Gg, Gs^Fdf, Gs^Fmf, Gs^Fmf
-Wo, Wo, Wo, Ww, Ds, Gs, Re^Gvs, Re^Gvs, Gs, Mm, Hh, Gg, Gg, Hh, Hh, Mm, Hh, Mm, Gs^Vh, Gg, Re, Gg, Gg, Gg, Gs^Fdf, Gs^Fdf, Gs^Fdf
-Wo, Wo, Wo, Ww, Ww, Gs, Gs, Gs, Mm, Mm, Hh, Gs, Hh, Gs, Hh, Hh, Mm, Mm, Mm, Gg, Gg, Re, Gg, Gg, Gs^Fdw, Gs^Fdf, Gs^Fdf
-Wo, Wo, Wo, Wo, Ww, Gs, Gs, Gg^Efm, Mm, Mm, Mm, Hh, Mm, Hh, Mm, Mm, Gs, Mm, Gg, Gg, Gg^Efm, Re, Re, Gg, Gs^Fdf, Gs^Fdf, Gs^Fdf
-Wo, Wo, Ww^Vm, Ww, Ds, Gs, Gs, Gg, Mm, Gs^Vh, Gs, Gs, Mm, Mm, Gs, Mm, Mm, Gg, Re^Gvs, Gg, Gg, Gg, Re, Gg, Gg, Gs^Fdf, Gs^Fdf
-Wo, Wo, Wo, Ww, Ds, Gs, Gs, Gg, Gg, Mm, Mm, Mm, Gs, Mm, Gs, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Re, Gg, Gg, Gg, Gg
-Wo, Wo, Wo, Ww, Ww, Ds, Gs, Gs, Gg, Mm, Gg, Mm, Gg, Gg^Efm, Gg, Gg, Gg^Efm, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Re, Gg, Hh, Gg, Gg
-Wo, Wo, Wo, Wo, Ww, Ds, Gs, Gg^Efm, Gg, Gg^Efm, Gg, Gg, Gs^Fdf, Gg, Gg, Gg, Gs, Gg, Re, Gg, Gs, Re, Gs, Gs^Vh, Hh, Hh, Hh
-Wo, Wo, Wo, Wo, Ww, Ds, Gs, Gs, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gg, Gg, Gg, Gg, Gg, Gs, Gs, Ce, Ce, Ce, Re, Re, Gs^Fdf, Gs, Hh, Hh
-Ww, Ww, Ww, Ww, Ds, Ds, Gs, Gs, Gg, Gs^Fdf, Gg^Vh, Gs^Fdf, Gg, Gg, Gg, Gg, Re, Ce, Ce, 1 Ke, Ce, Ce, Re, Re, Re, Re, Re
-Ww, Ww, Ww, Ds, Gs, Gs, Gs, Gg, Gg, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gg, Gg, Gg, Gg, Gg, Re, Gs, Ce, Gs, Hh, Gg, Gg, Hh, Hh, Hh
-Ww, Ww, Ww, Ds, Gs, Gs, Gg, Gg, Gg, Gs^Fdf, Gs^Fdf, Gs^Fdf, Gg, Gg, Gg, Gg, Gg, Re, Gg, Gg, Gg, Hh, Gg, Gg, Hh, Hh, Hh
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Wwr, Wwr, Ds, Gll^Fmf, Gs^Fp, Gg^Fms, Ss, Ss, Gg^Fms, Gs, Ss, Ss, Ss, Gs, Gg, Gg, Ss, Ss, Gg, Re, Gg^Efm, Ss^Vhs, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg^Fms, Gg^Fms, Gs^Ftr, Gg^Fmf, Gs^Ftr, Ss, Ss, Gg^Fds, Gll^Fdf, Gg^Fmf, Gg, Gg^Fds, Gg^Fp, Ss, Gll^Fp
+Wo, Wo, Wo, Ww, Ww, Wwr, Ww, Wo, Wo, Ww, Wo, Ww, Ww, Ds, Ds, Ss, Ss, Gg^Fms, Ds, Sm, Ss, Ss, Gg, Ss, Gg^Vht, Gg, Gg, Gg, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Ss, Gg, Ss, Gg^Fms, Gg^Fms, Gg^Fms, Ss^Fp, Ss^Fp, Gg^Fms, Gg^Fds, Gg^Fms, Gg^Fmf, Gg^Fms, Gg^Fp, Ss^Fp, Gg^Fms
+Wo, Wo, Wo, Wo, Wo, Wwr, Wwr, Wo, Wo, Wo, Wo, Ww, Ww, Ds, Ds, Ss, Ds, Ds, Sm, Sm, Ss, Gg, Gg, Gg, Gg, Gg, Ss, Gg, Ss, Ss, Gg, Gg, Gg^Efm, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Gg^Fds, Gg^Fds, Ss, Gg, Gg, Gg^Fds, Gg^Fms, Gg, Gg^Fds, Gg^Fds, Gg^Fp, Gs^Fp, Gg^Fp, Ss, Gg^Fp, Gg^Fp, Ss, Gg, Ss
+Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Wo, Ww, Ww, Ss, Ds, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg^Efm, Gg, Gg, Gg^Efm, Gg^Efm, Ss, Ss, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Gg, Gg^Fms, Ss, Gg, Gg, Ss, Gg, Ss, Ss, Gg, Gg, Gg^Fds, Gg, Gg^Fds, Gg
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wwr, Ww, Wo, Wo, Wo, Wo, Wo, Ww, Ww^Ewsh, Ss, Ss, Ss, Ss, Cer, Ker, Cer, Ss, Ss, Ss, Ss, Ss, Ss^Fmw, Ss^Fp, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg^Fms, Gg^Vc, Gg^Fms, Gg, Hh, Ss, Ss, Ss, Gg^Fds, Gg, Ss^Fp, Ss^Fp, Gg, Gg, Gg, Gg^Fds, Gg, Gg^Fds, Gg^Ve, Gg^Fds
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Ww, Ww, Ds, Ss, Ss, Ss, Ss, Cer, Ss, Ss, Ss, Ss, Ss, Ss, Gg^Vc, Ss^Fmw, Gg, Gg, Ss, Ss, Ss, Gg, Gg, Ss, Ss, Gg^Fms, Gg^Fms, Ss^Fp, Ss, Hh, Hh, Hh, Ss, Ss, Gg^Fds, Ss, Ss, Gg^Fp, Ss, Gg^Fp, Gg^Fp, Gg^Fp, Gg^Fp, Gg^Fms, Gg^Fds
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Sm, Sm, Ss, Ss, Ss, Ss, Ss, Sm, Sm, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Ss, Ss^Fp, Ss, Gg, Hh^Es, Hh, Hh, Ss, Ss, Ss, Ss, Gg, Gg, Gg^Fds, Gg^Fds, Gg^Fp, Ss, Gg^Fds, Ss, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ss, Ss, Ww, Ss, Sm, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Hh, Hh, Hh, Hh, Sm, Hh, Sm, Ss, Sm, Ss, Ss, Ss, Ss, Gg, Ss, Gg^Fds, Ss, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ss, Ww, Sm, Ww, Sm, Sm, Ss, Ss, Ss, Ss, Ss, Gg, Ss, Ds, Gg^Vht, Gg, Gg, Ss, Ss, Ww, Ss, Sm, Sm, Ww, Sm, Sm, Ww^Ewl, Ww, Sm, Ww, Sm, Sm, Sm, Sm, Ss, Ss, Ss, Ss, Ss
+Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww^Es, Ww, Ss, Ww, Ss, Gg^Vht, Gg, Ds^Ewsh, Ds, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Sm, Sm, Ss, Sm, Ss, Ss, Ss
+Wo, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ds, Ww, Ww, Ww, Wo, Ww, Wo, Ds^Ewsh, Ss, Gg, Gg, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Sm, Ww, Sm, Sm, Ss, Sm, Sm
+Wo, Wo, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Wwr, Ww, Ds, Wwr, Gg, Ww, Ww, Ww, Ww^Bw\, Ww, Ket, Ww, Wo, Ww, Ww, Ds^Ewsh, Wo, Ww, Ww, Wo, Wo, Wo, Wo^Bw/r, Ss, Wo, Wo, Wo, Ww, Ww, Ww, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo
+Wo, Wo, Ww, Ww, Wo, Ww, Wo, Ww, Ww, Ww, Ds, Ds, Gg, Gg, Ss, Gg, Ss, Ww, Gg, Gg^Vct, Ds^Ewsh, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ds, Ww, Ww^Bw/r, Wo^Bw/r, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ds, Gg, Gg, Gg, Ds, Ss, Ss, Ds, Ds, Gg, Ds^Ewsh, Ww^Bw\, Ww, Ww, Ds, Ds, Ww, Gg^Fds, Gg^Vct, Gg, Gg, Ce, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Ww
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ds, Ds, Gg, Ds, Ss, Ss, Ds, Ds, Gg, Ds, Ww^Ewsh, Ww, Ww^Bw\, Rb, Ds^Ewsh, Gg, Gg, Rb^Gvs, Gg, Hh, Gg, Gg, Ww, Wwr, Wwr, Mm, Hh, Mm^Xm, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww^Vm, Ds, Ds, Ww, Ss, Wo, Ds, Wo, Wo, Ww, Ww, Gs^Fds, Gg, Gg^Vwm, Rb^Gvs, Rb^Gvs, Rb^Gvs, Hh, Mm, Hh, Mm, Mm, Mm, Mm, Mm, Mm, Mm, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ds^Ewsh, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Ww, Ww, Hh^Fms, Gs^Fms, Gll^Fds, Gg, Gg, Rb^Gvs, Gg, Gg, Gg, Hh, Gg^Vct, Hh, Hh, Hh, Hh, Hh, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ds, Ww, Ds^Ewsh, Wo, Wo, Wo, Wo, Wo, Ww^Bw\, Ds, Gg^Vct, Gg, Hh^Fdf, Gg, Gg, Ce, Gg^Vct, Ce, Gg^Vct, Ce, Gg, Gg, Gg^Vct, Mm, Mm, Hh, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Ww, Wo, Wo, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Ww, Ds, Ket, Ds, Gg, Gg^Vct, Ce, Ce, Ce, 2 Ket, Ce, Ce, Ce, Ce, Hh^Fdf, Hh^Fms, Gs^Fms, Ww, Ww, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ds, Ds, Ds, Ds, Gg, Gg^Fds, Ce, Ce, Ds, Ce, Ww^Bw|, Ce, Ww, Ce, Gg, Gg, Wo, Ww, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Hh, Hh, Ss, Ww, Ss, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww^Ewsh, Ww, Ww^Vm, Wo, Ds, Wo, Gg, Ww, Ww, Ww, Ww, Rb, Wo, Wo, Ww^Bw|, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Hh^Fms, Hh, Hh, Hh^Es, Ss, Hh, Hh, Hh, Ss, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Gg^Vct, Gg, Gg, Gg^Fds, Gg, Gg, Rb, Ce, Ww, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Hh^Fms, Hh, Hh^Fms, Gg^Fmf, Hh, Hh^Fms, Ss^Fds, Ss, Hh, Hh^Fms, Hh^Fms, Gg^Fds, Gg^Fds, Ww, Ww^Ewl, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Ww, Wo, Ds, Gg, Rb^Gvs, Rb^Gvs, Gg^Vct, Rb^Gvs, Gg, Gg, Ds^Ewsh, Ww^Bw\, Ww^Bw\, Wo, Wo, Wo, Wo, Ww, Ww, Gg^Fms, Gg^Fms, Gll^Fds, Ss, Ss, Ss, Ss^Fms, Ss^Fds, Ss^Fms, Ss^Fms, Hh, Hh, Gg^Fmf, Hh^Fms, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Ds^Ewsh, Ww, Ww, Wo, Wo, Ww, Wo, Ww, Wo, Ww, Wo, Wo, Wo, Ww, Wo, Ww, Ww, Ww, Ds^Ewsh, Ds^Ewsh, Ds, Ds, Ds, Ww, Ww, Ww, Ww^Ewsh, Ww, Wo^Bw\, Wo^Bw\, Wo, Ww, Ww, Ww, Hh, Gll^Fds, Gll^Fds, Ss, Ss, Cer, Ss^Fms, Hh, Hh^Fds, Hh^Fds, Hh^Es, Hh, Hh, Gg, Hh^Es, Hh, Ww, Ww, Ww, Ww, Ww, Ww, Ww
+Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ds, Ww, Wwr, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww^Bw\, Rb, Ww, Gg, Hh, Hh, Ss, Ss, Ss, Ss, Ker, Ss, Ss, Gg, Ss, Gg, Hh, Gg, Hh^Es, Hh, Hh, Hh, Ww, Ww, Ww, Ds, Ww
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ds^Ewsh, Ww, Ds, Ds, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Ww, Wo, Ww, Ww, Ww, Ww, Gg, Ss, Gg, Rb, Gg^Efm, Gg, Gg^Fds, Gg^Fms, Ss, Ss, Ss, Cer, Ss, Ss, Ss, Gg, Gg, Gg, Ss, Ss, Ss, Gg^Vht, Ss, Hh, Ss, Ds, Ss, Ds
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Wwr, Ds^Ewsh, Ds, Ds, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ss, Gg^Efm, Gg, Gg, Rb, Gg, Gg^Efm, Ss^Bw\r, Ss, Gg, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Ww, Ww, Ds^Ewsh, Ds, Gg, Ds^Vht, Gg, Ds, Ww, Ww, Ww, Gg, Ww, Ww, Ww^Ewsh, Ww, Ww, Ww^Vm, Ww, Gg, Ss^Efm, Gg^Efm, Gg, Gg, Gg, Gg, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Wo, Wo, Ww, Ds, Ds, Gg^Ewsh, Gg, Gg, Gg, Wwr, Gg^Ewsh, Gg, Ss, Sm, Sm, Ss, Gg, Gg^Efm, Gg, Ds, Gg^Efm, Gg^Fms, Ds, Gg, Gg, Gg, Gg, Ss, Gg, Ss, Gg, Gg, Gg, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Gg, Gg, Ss, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ds, Ww, Wwr, Ww, Wwr, Ww^Vm, Gg, Gg, Ss, Ss, Ss, Gg, Gg, Ss, Ds, Gg, Gg, Gg^Fds, Ds^Fds, Ds, Gg, Gg, Re^Vht, Ss, Gg^Efm, Gg, Gg, Gg, Gg, Ss^Vhs, Gg, Gg, Gg^Efm, Gg, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wwr, Wo, Ww, Wo, Ww, Ww, Wwr, Ww^Ewsh, Ss, Ww^Ewf, Ss, Ss, Gg, Ds, Ss, Ss, Ss, Ss, Ss, Gg^Vht, Ss, Gg^Fms, Gg, Gg, Gg, Ds, Ss, Ss, Gg, Gg^Efm, Ss, Ss, Gg, Gg^Efm, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Gg, Ss, Gg, Gg, Gg, Gg, Ss
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ket, Gg, Ww, Ss, Ss, Gg^Fms, Ds, Gg^Fms, Ww, Gg^Fms, Ss, Gg^Fms, Ss, Gg, Gg, Gg, Gg, Ss, Gg, Gg, Ss, Gg, Ss, Ss, Ss, Gg, Gg^Vc, Gg, Gg, Gg, Ss, Ss, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Gg^Vht, Gg, Ce, Ss
+Wo, Wo, Ww, Wo, Wo, Wo, Ww^Bw/, Gg, Gg, Ss, Gg, Gg, Ds, Gg^Fms, Gg^Fds, Gg^Fms, Gg^Fms, Gg^Fms, Gg^Fds, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Ss, Gg, Gg, Gg, Gg, Ss, Ss, Gg, Gg, Gg, Gg^Efm, Ss, Ss, Gg, Gg, Ss, Ss, Ss, Gg, Gg, Ss, Gg^Efm, Gg, Gg, Gg, Ce, Ce, Ce, Gg
+Wo, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Gg, Gg, Ds, Ds, Ds, Gg^Fms, Gg^Fds, Gg, Gg^Fms, Gg^Fms, Gg^Fds, Gs, Ds, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Ss, Gg, Ss, Gg, Ss, Ss, Ss, Ss, Gg^Efm, Gg, Gg, Gg, Gg, Gg, Gg^Efm, Gg, Ss, Ss, Ss^Vhs, Gg, Gg, Ds, Gg, Gg, Ce, Ce, 1 Ke, Ce, Ce, Gg
+Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Gg, Gg, Gg, Dd^Do, Ds, Ds, Ss, Gg^Fms, Ss, Gg^Fds, Ss, Gg^Fms, Ds^Fms, Ds, Gg^Fds, Ds, Ds, Ss, Ss, Ss, Ss, Ss^Vhs, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gg, Gg, Ss, Ss, Gg, Ss, Gg, Gg^Fds, Gg^Fms, Gg^Fds, Gg^Fds, Ce, Ce, Ce, Ce, Gg
+Ww, Ww, Wo, Wo, Ww^Vht, Ww, Ww, Ww, Gg, Gg, Gg, Ds, Ds, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gg^Fds, Gg^Fds, Gg^Fms, Gg^Fds, Gg^Fms, Gg, Gg, Ss, Ss, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Ss, Gg, Ss, Ss, Ss, Ss, Gg, Gg, Gg^Vht, Gg, Ss, Gg^Fms, Gg, Gg^Fms, Gg^Fds, Ce, Ce, Gg
+Wo, Wo, Wo, Wo, Ww, Ww^Bw\, Gg, Gg, Ds, Gg, Ds, Ds, Ds^Ewsh, Gg, Ds, Gg^Efm, Gg, Gg^Efm, Gg^Efm, Gg^Fds, Gg^Vht, Ds^Fms, Ds, Ds, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Gg, Gg, Gg, Gg^Fms, Gg
+Wo, Ww, Wwr, Ww, Ds^Ewsh, Ww, Ss, Gg, Ds, Ds, Ds^Ewsh, Ds, Ds^Ewsh, Ds^Ewsh, Ds, Gg, Gg^Fds, Ds, Ds, Gg^Efm, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Ss, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg^Vht, Gg, Gg, Gg, Gg, Gg, Gg, Ss, Ss, Ss, Ss, Gg, Gg, Gg^Fms
+Wo, Wwr, Ds, Ds, Gg, Gg, Ds, Ds, Ds^Ewsh, Ds^Ewsh, Ds, Ds, Ds, Ds^Ewsh, Ds, Gg, Gg^Fds, Gg^Fds, Gg, Gg^Efm, Gs, Gg, Gg, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Gg, Rb^Gvs, Gg, Re^Gvs, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Ss, Gg, Rb^Gvs, Gg, Rb^Gvs, Gg, Rb^Gvs, Gg, Ss, Ss, Ss, Ss, Ss, Gll^Fms

--- a/data/campaigns/Winds_of_Fate/scenarios/06_Landfall.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/06_Landfall.cfg
@@ -8,7 +8,7 @@
     turns=unlimited
     carryover_percentage=0
     {RECALL_COSTS}
-    {DEFAULT_SCHEDULE_DUSK}
+    {DEFAULT_SCHEDULE_DAWN}
     {INTRO_AND_SCENARIO_MUSIC revelation.ogg loyalists.ogg}
     {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
     {EXTRA_SCENARIO_MUSIC frantic.ogg}
@@ -46,8 +46,8 @@
             {ZEDRIX}
             placement=leader
         [/unit]
-        {UNIT 1 (Drake Arbiter)  16 38 ()}
-        {UNIT 1 (Drake Thrasher) 21 38 ()}
+        {UNIT 1 (Drake Arbiter)  53 32 ()}
+        {UNIT 1 (Drake Thrasher) 56 29 ()}
     [/side]
     {INTENDANT_PROTOCOL}
     {WOF_DEATHS}
@@ -56,8 +56,8 @@
         side=2
         controller=ai
         defeat_condition=no_units_left
-        recruit=Cavalryman, Dragoon, Horseman, Knight, Spearman, Swordsman, Bowman, Longbowman, Heavy Infantryman, Shock Trooper
-        {GOLD4 250 500 750 1000}
+        recruit=Cavalryman, Dragoon, Horseman, Knight, Spearman, Swordsman, Bowman, Longbowman, Heavy Infantryman, Shock Trooper, Merman Fighter, Merman Warrior
+        {GOLD4 300 600 800 1000}
         village_gold={ON_DIFFICULTY4    1 1 2 4}
         village_support={ON_DIFFICULTY4 0 1 2 4}
         team_name=humans
@@ -73,20 +73,18 @@
             id=Iryn
             name= _ "Iryn"
             type=Cavalier
-            x,y=21,30
+            x,y=47,29
             facing=se
         [/unit]
         # Watchtowers
-        {UNIT       2 (Bowman)  16  7 (facing=ne)} {GUARDIAN}
-        {UNIT       2 (Bowman)  14  7 (facing=nw)} {GUARDIAN}
-        {UNIT       2 (Bowman)  12 12 (facing=nw)} {GUARDIAN}
-        {UNIT       2 (Bowman)  12 14 (facing=sw)} {GUARDIAN}
-        {UNIT       2 (Bowman)  16 19 (facing=sw)} {GUARDIAN}
-        {UNIT       2 (Bowman)  18 19 (facing=se)} {GUARDIAN}
+        {UNIT       2 (Bowman)  19 18 (facing=nw)} {GUARDIAN}
+        {UNIT       2 (Bowman)  20 11 (facing=nw)} {GUARDIAN}
+        {UNIT       2 (Bowman)  29 21 (facing=sw)} {GUARDIAN}
+        {UNIT       2 (Bowman)  30 13 (facing=sw)} {GUARDIAN}
         # Navy
-        {NAMED_UNIT 2 (Caravel) 10  8 "King Haldric" _"King Haldric" (facing=sw)}
-        {NAMED_UNIT 2 (Caravel) 11 19 "Queen Jessene" _"Queen Jessene" (facing=nw)}
-        {NAMED_UNIT 2 (Caravel)  3 26 "Lance of Ladoc" _"Lance of Ladoc" (facing=sw)}
+        {NAMED_UNIT 2 (Caravel)  5 33 "King Haldric" _"King Haldric" (facing=sw)}
+        {NAMED_UNIT 2 (Caravel) 16 16 "Queen Jessene" _"Queen Jessene" (facing=nw)}
+        {NAMED_UNIT 2 (Caravel) 17 11 "Lance of Ladoc" _"Lance of Ladoc" (facing=sw)}
         [ai]
             passive_leader=yes # So he does not get himself killed.
         [/ai]
@@ -96,17 +94,13 @@
     [side]
         side=3
         controller=ai
-        recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider
-        income=20
+        recruit=Drake Burner, Drake Fighter, Drake Glider
         village_gold={ON_DIFFICULTY4    1 1 2 4}
         village_support={ON_DIFFICULTY4 0 1 2 4}
         team_name=hero
         user_team_name= _ "Reinforcements"
         side_name= _ "Reinforcements"
         {FLAG_VARIANT long}
-        [ai]
-            aggression=0.75
-        [/ai]
     [/side]
 
     [event]
@@ -115,12 +109,12 @@
         # Place the beacon brazier.
         [terrain]
             terrain=^Eb
-            x,y=14,41
+            x,y=57,30
             layer=overlay
         [/terrain]
         [objectives]
             [objective]
-                description= _ "Kill all the humans"
+                description= _ "Kill all prey"
                 condition=win
             [/objective]
             [objective]
@@ -160,7 +154,7 @@ Saurians attacking from the north
             [/note]
         [/objectives]
         # Prepare for starting dialogue.
-        {TELEPORT_UNIT id=Resha 25 36}
+        {TELEPORT_UNIT id=Resha 42 37}
     [/event]
 
     [event]
@@ -173,18 +167,18 @@ Saurians attacking from the north
         [/delay]
         [move_unit]
             id=Resha
-            to_x,to_y=19,38
+            to_x,to_y=52,33
         [/move_unit]
         [message]
             speaker=Resha
-            image_pos=right
-            mirror=yes
             message= _ "Gorlack, you have made landfall!
 
 Within sight of these humans!"
         [/message]
         [message]
             speaker=Gorlack
+            image_pos=right
+            mirror=yes
             message= _ "You have returned from patrol with fortunate timing, Resha.
 These creatures are to be our prey.
 I shall grant you the details at the keep.
@@ -193,14 +187,14 @@ Fall in."
         [/message]
         [message]
             speaker=Resha
-            image_pos=right
-            mirror=yes
             message= _ "Gorlack, this is terribly unwise!
 
 The full ability of the humans is still unknown to us."
         [/message]
         [message]
             speaker=Gorlack
+            image_pos=right
+            mirror=yes
             message= _ "We have no choice, we need the meat.
 
 When I give you the signal, light the beacon.
@@ -214,7 +208,7 @@ It will call in our reinforcements."
         [/delay]
         [move_unit]
             id=Iryn
-            to_x,to_y=17,15
+            to_x,to_y=27,21
         [/move_unit]
         [scroll_to_unit]
             id=Vorlyan
@@ -287,7 +281,7 @@ It will call in our reinforcements."
         [/message]
         [move_unit]
             id=Iryn
-            to_x,to_y=25,20
+            to_x,to_y=31,1
         [/move_unit]
         [kill]
             id=Iryn
@@ -340,15 +334,15 @@ It will call in our reinforcements."
             [/have_location]
         [/filter_condition]
         # Karron’s Wing
-        {UNIT 3 (Sky Drake)      2 11 (facing=se)}
-        {UNIT 3 (Fire Drake)     3 12 (facing=se)}
-        {UNIT 3 (Drake Warrior)  4 12 (facing=se)}
+        {UNIT 3 (Sky Drake)      4 3 (facing=se)}
+        {UNIT 3 (Fire Drake)     4 4 (facing=se)}
+        {UNIT 3 (Drake Warrior)  4 5 (facing=se)}
         [unit]
             {KARRON (Drake Blademaster)}
             side=3
             facing=se
             canrecruit=yes
-            x,y=4,13
+            x,y=4,6
         [/unit]
         [unit]
             type=Hurricane Drake
@@ -359,7 +353,7 @@ It will call in our reinforcements."
                 {TRAIT_LOYAL}
             [/modifications]
             facing=se
-            x,y=3,13
+            x,y=2,5
         [/unit]
         [unit]
             type=Drake Flameheart
@@ -370,22 +364,22 @@ It will call in our reinforcements."
                 {TRAIT_LOYAL}
             [/modifications]
             facing=se
-            x,y=3,14
+            x,y=3,6
         [/unit]
-        {UNIT 3 (Drake Warrior)  4 14 (facing=se)}
-        {UNIT 3 (Fire Drake)     3 15 (facing=se)}
-        {UNIT 3 (Sky Drake)      2 15 (facing=se)}
+        {UNIT 3 (Drake Warrior)  3 7 (facing=se)}
+        {UNIT 3 (Fire Drake)     2 7 (facing=se)}
+        {UNIT 3 (Sky Drake)      1 8 (facing=se)}
         # Arinexis’ Avengers
         # NE
-        {UNIT 3 (Dragonfly)          25  1 (facing=s)}
-        {UNIT 3 (Dragonfly)          25  2 (facing=s)}
-        {UNIT 3 (Saurian Oracle)     20  1 (facing=s)}
-        {UNIT 3 (Saurian Skirmisher) 19  2 (facing=s)}
-        {UNIT 3 (Water Serpent)      20  2 (facing=s)}
+        {UNIT 3 (Dragonfly)          41  1 (facing=s)}
+        {UNIT 3 (Dragonfly)          44  1 (facing=s)}
+        {UNIT 3 (Saurian Oracle)     39  1 (facing=s)}
+        {UNIT 3 (Saurian Skirmisher) 37  1 (facing=s)}
+        {UNIT 3 (Water Serpent)      35  1 (facing=s)}
         # NW
-        {UNIT 3 (Swamp Lizard)        9  2 (facing=s)}
-        {UNIT 3 (Saurian Augur)      10  1 (facing=s)}
-        {UNIT 3 (Saurian Ambusher)   11  1 (facing=s)}
+        {UNIT 3 (Swamp Lizard)       29  1 (facing=s)}
+        {UNIT 3 (Saurian Augur)      28  1 (facing=s)}
+        {UNIT 3 (Saurian Ambusher)   30  1 (facing=s)}
         [scroll_to_unit]
             id=Karron
         [/scroll_to_unit]


### PR DESCRIPTION
With the scenario heavily reworked to fit.

As requested by @Dalas this map is updated to match the terrain of the elense isle map in the newly reworked campaigns. However, since these take place 500 years later in the timeline, this version has been "de-aged" with vast not yet drained swamp lands to resemble the "Lizard Beach" map from TRoW (which has important story connections to this scenario in WoF).

Closes #10712