### PR TITLE
wmllint: remove speaker and id checks

### DIFF
--- a/data/ai/micro_ais/scenarios/The_Elves_Besieged.cfg
+++ b/data/ai/micro_ais/scenarios/The_Elves_Besieged.cfg
@@ -26,8 +26,6 @@
     {STARTING_VILLAGES_AREA 5 26 31 5}
     {STARTING_VILLAGES_AREA 5 29 46 1}
 
-    # wmllint: recognize Kalenz
-
     [side]
         type=Spearman
         id=Konrad

--- a/data/campaigns/Dead_Water/scenarios/01_Invasion.cfg
+++ b/data/campaigns/Dead_Water/scenarios/01_Invasion.cfg
@@ -72,7 +72,6 @@
     {TURNS4 32 30 28 26}
 
     [side]
-        # wmllint: who SIDE_1 is Kai Krellis
         {SIDE_1}
         {GOLD4 110 120 120 130}
     [/side]

--- a/data/campaigns/Dead_Water/scenarios/02_Flight.cfg
+++ b/data/campaigns/Dead_Water/scenarios/02_Flight.cfg
@@ -71,7 +71,6 @@
             append=yes
         [/music]
 
-        # wmllint: who RECALL_LOYAL_UNITS is Cylanna, Gwabbo
         {RECALL_LOYAL_UNITS}
 
         [objectives]

--- a/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
+++ b/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
@@ -56,7 +56,6 @@
             append=yes
         [/music]
 
-        # wmllint: who RECALL_LOYAL_UNITS is Friendly Bat, Undead Bat, Fearsome Bat
         {RECALL_LOYAL_UNITS}
 
         [objectives]

--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -56,7 +56,6 @@
             append=yes
         [/music]
 
-        # wmllint: who RECALL_LOYAL_UNITS is Teeloa, Keshan
         {RECALL_LOYAL_UNITS}
 
         [objectives]

--- a/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
+++ b/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
@@ -98,7 +98,6 @@
             name=knalgan_theme.ogg
         [/music]
 
-        # wmllint: who RECALL_LOYAL_UNITS is Inky
         {RECALL_LOYAL_UNITS}
 
         [objectives]

--- a/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
+++ b/data/campaigns/Dead_Water/scenarios/12_Revenge.cfg
@@ -451,7 +451,6 @@
 
         # ...and:
         [unhide_unit][/unhide_unit]
-        # wmllint: who RECALL_LOYAL_UNITS is Tyegea
         {RECALL_LOYAL_UNITS}
 
         [clear_variable]

--- a/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Dead_Water/scenarios/13_Epilogue.cfg
@@ -23,7 +23,6 @@
         [/music]
 
         {RECALL_LOYAL_UNITS}
-        # wmllint: unwho ALL
     [/event]
 
     [event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
@@ -80,7 +80,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=nw
@@ -144,7 +143,6 @@
         {UNIT 3 (Spearman) 7 13 ()}
 
         [unit]
-            # wmllint: recognize Dela Keshar
             {CHARACTER_STATS_DELA_KESHAR}
             ai_special=guardian
             x,y=4,17

--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -38,7 +38,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         fog=yes
@@ -49,7 +48,6 @@
             x,y=15,12
             facing=nw
 
-            # wmllint: recognize Darken Volk
             {CHARACTER_STATS_DARKEN_VOLK}
         [/unit]
     [/side]
@@ -378,11 +376,9 @@
 
             # Make sure the guards actually exist, in case there was no space for them
             [have_unit]
-                # wmllint: recognize guard_$x1|_$y1|_1
                 id=guard_$x1|_$y1|_1
             [/have_unit]
             [have_unit]
-                # wmllint: recognize guard_$x1|_$y1|_2
                 id=guard_$x1|_$y1|_2
             [/have_unit]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -46,7 +46,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         shroud=yes
@@ -197,7 +196,6 @@
         [/unit]
 
         # Non-strong one:
-        # wmllint: recognize YOgre2
         [while]
             [not]
                 [have_unit]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
@@ -38,7 +38,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=nw

--- a/data/campaigns/Descent_Into_Darkness/scenarios/05_Schism.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/05_Schism.cfg
@@ -50,7 +50,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=sw

--- a/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
@@ -43,7 +43,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=sw
@@ -123,7 +122,6 @@
         {FLAG_VARIANT loyalist}
         color=green
 
-        # wmllint: recognize Dela Keshar
         {CHARACTER_STATS_DELA_KESHAR}
 
         facing=ne

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
@@ -125,7 +125,6 @@
         village_gold=2
         village_support=1
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         fog=yes

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -33,7 +33,6 @@
 
         income=-2
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         shroud=yes

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -27,7 +27,6 @@
 
         income=-2
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         shroud=yes

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -43,7 +43,6 @@
         village_gold=2
         village_support=1
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=ne
@@ -574,7 +573,6 @@
     # Jaime is spawned by an easter egg in 07a_A_Small_Favor.
     # Jaime may be on the recall list for this scenario if the egg was triggered and if Jaime survives 07a, 07b and 07c.
     # I assume that in this case the scenario author intentionally counts on the player manually recalling Jaime instead of using [recall].
-    # wmllint: recognize Jaime
     [event]
         name=moveto
         [filter]
@@ -722,7 +720,6 @@
             moves=0
             facing=sw
 
-            # wmllint: recognize Dela Keshar
             {CHARACTER_STATS_DELA_KESHAR}
         [/unit]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
@@ -71,7 +71,6 @@
 
         income=-2
 
-        # wmllint: recognize Malin Keshar
         {CHARACTER_STATS_MALIN_KESHAR}
 
         facing=ne
@@ -1689,7 +1688,6 @@
             facing=se
             animate=yes
 
-            # wmllint: recognize Mal Keshar
             {CHARACTER_STATS_MAL_KESHAR}
         [/unit]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -123,7 +123,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Mal Keshar
         {CHARACTER_STATS_MAL_KESHAR}
 
         facing=ne

--- a/data/campaigns/Descent_Into_Darkness/scenarios/11_Squidville.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/11_Squidville.cfg
@@ -26,7 +26,6 @@
         {FLAG_VARIANT undead}
         color=darkblue
 
-        # wmllint: recognize Mal Keshar
         {CHARACTER_STATS_MAL_KESHAR}
 
         facing=ne

--- a/data/campaigns/Dusk_of_Dawn/scenarios/01_First_Steps.cfg
+++ b/data/campaigns/Dusk_of_Dawn/scenarios/01_First_Steps.cfg
@@ -50,7 +50,6 @@
         shroud=yes
         fog=yes
 
-        # wmllint: recognize Ougl
         {CHARACTER_STATS_OUGL}
 
         facing=se

--- a/data/campaigns/Dusk_of_Dawn/scenarios/02_A_Dream.cfg
+++ b/data/campaigns/Dusk_of_Dawn/scenarios/02_A_Dream.cfg
@@ -44,7 +44,6 @@
         {FLAG_VARIANT6 ragged}
         shroud=yes
 
-        # wmllint: recognize Ougl
         {CHARACTER_STATS_OUGL}
 
         facing=sw

--- a/data/campaigns/Dusk_of_Dawn/scenarios/03_Fateful_Day.cfg
+++ b/data/campaigns/Dusk_of_Dawn/scenarios/03_Fateful_Day.cfg
@@ -68,7 +68,6 @@
         user_team_name= _ "Golden Flame Tribe"
         {FLAG_VARIANT6 ragged}
 
-        # wmllint: recognize Ougl
         {CHARACTER_STATS_OUGL}
 
         facing=nw

--- a/data/campaigns/Dusk_of_Dawn/scenarios/04_A_Beautiful_World.cfg
+++ b/data/campaigns/Dusk_of_Dawn/scenarios/04_A_Beautiful_World.cfg
@@ -42,7 +42,6 @@
         {FLAG_VARIANT6 ragged}
         shroud=yes
 
-        # wmllint: recognize Ougl
         {CHARACTER_STATS_OUGL}
 
         facing=nw

--- a/data/campaigns/Dusk_of_Dawn/scenarios/Secret.cfg
+++ b/data/campaigns/Dusk_of_Dawn/scenarios/Secret.cfg
@@ -45,7 +45,6 @@
         user_team_name= _ "Golden Flame Tribe"
         {FLAG_VARIANT6 ragged}
 
-        # wmllint: recognize Ougl
         {CHARACTER_STATS_OUGL}
 
         facing=se

--- a/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
@@ -85,7 +85,6 @@
         [unit]
             x,y=10,14
             facing=se
-            # wmllint: recognize Dacyn
             {CHARACTER_STATS_DACYN}
         [/unit]
     [/side]

--- a/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
@@ -41,7 +41,6 @@
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
     {STARTING_VILLAGES_AREA 1 29-99 13-99 0}

--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -27,7 +27,6 @@
         team_name=good
         user_team_name=_"Wesnothians"
         {FLAG_VARIANT loyalist}
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 
@@ -189,7 +188,7 @@
     #--------------------
     [side]
         side=7
-        {CHARACTER_STATS_RAVANAL} # wmllint: recognize Mal-Ravanal
+        {CHARACTER_STATS_RAVANAL}
         recruit=Spectre,Wraith
         gold=-2
         income=-2

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -64,7 +64,6 @@
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 
@@ -80,7 +79,6 @@
         team_name=good
         user_team_name= _ "Wesnothians"
 
-        # wmllint: recognize Owaec
         {CHARACTER_STATS_OWAEC}
         canrecruit=yes # manual canrecruit flag here is deliberate
         facing=sw

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -32,7 +32,6 @@
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -36,7 +36,6 @@
         user_team_name=_"Wesnothians"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
     {STARTING_VILLAGES 1 4}

--- a/data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg
@@ -30,7 +30,6 @@
 
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -28,7 +28,6 @@
         team_name=good
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -45,7 +45,6 @@
         team_name=good
         user_team_name= _ "Wesnothians"
         {FLAG_VARIANT loyalist}
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -60,7 +60,6 @@
         fog=yes
         gold=0 # see notes in S09_Castle_In_The_Ice
         {FLAG_VARIANT loyalist}
-        # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
@@ -465,7 +465,6 @@
         {FLAG_VARIANT undead}
     [/side]
 
-    # wmllint: recognize Mal-Ravanal
     [event]
         name=prestart
         {VARIABLE fork_18b yes}

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/01_The_Elves_Besieged.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/01_The_Elves_Besieged.cfg
@@ -63,8 +63,6 @@
     {STARTING_VILLAGES_AREA 5 26 31 5}
     {STARTING_VILLAGES_AREA 5 29 46 1}
 
-    # wmllint: recognize Kalenz
-
     [side]
         type=Fighter
         id=Konrad

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/03_The_Isle_of_Alduin.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/03_The_Isle_of_Alduin.cfg
@@ -64,8 +64,6 @@
         {FLAG_VARIANT long}
     [/side]
 
-    # wmllint: recognize Delfador
-
     [side]
         type=Orcish Warrior
         id="Usadar Q'kai"

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/05b_Isle_of_the_Damned.cfg
@@ -195,8 +195,6 @@
 
         {NAMED_LOYAL_UNIT 1 (Merman Fighter) 27 12 (Kalba) ( _ "Kalba")}
         {NAMED_LOYAL_UNIT 1 (Merman Fighter) 31 14 (Gnaba) ( _ "Gnaba")}
-        # wmllint: recognize Kalba
-        # wmllint: recognize Gnaba
     [/event]
 
     [event]
@@ -228,7 +226,6 @@
                 {TRAIT_INTELLIGENT}
             [/modifications]
         [/unit]
-        # wmllint: recognize Delurin
 
         [redraw]
             side=1

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -60,8 +60,6 @@
         {FLAG_VARIANT long}
     [/side]
 
-    # wmllint: recognize Delfador
-
     [side]
         type=Orcish Warlord
         id=Agadla

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/10_Gryphon_Mountain.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/10_Gryphon_Mountain.cfg
@@ -126,9 +126,6 @@
         {NAMED_LOYAL_UNIT 3 (Sleeping Gryphon) 12 18 (Graak) ( _ "Graak")}
         {NAMED_LOYAL_UNIT 3 (Sleeping Gryphon) 16 16 (Grook) ( _ "Grook")}
         {NAMED_LOYAL_UNIT 3 (Sleeping Gryphon) 10 14 (Gruak) ( _ "Gruak")}
-        # wmllint: recognize Rampant Graak
-        # wmllint: recognize Rampant Grook
-        # wmllint: recognize Rampant Gruak
 
         {VARIABLE gryphon_disposition 1}
     [/event]

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/13_The_Dwarven_Doors.cfg
@@ -371,7 +371,6 @@ end
         [/filter]
         [filter_second]
             side=1
-            # wmllint: recognize Simyr
             id=Haldiel,Simyr
             [or]
                 type=Paladin

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/17_Scepter_of_Fire.cfg
@@ -239,8 +239,6 @@
     {UNDERGROUND_VOLCANO -32 -42 -42}
     {UNDERGROUND_VOLCANO -28 -38 -38}
 
-    # wmllint: recognize Konrad
-
     {SCENARIO_MUSIC "the_deep_path.ogg"}
     {EXTRA_SCENARIO_MUSIC "knalgan_theme.ogg"}
     {EXTRA_SCENARIO_MUSIC "heroes_rite.ogg"}

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/22_Return_to_Wesnoth.cfg
@@ -70,10 +70,6 @@
                     [scroll_to]
                         x,y=1,1
                     [/scroll_to]
-                    # wmllint: recognize Kalenz
-                    # wmllint: recognize Delfador
-                    # wmllint: recognize Konrad
-                    # wmllint: recognize Li'sar
                     [message]
                         speaker=Kalenz
                         scroll=no

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/01_The_Uprooting.cfg
@@ -79,7 +79,6 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
     [side]
         side=1
         {PLAYABLE}
-        # wmllint: who KALENZ_YOUNG is Kalenz
         {KALENZ_YOUNG}
         save_id=Kalenz
         x=16
@@ -87,13 +86,11 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
 
 #ifndef MULTIPLAYER
         [unit]
-            # wmllint: who LANDAR_YOUNG is Landar
             {LANDAR_YOUNG}
             x=18
             y=15
         [/unit]
         [unit]
-            # wmllint: who ARKILDUR is Arkildur
             {ARKILDUR}
             x=19
             y=16
@@ -104,7 +101,6 @@ This is the story of Kalenz, Landar, and of the elves in the first days of the h
         {MULTIPLAYER_GOLD}
 #endif
         [unit]
-            # wmllint: who ANDUILAS is Anduilas
             {ANDUILAS}
             x=15
             y=16

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/02_Hostile_Mountains.cfg
@@ -87,7 +87,6 @@
 #enddef
 
     [side]
-        # wmllint: who OLURF is Olurf
         {OLURF}
         side=3
         allow_player=no

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -138,8 +138,6 @@
             x=24
             y=21
         [/unit]
-        # wmllint: recognize Eradion
-        # wmllint: recognize Galtrid
     [/side]
 
     {MP_SIDE 4 (
@@ -233,7 +231,6 @@
     [/event]
 #endif
 
-    # wmllint: recognize Urudin
     [event]
         name=last breath
         [filter]
@@ -319,7 +316,6 @@
         [/ai]
     [/side]
 
-    # wmllint: recognize Mutaf-uru
     [event]
         name=last breath
         [filter]
@@ -559,7 +555,6 @@
 
                 # if fog is gone (thus, Kalenz is here), then do not wait
                 [if]
-                    # wmllint: recognize Kalenz
                     [have_unit]
                         id=Kalenz
                         side=1
@@ -1160,5 +1155,3 @@
 #undef ORC_BATTLEFIELD_EVALUATION
 #undef ORC_BATTLEFIELD_EVALUATION_SUCCESS
 #undef ORC_BATTLEFIELD_EVALUATION_FAILURE
-# wmllint: unwho KALENZ_YOUNG
-# wmllint: unwho LANDAR_YOUNG

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/04_The_Elvish_Treasury.cfg
@@ -58,7 +58,6 @@ Chapter Two"
 
     [side]
         side=1
-        # wmllint: who KALENZ is Kalenz
         {KALENZ}
         {PLAYABLE}
         save_id=Kalenz
@@ -66,7 +65,6 @@ Chapter Two"
         {PLAYER_GOLD}
 #ifndef MULTIPLAYER
         [unit]
-            # wmllint: who LANDAR is Landar
             {LANDAR}
             x=16
             y=29
@@ -191,7 +189,6 @@ Chapter Two"
             scenario_id = LoW_Chapter_One
         [/persistent_carryover_unstore]
 #endif
-        # wmllint: who RECALL_LOYALS is Huraldur
         #{RECALL_LOYALS}
         # Kalenz's pals
         [recall]
@@ -286,7 +283,6 @@ Chapter Two"
         {INCIDENTAL_MUSIC love_theme.ogg}
 
         [unit]
-            # wmllint: who CLEODIL is Cleodil
             {CLEODIL}
 #ifdef MULTIPLAYER
             side=3

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
@@ -141,7 +141,6 @@
 #endif
 
         [unit]
-            # wmllint: recognize Galtrid
             {GALTRID}
             x=33
             y=32
@@ -149,13 +148,11 @@
 
 #ifndef MULTIPLAYER
         [unit]
-            # wmllint: recognize El_Isomithir
             {EL_ISOMITHIR}
             x=29
             y=32
         [/unit]
         [unit]
-            # wmllint: recognize Eradion
             {ERADION}
             x=7
             y=36

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -222,11 +222,6 @@ Chapter Three"
     [event]
         name=start
 
-        # wmllint: recognize Arkildur
-        # wmllint: recognize Tameril-Isimeril
-        # wmllint: recognize Laril
-        # wmllint: recognize Anduilas
-
         [command]
 #ifdef MULTIPLAYER
             [persistent_carryover_unstore]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -69,7 +69,6 @@ Chapter Four"
         disallow_shuffle=yes
 
         {KALENZ}
-        # wmllint: recognize Kalenz
         x=25
         y=11
 
@@ -220,7 +219,6 @@ Chapter Four"
 #endif
 
         [unit]
-            # wmllint: recognize Galtrid
             {GALTRID}
             x=15
             y=12
@@ -228,14 +226,12 @@ Chapter Four"
 
 #ifndef MULTIPLAYER
         [unit]
-            # wmllint: recognize El_Isomithir
             {EL_ISOMITHIR}
             x=13
             y=15
         [/unit]
 
         [unit]
-            # wmllint: recognize Eradion
             {ERADION}
             x=15
             y=15

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/17_Breaking_the_Siege.cfg
@@ -423,7 +423,6 @@
 #endif
     [/event]
 
-    # wmllint: unwho "{OLURF}"
     {campaigns/Legend_of_Wesmere/utils/deaths.cfg}
 [/scenario]
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/21_Elvish_Assassins.cfg
@@ -4,7 +4,6 @@
 
     [goal]
         [criteria]
-            # wmllint: recognize Kalenz
             id=Kalenz
         [/criteria]
         value=200

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/22_Northern_Battle.cfg
@@ -74,7 +74,6 @@
                     id=Kalenz
                 [/not]
                 [not]
-                    # wmllint: recognize Anduilas
                     id=Anduilas
                 [/not]
                 [not]
@@ -125,7 +124,6 @@
         [/recall]
     [/event]
 
-    # wmllint: recognize Uradredia
     [event]
         name=scenario_end
         [filter_condition]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter5/23_End_of_War.cfg
@@ -220,6 +220,5 @@
         [/endlevel]
     [/event]
 
-    # wmllint: unwho ALL
     {campaigns/Legend_of_Wesmere/utils/deaths.cfg}
 [/scenario]

--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -223,8 +223,6 @@ Months... seven months it’s been since the Crown did send a single guard here 
         {DALLBEN_PEASANT Thug_Peasant 7 30 Teneor ( _ "Teneor")}
         {DALLBEN_PEASANT Poacher_Peasant 5 28 Kembe ( _ "Kembe")}
         {DALLBEN_PEASANT Poacher_Peasant 5 30 Treagh ( _ "Treagh")}
-        # wmllint: recognize Red
-        # wmllint: recognize Kembe
 
         [unit]
             type=Footpad_Peasant
@@ -503,8 +501,6 @@ Months... seven months it’s been since the Crown did send a single guard here 
 
         {DALLBEN_PEASANT Thug_Peasant 12 2 Remald ( _ "Remald")}
         {DALLBEN_PEASANT Thug_Peasant 10 2 Wolmas ( _ "Wolmas")}
-        # wmllint: recognize Remald
-        # wmllint: recognize Wolmas
 
         {IF_VAR unit.side equals 1 (
             [then]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -100,7 +100,6 @@
         user_team_name= _ "Rebels"
         {FLAG_VARIANT6 ragged}
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         [unit]

--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -51,7 +51,6 @@
         user_team_name= _ "Rebels"
         {FLAG_VARIANT6 ragged}
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         shroud=yes
@@ -352,7 +351,6 @@
             side=1
             x,y=1,1
 
-            # wmllint: recognize Camerin
             {CHARACTER_STATS_CAMERIN}
         [/unit]
 
@@ -1110,7 +1108,6 @@
                     side=1
                     x,y=6,11
 
-                    # wmllint: recognize Camerin
                     {CHARACTER_STATS_CAMERIN}
                 [/unit]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
@@ -26,7 +26,6 @@
         user_team_name= _ "Rebels"
         # Use stock flags, Tallin's troops are ceasing to be ragged
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         facing=sw

--- a/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
@@ -31,7 +31,6 @@
         user_team_name= _ "Rebels"
         # Use stock flags, Tallin’s troops are ceasing to be ragged
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         # Since in last scenario Hamel was AI controlled we need to place him again to have him in this and future scenarios

--- a/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/04_Clearing_the_Mines.cfg
@@ -27,7 +27,6 @@
         team_name=alliance
         user_team_name= _ "Alliance"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -30,7 +30,6 @@
         team_name=rebels
         user_team_name= _ "Alliance"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         shroud=yes
@@ -527,7 +526,6 @@
             side=1
             x,y=9,32
 
-            # wmllint: recognize Father Morvin
             {CHARACTER_STATS_FATHER_MORVIN}
         [/unit]
 
@@ -544,7 +542,6 @@
         # If he was freed after sister Thera, there is no need to repeat the exposition
         [if]
             [have_unit]
-                # wmllint: recognize Sister Thera
                 id="Sister Thera"
             [/have_unit]
             [then]
@@ -644,7 +641,6 @@
             side=1
             x,y=6,29
 
-            # wmllint: recognize Sister Thera
             {CHARACTER_STATS_SISTER_THERA}
         [/unit]
 
@@ -827,7 +823,6 @@
             x,y=4,39
             hitpoints=1
 
-            # wmllint: recognize Elenia
             {CHARACTER_STATS_ELENIA}
         [/unit]
 
@@ -1018,7 +1013,6 @@
             side=1
             x,y=8,38
 
-            # wmllint: recognize Krash
             {CHARACTER_STATS_KRASH}
         [/unit]
 
@@ -1293,7 +1287,6 @@
         first_time_only=yes
         [filter]
             side=1
-            # wmllint: recognize Abhai
             id=Abhai
             x,y=9,15
         [/filter]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
@@ -35,7 +35,6 @@
         team_name=rebels
         user_team_name= _ "Rebels"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         facing=sw

--- a/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
@@ -41,7 +41,6 @@
         team_name=knalgans
         user_team_name= _ "Knalgans"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 
@@ -56,7 +55,6 @@
         user_team_name= _ "Orcs"
         {FLAG_VARIANT6 ragged}
 
-        # wmllint: recognize Rakshas
         {CHARACTER_STATS_RAKSHAS}
 
         [ai]

--- a/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
@@ -125,7 +125,6 @@
         team_name=knalgans
         user_team_name= _ "Knalgans"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         fog=yes

--- a/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
@@ -96,7 +96,6 @@
         team_name=knalgans
         user_team_name= _ "Knalgans"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
@@ -26,7 +26,6 @@
         team_name=knalgans
         user_team_name=_ "Knalgans"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
 
         shroud=yes

--- a/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/10a_Stolen_Gold.cfg
@@ -22,7 +22,6 @@
 
     # Story with few branches depending on whether Eryssa is alive and hostile
     # towards the Alliance.
-    # wmllint: recognize Eryssa
     [story]
         [part]
             story= _ "Puzzled by the presence of trolls so close to the dwarvish defenses, the party quickly made their way back to Knalga."
@@ -159,7 +158,6 @@
         team_name=alliance
         user_team_name= _ "Alliance"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/11a_The_Eastern_Flank.cfg
@@ -35,7 +35,6 @@
         team_name=knalgans
         user_team_name= _ "Alliance"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
@@ -118,7 +118,6 @@
         team_name=knalgans
         user_team_name= _ "Alliance"
 
-        # wmllint: recognize Tallin
         {CHARACTER_STATS_TALLIN}
     [/side]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -104,7 +104,6 @@
                 [show_if]
                     [not]
                         [have_unit]
-                            # wmllint: recognize Krawg
                             id=Krawg
                         [/have_unit]
                     [/not]
@@ -119,7 +118,6 @@
                     [/have_unit]
                     [not]
                         [have_unit]
-                            # wmllint: recognize Thursagan
                             id=Thursagan
                         [/have_unit]
                     [/not]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -302,8 +302,6 @@
 
     {SOF_DEATHS}
 
-    # wmllint: recognize Rugnur
-
     {STARTING_VILLAGES 1 5}
     {STARTING_VILLAGES 2 8}
     {STARTING_VILLAGES 3 8}
@@ -321,8 +319,6 @@
         name=prestart
 
         # Alanin and Krawg are taking a break
-        # wmllint: recognize Alanin
-        # wmllint: recognize Krawg
 
         [store_unit]
             [filter]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -223,7 +223,6 @@
                 condition=lose
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Krawg
                         id=Krawg
                     [/have_unit]
                 [/show_if]
@@ -233,7 +232,6 @@
                 condition=lose
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Thursagan
                         id=Thursagan
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -135,7 +135,6 @@
                 [show_if]
                     {VARIABLE_CONDITIONAL found_forge boolean_equals no}
                     [have_unit]
-                        # wmllint: recognize Thursagan
                         id=Thursagan
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
@@ -112,7 +112,6 @@ With further observation, I have determined that this is probably not the way to
     {ZOMBIE_INIT}
 
     [side]
-        # wmllint: who SIDE_1_ARDONNA is Ardonna
         {SIDE_1_ARDONNA}
         {ARDONNA_RECRUIT_1}
         facing=se

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -220,7 +220,6 @@ I decided to hide in the cemetery. That way I could try my experiment to animate
         [/modifications]
     [/unit]
 #enddef
-    # wmllint: whofield PLACE_GUARD 6
 
     # *************************** PRESTART ***************************
     [event]
@@ -623,7 +622,6 @@ of Healing"
         name=location
     [/clear_variable]
 #enddef
-    # wmllint: whofield MOVE_AND_PLACE_GUARD 3
 
     [event]
         name=guards_emerge
@@ -939,7 +937,6 @@ Well, I might as well do my experiment and worry about leaving later."
     {MAKE_BATS_NORMAL}
     {ZOMBIES}
 
-    # wmllint: whofield clear PLACE_GUARD MOVE_AND_PLACE_GUARD
 #undef PLACE_GUARD
 #undef MOVE_AND_PLACE_GUARD
 #undef SET_MENU_ITEM_FOR

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
@@ -657,7 +657,6 @@ The journey started well enough, but on the dawn following our departure, the wi
             kill=yes
         [/store_unit]
         [unit]
-            # wmllint: who CHARACTER_STATS_BONE_CAPTAIN is Bone Captain
             {CHARACTER_STATS_BONE_CAPTAIN}
             side=1
             x=$rudic_stored.x

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
@@ -35,7 +35,6 @@ The tunnel at the back of the cave narrowed and ran on for quite some time. Patc
         controller=human # sets persistent so the units here will be on the recall list in next scenario
         team_name=good
         user_team_name= _ "Ras-Tabahn"
-        # wmllint: who CHARACTER_STATS_RAS-TABAHN is Ras-Tabahn
         {CHARACTER_STATS_RAS-TABAHN}
         {RAS-TABAHN_RECRUIT_1}
         gold=0

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/08_Carcyn.cfg
@@ -44,7 +44,6 @@ After several days of travel, he approached the frontier town of Carcyn."
     {TURNS 28 28 28}
 
     [side]
-        # wmllint: who SIDE_1_RAS-TABAHN is Ras-Tabahn
         {SIDE_1_RAS-TABAHN}
         {RAS-TABAHN_RECRUIT_1}
         {GOLD 200 200 200}
@@ -230,7 +229,6 @@ After several days of travel, he approached the frontier town of Carcyn."
             y=12,12
         [/move_unit_fake]
         [unit]
-            # wmllint: who CHARACTER_STATS_SHYNAL is Shynal
             {CHARACTER_STATS_SHYNAL}
             x,y=5,12
             side=1
@@ -242,7 +240,6 @@ After several days of travel, he approached the frontier town of Carcyn."
             y=12,13
         [/move_unit_fake]
         [unit]
-            # wmllint: who CHARACTER_STATS_CARCYN is Carcyn
             {CHARACTER_STATS_CARCYN}
             x,y=5,13
             side=1

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
@@ -115,7 +115,6 @@ Ras-Tabahn seems like an acceptable ally. He is quite different from the stodgy 
             name=ardonna_zombies
         [/clear_variable]
 
-        # wmllint: who RECALL_LOYAL_UNITS is Bone Captain
         {RECALL_LOYAL_UNITS}
     [/event]
 
@@ -192,7 +191,6 @@ Ras-Tabahn seems like an acceptable ally. He is quite different from the stodgy 
         [/move_unit_fake]
 
         [unit]
-            # wmllint: who CHARACTER_STATS_VENDRAXIS is Vendraxis
             {CHARACTER_STATS_VENDRAXIS}
             x=$location.x
             y=$location.y

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
@@ -38,10 +38,6 @@ We reached the Ford of Abez as the dawn light spread behind the mountain peaks t
     {TURNS 29 27 25}
 
     [side]
-        # wmllint: unwho SIDE_1_ARDONNA
-        # wmllint: unwho SIDE_1_RAS-TABAHN
-        # wmllint: who SIDE_1_BOTH is Ardonna,Ras-Tabahn
-        # wmllint: who RECALL_LOYAL_UNITS is Bone Captain, Vendraxis, Shynal, Carcyn
         {SIDE_1_BOTH}
         {GOLD 170 160 150}
     [/side]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/21_Against_the_World.cfg
@@ -53,7 +53,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Gwendir
         side=2
         controller=ai
         user_team_name= _ "Cavalry"
@@ -66,7 +65,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Fizztsars
         side=3
         controller=ai
         user_team_name= _ "Saurians"
@@ -84,7 +82,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Thrigalurd
         side=4
         controller=ai
         user_team_name= _ "Dwarves"
@@ -98,7 +95,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Carmyna
         side=5
         controller=ai
         user_team_name= _ "Magi"
@@ -112,7 +108,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Isthiniel
         side=6
         controller=ai
         user_team_name= _ "Elves"
@@ -126,7 +121,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Mauapan
         side=7
         controller=ai
         user_team_name= _ "Merfolk"
@@ -151,7 +145,6 @@ We finally made it out of the mountains. We crossed the Ford of Abez late this m
     [/side]
 
     [side]
-        # wmllint: recognize Taxtrimon
         side=8
         controller=ai
         user_team_name= _ "Nagas"

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/22_Epilogue.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/22_Epilogue.cfg
@@ -52,6 +52,4 @@ We prevailed today on the field, but our victory was somewhat bitter. <i>Everyon
     [side]
         {SIDE_1_BOTH}
     [/side]
-
-    # wmllint: unwho ALL
 [/scenario]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
@@ -40,7 +40,6 @@
                 description=_ "Death of Grüü"
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Grüü
                         id=Grüü
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/04_The_Siege_of_Barag_Gor.cfg
@@ -186,11 +186,8 @@
 
         {GENERIC_UNIT 3 "Orcish Grunt" 25 15} {GUARDIAN}
         {GENERIC_UNIT 3 "Orcish Grunt" 22 16} {GUARDIAN}
-        # wmllint: whofield ORCISH_SHAMAN 4
         {ORCISH_SHAMAN 3 22 14 Pirk _"Pirk"}
-        # wmllint: whofield OLD_ORCISH_SHAMAN 4
         {OLD_ORCISH_SHAMAN 3 22 15 Gork _"Gork"}
-        # wmllint: whofield NOVICE_ORCISH_SHAMAN 4
         {NOVICE_ORCISH_SHAMAN 3 21 15 Vraurk _"Vraurk"}
 
         [item]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
@@ -1148,7 +1148,6 @@
         {ORCISH_SHAMAN 1 11 1 Pirk _"Pirk"}
         {OLD_ORCISH_SHAMAN 1 11 1 Gork _"Gork"}
         {NOVICE_ORCISH_SHAMAN 1 11 1 Vraurk _"Vraurk"}
-        # wmllint: whofield clear
         {UNIT 1 "Orcish Warrior" 11 1 role=greathordeprops}
         {UNIT 1 "Orcish Warrior" 11 1 role=greathordeprops}
         {UNIT 1 "Orcish Crossbowman" 11 1 role=greathordeprops}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
@@ -61,14 +61,12 @@
     [/side]
 
     [side]
-        # wmllint: who ALBROCK_SIDE is Al'Brock
         {ALBROCK_SIDE}
         {GOLD 300 250 200}
         {INCOME 10 8 6}
     [/side]
 
     [side]
-        # wmllint: who FLARTAR_SIDE is Flar'Tar
         {FLARTAR_SIDE}
         {GOLD 300 250 200}
         {INCOME 10 8 6}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/15_Civil_War.cfg
@@ -25,10 +25,6 @@
                 description=_ "Defeat all rebel leaders and..."
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Braga
-                        # wmllint: recognize Meato
-                        # wmllint: recognize Ragvan
-                        # wmllint: recognize Kergai
                         id=Braga, Meato, Ragvan, Kergai
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
@@ -351,7 +351,6 @@
         name=turn 10
 
         {HUMAN_REINFORCEMENTS Bruce}
-        # wmllint: recognize Bruce
 
         [message]
             speaker=Bruce

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/18_Northern_Alliance.cfg
@@ -67,7 +67,6 @@
 
     [side]
         {FLARTAR_SIDE}
-        # wmllint: unwho ALL
         {GOLD 250 225 200}
         {INCOME 12 10 8}
     [/side]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/02_Reclaiming_the_Past.cfg
@@ -52,7 +52,6 @@
             x,y=11,4
             facing=sw
 
-            # wmllint: recognize Angarthing
             {CHARACTER_STATS_ANGARTHING}
         [/unit]
     [/side]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/08_The_Siege_of_Kal_Kartha.cfg
@@ -37,7 +37,6 @@
         user_team_name= _ "Kal Kartha"
         {FLAG_VARIANT knalgan}
 
-        # wmllint: recognize Dulcatulos
         {CHARACTER_STATS_DULCATULOS_AS_LEADER}
         facing=sw
     [/side]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/10_The_Underlevels.cfg
@@ -47,7 +47,6 @@
         user_team_name= _ "Masked Dwarves"
         {FLAG_VARIANT knalgan}
 
-        # wmllint: recognize Karrag
         {CHARACTER_STATS_KARRAG}
 
         color=black

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/11_Epilogue.cfg
@@ -36,7 +36,6 @@
     [/unit]
 #enddef
         # The Kal Karthans. One has to be named Narithil for the dialog
-        # wmllint: recognize Narithil
         {KAL_KARTHAN 16  7  (Dwarvish Fighter)      Glamcatsil ( _ "Glamcatsil")}
         {KAL_KARTHAN 14  8  (Dwarvish Fighter)      Trithdurus ( _ "Trithdurus")}
         {KAL_KARTHAN 13  9  (Dwarvish Fighter)      Althasol   ( _ "Althasol")}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
@@ -113,7 +113,6 @@
     [event]
         name=prestart
 
-        # wmllint: whofield HERO 2
         {HERO (Warrior King) (King Eldaric IV) ( _ "King Eldaric IV") 1 28 15  "portraits/eldaric.webp"}
 
         [objectives]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
@@ -392,7 +392,6 @@
                 condition=lose
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Lord Typhon
                         id=Lord Typhon
                     [/have_unit]
                 [/show_if]
@@ -575,7 +574,6 @@
             y=22,22,23,23
         [/move_unit_fake]
 
-        # wmllint: whofield LIVING_INTEL 2
         {LIVING_INTEL (Familiar) (Familiar) ( _ "Familiar") "portraits/familiar.webp" 6 42 23}
         [+unit]
             facing=sw
@@ -588,7 +586,6 @@
             y=22,22,23,23,24
         [/move_unit_fake]
 
-        # wmllint: whofield UNDEAD_INTEL 2
         {UNDEAD_INTEL (Jevyan Cloaked) (Lich-Lord Jevyan) ( _ "Lich-Lord Jevyan") "portraits/jevyan.webp" 6 42 24}
         [+unit]
             facing=sw

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
@@ -128,7 +128,6 @@
 
 #define TEMP_QUEEN X Y
     [event]
-        # wmllint: recognize Lady Jessene
         name=moveto
         [filter]
             side=1

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
@@ -63,7 +63,6 @@
         {FLAG_VARIANT long}
     [/side]
 
-    # wmllint: recognize Lady Jessene
     [event]
         name=prestart
 
@@ -99,15 +98,12 @@
         [/unstore_unit]
 
         {HERO (Elvish Marshal) ("Lord El’Isomithir") ( _ "Lord El’Isomithir") 4 13 14 ("portraits/isomithir.webp")}
-        # wmllint: whofield clear HERO
     [/event]
 
     [event]
         name=start
 
         {MOVE_UNIT (id=Jessene in Hiding) 19 16}
-
-        # wmllint: recognize Jessene in Hiding
 
         [scroll_to_unit]
             id=Jessene in Hiding

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/20_Return_of_the_Fleet.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/20_Return_of_the_Fleet.cfg
@@ -184,7 +184,6 @@
                 [show_if]
                     # Don't show if she's not back yet
                     [have_unit]
-                        # wmllint: recognize Lady Jessene
                         id=Lady Jessene
                     [/have_unit]
                 [/show_if]
@@ -266,7 +265,6 @@
         [/move_unit_fake]
 
         {UNDEAD_INTEL (Jevyan Cloaked) (Lich-Lord Jevyan) ( _ "Lich-Lord Jevyan") "portraits/jevyan.webp" 2 25 2}
-        # wmllint: whofield clear UNDEAD_INTEL
 
         [message]
             speaker=Lich-Lord Jevyan

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -247,7 +247,6 @@
         [/unit_overlay]
 
         {LIVING_INTEL (Familiar) (Familiar) ( _ "Familiar") "portraits/familiar.webp" 2 40 39}
-        # wmllint: whofield clear LIVING_INTEL
 
         [objectives]
             side=1

--- a/data/campaigns/Two_Brothers/_main.cfg
+++ b/data/campaigns/Two_Brothers/_main.cfg
@@ -117,5 +117,3 @@
 
 {campaigns/Two_Brothers/scenarios}
 #endif
-
-# wmllint: who NEED_BARAN is Baran

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -97,7 +97,6 @@ I need my brother; he always had a better head for battle than I. Yet we have no
         user_team_name= _ "Humans"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Arvith
         {CHARACTER_STATS_ARVITH}
 
         facing=nw

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -64,7 +64,6 @@ Besides... I want my brother back."
         user_team_name= _ "Humans"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Arvith
         {CHARACTER_STATS_ARVITH}
 
         facing=ne

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -54,7 +54,6 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
         user_team_name= _ "Humans"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Arvith
         {CHARACTER_STATS_ARVITH}
 
         facing=nw
@@ -298,7 +297,6 @@ Yet for some reason I fear these brothers more. If Mordak were here it would be 
                 [show_if]
                     [not]
                         [have_unit]
-                            # wmllint: recognize Baran
                             id=Baran
                         [/have_unit]
                     [/not]

--- a/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
@@ -56,7 +56,6 @@ But I am still troubled. I wonder... is this sense of foreboding I feel merely a
         user_team_name= _ "Humans"
         {FLAG_VARIANT loyalist}
 
-        # wmllint: recognize Arvith
         {CHARACTER_STATS_ARVITH}
 
         facing=ne

--- a/data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg
@@ -39,7 +39,6 @@ In the meantime, though, it’s good to relax and enjoy the peace."
         controller=human
         gold=100
 
-        # wmllint: recognize Arvith
         {CHARACTER_STATS_ARVITH}
     [/side]
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -49,14 +49,12 @@
         user_team_name= _ "team_name^Quenoth Elves"
         {FLAG_VARIANT long}
 
-        # wmllint: recognize Kaleh
         {KALEH}
 
         shroud=yes
 
         # Start with Nym
         [unit]
-            # wmllint: who NYM is Nym
             {NYM}
             x,y=17,21
         [/unit]
@@ -131,7 +129,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Xanthos
                         id=Xanthos
                     [/have_unit]
                 [/show_if]
@@ -535,7 +532,6 @@
             add=1
         [/set_variable]
 
-        # wmllint: recognize Rocky Horror
         {UNIT 2 "Giant Mudcrawler" 28 33 (
             role="Rocky Horror"
             generate_name,random_traits,random_gender=yes,no,yes
@@ -560,7 +556,6 @@
         )}
 
         [unit]
-            # wmllint: who GARAK is Garak
             {GARAK}
             side=1
             x,y=29,34
@@ -724,7 +719,6 @@
         [/message]
 
         [unit]
-            # wmllint: who ZHUL is Zhul
             {ZHUL}
             side=1
             x,y=25,27

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -207,7 +207,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Thorn
                         id=Thorn
                     [/have_unit]
                 [/show_if]
@@ -1125,7 +1124,6 @@
         {PLACE_UNITS_RANDOMLY $archers   4 "Bone Shooter"     "ElyssaUndead" ( _ "Undead Raider") ()}
         {PLACE_UNITS_RANDOMLY $revenants 4 "Revenant"         "ElyssaUndead" ( _ "Undead Raider") ()}
         {PLACE_UNITS_RANDOMLY $shooters  4 "Bone Shooter"     "ElyssaUndead" ( _ "Undead Raider") ()}
-        # wmllint: recognize Go'hag
 
         {CLEAR_VARIABLE skeletons}
         {CLEAR_VARIABLE archers}

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -212,7 +212,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Possessed Garak
                         id=Possessed Garak
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -344,7 +344,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Cloaked Figure
                         id=Cloaked Figure
                     [/have_unit]
                 [/show_if]
@@ -911,9 +910,6 @@
         {DEFENDER 3 (Troll Shaman) 44 31 (Troll Defender) ( _ "Troll Defender")}
 
 #undef DEFENDER
-
-        # wmllint: recognize Dwarf Defender
-        # wmllint: recognize Troll Defender
 
         [redraw]
         [/redraw]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1393,7 +1393,6 @@
     [event]
         name=last breath
 
-        # wmllint: recognize Big Hairy Bat
         [filter]
             id=Big Hairy Bat
         [/filter]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -322,11 +322,6 @@
             x,y=51,43
         [/recall]
 
-        # wmllint: recognize Grog
-        # wmllint: recognize Nog
-        # wmllint: recognize Rogrimir
-        # wmllint: recognize Jarl
-
         # put hero icon on troll/dwarf ally
         [unit_overlay]
             id=$ally_id
@@ -401,8 +396,6 @@
                 [show_if]
                     [not]
                         [have_unit]
-                            # wmllint: recognize Sergeant Durstrag
-                            # wmllint: recognize Esanoo
                             id=Sergeant Durstrag,Esanoo
                         [/have_unit]
                     [/not]
@@ -1661,10 +1654,6 @@
         [fire_event]
             name=respawn_trainees
         [/fire_event]
-
-        # wmllint: recognize Novice Pior
-        # wmllint: recognize Novice Dani
-        # wmllint: recognize Novice Iona
 
         [message]
             speaker=Blessed Kali

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -306,10 +306,6 @@
         [recall]
             id=$ally_id
         [/recall]
-        # wmllint: recognize Grog
-        # wmllint: recognize Nog
-        # wmllint: recognize Rogrimir
-        # wmllint: recognize Jarl
         [recall]
             id=Esanoo
             x,y=46,42
@@ -351,8 +347,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Tanstafaal
-                        # wmllint: recognize Eloh
                         id=Tanstafaal,Eloh
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
@@ -79,11 +79,6 @@
             x,y=13,15
         [/recall]
 
-        # wmllint: recognize Grog
-        # wmllint: recognize Nog
-        # wmllint: recognize Rogrimir
-        # wmllint: recognize Jarl
-
         # create 6 merfolk guards to protect the seer
         [unit]
             type=Merman Warrior

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -408,11 +408,6 @@
             id=$ally_id
         [/recall]
 
-        # wmllint: recognize Grog
-        # wmllint: recognize Nog
-        # wmllint: recognize Rogrimir
-        # wmllint: recognize Jarl
-
         #recall merfolk
 
         [recall]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
@@ -226,18 +226,11 @@
             x,y=10,16
         [/recall]
 
-        # wmllint: unwho ALL
-
         # recall dwarf/troll
         [recall]
             id=$ally_id
             x,y=9,17
         [/recall]
-
-        # wmllint: recognize Grog
-        # wmllint: recognize Nog
-        # wmllint: recognize Rogrimir
-        # wmllint: recognize Jarl
 
         # store/remove kaleh
 
@@ -263,7 +256,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Eloh
                         id=Eloh
                     [/have_unit]
                 [/show_if]
@@ -273,7 +265,6 @@
                 condition=win
                 [show_if]
                     [have_unit]
-                        # wmllint: recognize Yechnagoth
                         id=Yechnagoth
                     [/have_unit]
                 [/show_if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
@@ -35,8 +35,6 @@
     # will still complain about "unknown '<NAME>' referred to by id" without
     # these comments.
     #
-    # wmllint: recognize Nym
-    # wmllint: recognize Zhul
 
     # Prestart functions:
 

--- a/data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg
@@ -47,7 +47,6 @@
         user_team_name= _ "Gorlack’s Wing"
         side_name= _ "Gorlack"
         {FLAG_VARIANT long}
-        # wmllint: who GORLACK is Gorlack
         [leader]
             {GORLACK}
             x,y=1,66
@@ -137,7 +136,6 @@
         [scroll_to]
             x,y=10,51
         [/scroll_to]
-        # wmllint: who RESHA is Resha
         [unit]
             {RESHA}
             x,y=9,52
@@ -253,7 +251,6 @@ My sanction is given."
             x,y=28,16
         [/unit]
         [message]
-            # wmllint: recognize Karron
             speaker=Karron
             message= _ "So it is, that timid Gorlack attempts the Trial of Gaall."
         [/message]

--- a/data/campaigns/Winds_of_Fate/scenarios/02_Reclamation.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/02_Reclamation.cfg
@@ -485,7 +485,6 @@ Jessene says her people are familiar with these dragons. Their tomes describe su
         {UNIT 6 (Drake Glider)  27  5 (facing=sw)}
         {UNIT 6 (Drake Fighter) 27  6 (facing=sw)}
         {UNIT 6 (Drake Burner)  27  7 (facing=sw)}
-        # wmllint: who KARRON is Karron
         [unit]
             side=6
             {KARRON (Drake Warrior)}

--- a/data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg
@@ -96,7 +96,6 @@
         side_name= _ "Karron"
         {FLAG_VARIANT long}
         recall_cost=99999 # This is needed as AI ignores disallow_recall.
-        # wmllint: who KARRON is Karron
         [leader]
             {KARRON (Drake Blademaster)}
             facing=n

--- a/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
@@ -553,14 +553,12 @@ Those hatchlings will be slain if our intervention is not swift."
     [event]
         name=saurians rescued
         # Dialogue with saurians.
-        # wmllint: who ARINEXIS is Arinexis
         [unit]
             {ARINEXIS}
             side=5
             x,y=8,30
             facing=nw
         [/unit]
-        # wmllint: who ZEDRIX is Zedrix
         [unit]
             {ZEDRIX}
             side=5

--- a/data/campaigns/Winds_of_Fate/scenarios/06_Landfall.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/06_Landfall.cfg
@@ -343,7 +343,6 @@ It will call in our reinforcements."
         {UNIT 3 (Sky Drake)      2 11 (facing=se)}
         {UNIT 3 (Fire Drake)     3 12 (facing=se)}
         {UNIT 3 (Drake Warrior)  4 12 (facing=se)}
-        # wmllint: who KARRON is Karron
         [unit]
             {KARRON (Drake Blademaster)}
             side=3

--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -81,7 +81,6 @@
                 max_risk=1
             [/leader_goal]
         [/ai]
-        # wmllint: who KARRON is Karron
         [leader]
             {KARRON (Drake Blademaster)}
             facing=ne

--- a/data/campaigns/Winds_of_Fate/scenarios/12_Epilogue.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/12_Epilogue.cfg
@@ -33,5 +33,4 @@
             replay_save=no
         [/endlevel]
     [/event]
-    # wmllint: unwho ALL
 [/scenario]

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -51,14 +51,7 @@
 # wmllint: noconvert                          - disables and suppresses output for changing the line the comment is on.
 # wmllint: markcheck on|off                   - disables checking for missing or extra translation marks in the block between off and on.
 # wmllint: no-icon                            - disables adding the name as the description (which also determines the icon) to attacks missing the description attribute.
-# wmllint: recognize <unit id>                - suppresses output for dialogue where wmllint is not aware of the speaker for the single file it's in.
-# wmllint: whofield <macro> <argument number> - when using a macro to place a unit, tells wmllint which macro argument contains the unit id.
 #                                               used in the current and subsequent files that are processed.
-# wmllint: whofield clear <macro>             - removes wmllint's recognition of the unit id used in <macro>. using without specifying <macro> clears all macros from recognition.
-# wmllint: who <macro> is <characters>        - adds wmllint recognition of <characters> (comma delimited list of unit ids) when it encounters <macro>.
-#                                               used in the current and subsequent files that are processed.
-# wmllint: unwho ALL                          - removes all unit ids added by any "wmllint: who[field]" comments.
-# wmllint: unwho <macro>                      - removes all unit ids recognized by that macro.
 # wmllint: usage of <unit> is <class>         - explicitly declares the recruitment type of the unit (see the usage attribute of [unit_type]) in case wmllint doesn't find it.
 #                                               <unit> must be inside ascii double quotes.
 # wmllint: usagetype <class>                  - tell wmllint about custom recruitment types. <class> can be a comma separated list.
@@ -1343,17 +1336,6 @@ def standard_unit_filter():
 
 # Sanity checking
 
-# This dictionary will pair macros with the characters they recall or create,
-# but must be populated by the magic comment, "#wmllint: who ... is ...".
-whopairs = {}
-
-# This dictionary pairs macros with the id field of the characters they recall
-# or create, and is populated by the comment, "wmllint: whofield <macro> <#>."
-whomacros = {}
-
-# This dictionary pairs the ids of stored units with their variable name.
-storedids = {}
-
 # This set of the standard recruitable usage types can be appended with the
 # magic comment, "#wmllint: usagetype[s]".
 standard_usage_types = {"scout", "fighter", "mixed fighter", "archer", "healer"}
@@ -1898,50 +1880,19 @@ to be called on their own".format(filename, num))
     # Consistency-check the id= attributes in [side], [unit], [recall],
     # and [message] scopes, also correctness-check translation marks and look
     # for double spaces at end of sentence.
-    present = []
     extra_translatables = []
     in_scenario = False
     in_multiplayer = False
     subtag_depth = 0
-    in_person = False
-    in_trait = False
-    ignore_id = False
-    in_object = False
-    in_stage = False
-    in_cfg = False
-    in_goal = False
-    in_set_menu_item = False
-    in_clear_menu_item = False
-    in_aspect = False
-    in_facet = False
-    in_sound_source = False
-    in_remove_sound_source = False
-    in_load_resource = False
     in_message = False
     in_option = False
     #last index is true: we're currently directly in an [event]
     #this avoids complaints about unknown [event]id=something, but keeps the check
     #in case some [filter]id= comes in this [event]
     directly_in_event = []
-    in_time_area = False
     in_store = False
-    in_unstore = False
     in_not = False
-    in_clear = False
-    in_fire_event = False
-    in_primary_unit = False
-    in_secondary_unit = False
-    in_remove_event = False
-    in_remove_time_area = False
-    in_tunnel = False
-    in_filter = False
-    in_checkbox = False
-    in_combo = False
-    in_entry = False
-    in_slider = False
-    in_map_generator = False
     in_name_generator = False
-    in_candidate_action = False
     in_lua = False
     in_lua_args = False
     in_window = False
@@ -1950,9 +1901,7 @@ to be called on their own".format(filename, num))
     in_deprecated_message = False
     in_chat = False
     storeid = None
-    storevar = None
     ignoreable = False
-    preamble_seen = False
     sentence_end = re.compile("(?<=[.!?;:])  +")
     capitalization_error = re.compile("(?<=[.!?])  +[a-z]")
     markcheck = True
@@ -1975,20 +1924,16 @@ to be called on their own".format(filename, num))
             if not in_lua_args:
                 # As far as I can tell none of the below tests make sense inside of a lua tag
                 continue
-        if '[' in lines[i]:
-            preamble_seen = True
         # This logic looks odd because a scenario can be conditionally
         # wrapped in both [scenario] and [multiplayer]; we mustn't count
         # either as a subtag even if it occurs inside the other, otherwise
         # this code might see id= declarations as being at the wrong depth.
         if "[scenario]" in lines[i]:
             in_scenario = True
-            preamble_seen = False
         elif "[/scenario]" in lines[i]:
             in_scenario = False
         elif "[multiplayer]" in lines[i]:
             in_multiplayer = True
-            preamble_seen = False
         elif "[/multiplayer]" in lines[i]:
             in_multiplayer = False
         else:
@@ -2006,55 +1951,7 @@ to be called on their own".format(filename, num))
             if len(directly_in_event) > 0:
                 directly_in_event.pop()
         # Ordinary subtag flags begin here
-        if has_opening_tag(lines[i], "trait"):
-            in_trait = True
-        elif "[/trait]" in lines[i]:
-            in_trait = False
-        elif has_opening_tag(lines[i], "object"):
-            in_object = True
-        elif "[/object]" in lines[i]:
-            in_object = False
-        elif has_opening_tag(lines[i], "stage"):
-            in_stage = True
-        elif "[/stage]" in lines[i]:
-            in_stage = False
-        elif has_opening_tag(lines[i], "cfg"):
-            in_cfg = True
-        elif "[/cfg]" in lines[i]:
-            in_cfg = False
-        elif has_opening_tag(lines[i], "goal"):
-            in_goal = True
-        elif "[/goal]" in lines[i]:
-            in_goal = False
-        elif has_opening_tag(lines[i], "set_menu_item"):
-            in_set_menu_item = True
-        elif "[/set_menu_item]" in lines[i]:
-            in_set_menu_item = False
-        elif has_opening_tag(lines[i], "clear_menu_item"):
-            in_clear_menu_item = True
-        elif "[/clear_menu_item]" in lines[i]:
-            in_clear_menu_item = False
-        elif has_opening_tag(lines[i], "aspect"):
-            in_aspect = True
-        elif "[/aspect]" in lines[i]:
-            in_aspect = False
-        elif has_opening_tag(lines[i], "facet"):
-            in_facet = True
-        elif "[/facet]" in lines[i]:
-            in_facet = False
-        elif has_opening_tag(lines[i], "sound_source"):
-            in_sound_source = True
-        elif "[/sound_source]" in lines[i]:
-            in_sound_source = False
-        elif has_opening_tag(lines[i], "remove_sound_source"):
-            in_remove_sound_source = True
-        elif "[/remove_sound_source]" in lines[i]:
-            in_remove_sound_source = False
-        elif has_opening_tag(lines[i], "load_resource"):
-            in_load_resource = True
-        elif "[/load_resource]" in lines[i]:
-            in_load_resource = False
-        elif has_opening_tag(lines[i], "message"):
+        if has_opening_tag(lines[i], "message"):
             in_message = True
         elif "[/message]" in lines[i]:
             in_message = False
@@ -2062,16 +1959,6 @@ to be called on their own".format(filename, num))
             in_option = True
         elif "[/option]" in lines[i]:
             in_option = False
-        elif has_opening_tag(lines[i], "time_area"):
-            in_time_area = True
-        elif "[/time_area]" in lines[i]:
-            in_time_area = False
-        elif has_opening_tag(lines[i], "label") or \
-             has_opening_tag(lines[i], "chamber") or \
-             has_opening_tag(lines[i], "time"):
-            ignore_id = True
-        elif "[/label]" in lines[i] or "[/chamber]" in lines[i] or "[/time]" in lines[i]:
-            ignore_id = False
         elif has_opening_tag(lines[i], "kill") or \
              has_opening_tag(lines[i], "effect") or \
              has_opening_tag(lines[i], "move_unit_fake") or \
@@ -2079,86 +1966,15 @@ to be called on their own".format(filename, num))
             ignoreable = True
         elif "[/kill]" in lines[i] or "[/effect]" in lines[i] or "[/move_unit_fake]" in lines[i] or "[/scroll_to_unit]" in lines[i]:
             ignoreable = False
-        elif has_opening_tag(lines[i], "side") or \
-             has_opening_tag(lines[i], "unit") or \
-             has_opening_tag(lines[i], "recall"):
-            in_person = True
-            continue
-        elif "[/side]" in lines[i] or "[/unit]" in lines[i] or "[/recall]" in lines[i]:
-            in_person = False
         elif has_opening_tag(lines[i], "store_unit"):
             in_store = True
         elif "[/store_unit]" in lines[i]:
-            if storeid and storevar:
-                storedids.update({storevar: storeid})
             in_store = False
-            storeid = storevar = None
-        elif has_opening_tag(lines[i], "unstore_unit"):
-            in_unstore = True
-        elif "[/unstore_unit]" in lines[i]:
-            in_unstore = False
+            storeid = None
         elif has_opening_tag(lines[i], "not"):
             in_not = True
         elif "[/not]" in lines[i]:
             in_not = False
-        elif has_opening_tag(lines[i], "clear_variable"):
-            in_clear = True
-        elif "[/clear_variable]" in lines[i]:
-            in_clear = False
-        # starting from 1.13.6, [fire_event] supports id= fields
-        # ignore them, but don't ignore [primary_unit] and [secondary_unit]
-        elif has_opening_tag(lines[i], "fire_event"):
-            in_fire_event = True
-        elif "[/fire_event]" in lines[i]:
-            in_fire_event = False
-        elif has_opening_tag(lines[i], "primary_unit"):
-            in_primary_unit = True
-        elif "[/primary_unit]" in lines[i]:
-            in_primary_unit = False
-        elif has_opening_tag(lines[i], "secondary_unit"):
-            in_secondary_unit = True
-        elif "[/secondary_unit]" in lines[i]:
-            in_secondary_unit = False
-        # version 1.13.0 added [remove_event], which accepts a id= field
-        elif has_opening_tag(lines[i], "remove_event"):
-            in_remove_event = True
-        elif "[/remove_event]" in lines[i]:
-            in_remove_event = False
-        elif "[remove_time_area]" in lines[i]:
-            in_remove_time_area = True
-        elif "[/remove_time_area]" in lines[i]:
-            in_remove_time_area = False
-        # [tunnel] supports a [filter] sub-tag, so handle it
-        elif has_opening_tag(lines[i], "tunnel"):
-            in_tunnel = True
-        elif "[/tunnel]" in lines[i]:
-            in_tunnel = False
-        elif has_opening_tag(lines[i], "filter"):
-            in_filter = True
-        elif "[/filter]" in lines[i]:
-            in_filter = False
-        # sub-tags of [options] tag
-        elif has_opening_tag(lines[i], "checkbox"):
-            in_checkbox = True
-        elif "[/checkbox]" in lines[i]:
-            in_checkbox = False
-        elif has_opening_tag(lines[i], "combo"):
-            in_combo = True
-        elif "[/combo]" in lines[i]:
-            in_combo = False
-        elif has_opening_tag(lines[i], "entry"):
-            in_entry = True
-        elif "[/entry]" in lines[i]:
-            in_entry = False
-        elif has_opening_tag(lines[i], "slider"):
-            in_slider = True
-        elif "[/slider]" in lines[i]:
-            in_slider = False
-        elif has_opening_tag(lines[i], "generator"):
-            in_map_generator = True
-        elif "[/generator]" in lines[i]:
-            in_map_generator = False
-
         elif has_opening_tag(lines[i], "window"):
             in_window = True
         elif "[/window]" in lines[i]:
@@ -2167,12 +1983,10 @@ to be called on their own".format(filename, num))
             in_resolution = True
         elif "[/resolution]" in lines[i]:
             in_resolution = False
-
         elif "_definition]" in lines[i] and "[/" not in lines[i]:
             in_gui_definition = True
         elif gui_def_regex.search(lines[i]):
             in_gui_definition = False
-
         elif has_opening_tag(lines[i], "deprecated_message"):
             in_deprecated_message = True
         elif "[/deprecated_message]" in lines[i]:
@@ -2181,11 +1995,6 @@ to be called on their own".format(filename, num))
             in_chat = True
         elif "[/chat]" in lines[i]:
             in_chat = False
-
-        elif has_opening_tag(lines[i], "candidate_action"):
-            in_candidate_action = True
-        elif "[/candidate_action]" in lines[i]:
-            in_candidate_action = False
         elif name_generator_re.search(lines[i]):
             in_name_generator = True
         elif in_name_generator and ">>" in lines[i]:
@@ -2194,100 +2003,18 @@ to be called on their own".format(filename, num))
             markcheck = False
         elif "wmllint: markcheck on" in lines[i]:
             markcheck = True
-        elif 'wmllint: who ' in lines[i]:
-            try:
-                fields = lines[i].split("wmllint: who ", 1)[1].split(" is ", 1)
-                if len(fields) == 2:
-                    mac = string_strip(fields[0].strip()).strip('{}')
-                    if mac in whopairs:
-                        whopairs[mac] = whopairs[mac] + ", " + fields[1].strip()
-                    else:
-                        whopairs.update({mac: fields[1].strip()})
-            except IndexError:
-                pass
-        elif 'wmllint: unwho ' in lines[i]:
-            unmac = lines[i].split("wmllint: unwho ", 1)[1].strip()
-            if string_strip(unmac).upper() == 'ALL':
-                whopairs.clear()
-            else:
-                try:
-                    del whopairs[string_strip(unmac).strip('{}')]
-                except KeyError:
-                    print('%s, line %s: magic comment "unwho %s" does not match any current keys: %s' \
-                          % (filename, i+1, unmac, ", ".join(whopairs.keys())), file=sys.stderr)
-        elif 'wmllint: whofield' in lines[i]:
-            fields = re.search(r'wmllint: whofield\s+([^\s]+)(\s+is)?\s*([^\s]*)', lines[i])
-            if fields:
-                if fields.group(1).startswith('clear'):
-                    if fields.group(3) in whomacros:
-                        del whomacros[fields.group(3)]
-                    else:
-                        whomacros.clear()
-                elif re.match(r'[1-9][0-9]*$', fields.group(3)):
-                    whomacros.update({fields.group(1): int(fields.group(3))})
-                else:
-                    try:
-                        del whomacros[fields.group(1)]
-                    except KeyError:
-                        print('%s, line %s: magic comment "whofield %s" should be followed by a number: %s' \
-                              % (filename, i+1, unmac, fields.group(3)), file=sys.stderr)
         # Parse recruit/recall macros to recognize characters.  This section
         # assumes that such a macro is the first item on a line.
         leadmac = re.match(r'{[^}\s]+.', lines[i].lstrip())
         if leadmac:
             macname = leadmac.group()[1:-1]
-            # Recognize macro pairings from "wmllint: who" magic
-            # comments.
-            if macname in whopairs:
-                for who in whopairs[macname].split(","):
-                    if who.strip().startswith("--"):
-                        try:
-                            present.remove(who.replace('--', '', 1).strip())
-                        except:
-                            ValueError
-                    else:
-                        present.append(who.strip())
-            elif not leadmac.group().endswith('}'):
-                # Update 1.4's {LOYAL_UNIT} macro to {NAMED_LOYAL_UNIT}.  Do
-                # this here rather than hack_syntax so the character can be
-                # recognized.
+            if not leadmac.group().endswith('}'):
+                # Update 1.4's {LOYAL_UNIT} macro to {NAMED_LOYAL_UNIT}.
                 if macname == 'LOYAL_UNIT':
                     (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
                     if len(args) == 6:
                         lines[i] = lines[i].replace('{LOYAL_UNIT', '{NAMED_LOYAL_UNIT', 1)
-                # Auto-recognize the people in the {NAMED_*UNIT} macros.
-                if re.match(r'NAMED_[A-Z_]*UNIT$', macname):
-                    (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
-                    if len(args) >= 6 and \
-                       re.match(r'([0-9]+|[^\s]*\$[^\s]*side[^\s]*|{[^\s]*SIDE[^\s]*})$', args[0]) and \
-                       re.match(r'([0-9]+|[^\s]*\$[^\s]*x[^\s]*|{[^\s]*X[^\s]*})$', args[2]) and \
-                       re.match(r'([0-9]+|[^\s]*\$[^\s]*y[^\s]*|{[^\s]*Y[^\s]*})$', args[3]) and \
-                       len(args[4]) > 0:
-                        present.append(args[4])
-                elif macname == 'RECALL':
-                    (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
-                    if len(args) == 1 and not is_unfinished:
-                        present.append(args[0])
-                elif macname == 'RECALL_XY':
-                    (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
-                    if len(args) == 3:
-                        present.append(args[0])
-                elif macname == 'CLEAR_VARIABLE':
-                    (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
-                    # having CLEAR_VARIABLE on a line and its arguments in the following lines
-                    # leads to an args list with length 0
-                    # skip the check and avoid a crash if that's the case
-                    if len(args) > 0:
-                        for arg in [x.lstrip() for x in args[0].split(',')]:
-                            if arg in storedids:
-                                del storedids[arg]
-                elif macname in whomacros:
-                    (args, optional_args, is_unfinished) = parse_macroref(0, leadmac.string)
-                    if len(args) >= whomacros[macname]:
-                        present.append(args[whomacros[macname] - 1])
         m = re.search("# *wmllint: recognize +(.*)", lines[i])
-        if m:
-            present.append(string_strip(m.group(1)).strip())
         if '=' not in lines[i] or ignoreable:
             continue
         parseable = False
@@ -2306,23 +2033,7 @@ to be called on their own".format(filename, num))
                         storeid == storeid + ',' + value
                     else:
                         storeid = value
-                elif key == 'variable' and '{' not in value:
-                    storevar = value
-            elif in_unstore:
-                if key == 'variable':
-                    value = value.split("[$")[0]
-                    if value in storedids:
-                        for unit_id in storedids[value].split(','):
-                            present.append(unit_id.lstrip())
-                        del storedids[value]
-            elif key == 'name' and in_clear:
-                for val in value.split(','):
-                    val = val.lstrip()
-                    if val in storedids:
-                        del storedids[val]
             has_tr_mark = translation_mark.search(value)
-            if key == 'role':
-                present.append(value)
             if has_tr_mark:
                 # FIXME: This test is rather bogus as is.
                 # Doing a better job would require tokenizing to pick up the
@@ -2374,37 +2085,6 @@ to be called on their own".format(filename, num))
                 if key == "message" and in_message and not in_option and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
                     lines[i] = pangoize(lines[i], filename, i)
             else:
-                if (in_scenario or in_multiplayer) and key == "id":
-                    if in_person:
-                        present.append(value)
-                    elif value and value[0] in ("$", "{"):
-                        continue
-                    elif preamble_seen and subtag_depth > 0 and not ignore_id \
-                         and not in_object and not in_cfg and not in_aspect \
-                         and not in_facet and not in_sound_source \
-                         and not in_remove_sound_source and not in_load_resource \
-                         and not in_stage \
-                         and not in_goal and not in_set_menu_item \
-                         and not in_clear_menu_item and not directly_in_event[-1] \
-                         and not in_time_area and not in_trait and not in_checkbox \
-                         and not in_combo and not in_entry and not in_slider \
-                         and not in_map_generator and not in_candidate_action \
-                         and not (in_fire_event and not (in_primary_unit or in_secondary_unit)) \
-                         and not in_remove_event and not in_remove_time_area \
-                         and not (in_tunnel and not in_filter):
-                        ids = value.split(",")
-                        for id_ in ids:
-                            # removal of leading whitespace of items in comma-separated lists
-                            # is usually supported in the mainline wesnoth lua scripts
-                            # not sure about trailing one
-                            # also, do not complain about ids if they're referred to a menu item being cleared
-                            if id_.lstrip() not in present:
-                                print('"%s", line %d: unknown \'%s\' referred to by id' \
-                                      % (filename, i+1, id_))
-                if (in_scenario or in_multiplayer) and key == "speaker":
-                    if value not in present and value not in ("narrator", "unit", "second_unit") and value[0] not in ("$", "{"):
-                        print('"%s", line %d: unknown speaker \'%s\' of [message]' \
-                              % (filename, i+1, value))
                 if markcheck and has_tr_mark and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
                     print('"%s", line %d: %s should not have a translation mark' \
                           % (filename, i+1, key))
@@ -2559,9 +2239,6 @@ def consistency_check():
         if value not in scenario_to_filename:
             print('"%s", line %d: unresolved scenario reference %s' % \
                   (filename, lineno, value))
-    # Report stored units never unstored or cleared
-    for store in storedids.keys():
-        print('wmllint: stored unit "%s" not unstored or cleared from "%s"' % (storedids[store], store))
 
 # Syntax transformations
 


### PR DESCRIPTION
the effort of addressing false positives and improving the already complex implemention in wmllint isn't justified by the benefit it provides given that these two issues haven't been recurring problems ever since wmllint stopped being consistently used on mainline