### PR TITLE
Enable Additional Colors

### DIFF
--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -19,12 +19,14 @@
     id=lightred
     rgb=D1620D,FFFFFF,000000,FF0000
     name= _ "Light Red"
+    default=yes
 [/color_range]
 
 [color_range]
     id=darkred
     rgb=8A0808,FFFFFF,000000,FF0000
     name= _ "Dark Red"
+    default=yes
 [/color_range]
 
 [color_range]
@@ -38,6 +40,7 @@
     id=lightblue
     rgb=00A4FF,FFFFFF,000A21,00A4FF
     name= _ "Light blue"
+    default=yes
 [/color_range]
 
 [color_range]
@@ -51,6 +54,7 @@
     id=brightgreen
     rgb=8CFF00,EBFFBF,2D4001,8CFF00
     name= _ "Bright green"
+    default=yes
 [/color_range]
 
 [color_range]
@@ -85,6 +89,7 @@
     id=brightorange
     rgb=FFC600,FFF7E6,792A00,FFC600
     name= _ "Bright orange"
+    default=yes
 [/color_range]
 
 [color_range]
@@ -105,6 +110,7 @@
     id=gold
     rgb=FFF35A,FFF8D2,994F13,FFF35A
     name= _ "color^Gold"
+    default=yes
 [/color_range]
 
 [color_range]

--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -10,22 +10,8 @@
 # wmllint will translate incoming UMC to use them.
 [color_range]
     id=red
-    rgb=FF0000,FFFFFF,000000,FF0000
+    rgb=FF0000,FFFFFF,000000,D80000
     name= _ "Red"
-    default=yes
-[/color_range]
-
-[color_range]
-    id=lightred
-    rgb=D1620D,FFFFFF,000000,FF0000
-    name= _ "Light Red"
-    default=yes
-[/color_range]
-
-[color_range]
-    id=darkred
-    rgb=8A0808,FFFFFF,000000,FF0000
-    name= _ "Dark Red"
     default=yes
 [/color_range]
 
@@ -37,23 +23,9 @@
 [/color_range]
 
 [color_range]
-    id=lightblue
-    rgb=00A4FF,FFFFFF,000A21,00A4FF
-    name= _ "Light blue"
-    default=yes
-[/color_range]
-
-[color_range]
     id=green
     rgb=62B664,FFFFFF,000000,00FF00
     name= _ "Green"
-    default=yes
-[/color_range]
-
-[color_range]
-    id=brightgreen
-    rgb=8CFF00,EBFFBF,2D4001,8CFF00
-    name= _ "Bright green"
     default=yes
 [/color_range]
 
@@ -86,13 +58,6 @@
 [/color_range]
 
 [color_range]
-    id=brightorange
-    rgb=FFC600,FFF7E6,792A00,FFC600
-    name= _ "Bright orange"
-    default=yes
-[/color_range]
-
-[color_range]
     id=white
     rgb=E1E1E1,FFFFFF,1E1E1E,FFFFFF
     name= _ "White"
@@ -110,6 +75,41 @@
     id=gold
     rgb=FFF35A,FFF8D2,994F13,FFF35A
     name= _ "color^Gold"
+    default=yes
+[/color_range]
+
+[color_range]
+    id=lightblue
+    rgb=00A4FF,FFFFFF,000A21,00A4FF
+    name= _ "Light blue"
+    default=yes
+[/color_range]
+
+[color_range]
+    id=brightgreen
+    rgb=8CFF00,EBFFBF,2D4001,8CFF00
+    name= _ "Bright green"
+    default=yes
+[/color_range]
+
+[color_range]
+    id=darkred
+    rgb=8A0808,FFFFFF,000000,8A0000
+    name= _ "Dark Red"
+    default=yes
+[/color_range]
+
+[color_range]
+    id=brightorange
+    rgb=FFC600,FFF7E6,792A00,FFC600
+    name= _ "Bright orange"
+    default=yes
+[/color_range]
+
+[color_range]
+    id=lightred
+    rgb=D1620D,FFFFFF,000000,FF0000
+    name= _ "Light Red"
     default=yes
 [/color_range]
 


### PR DESCRIPTION
Enables six additional colors in `./data/core/team-colors.cfg`. Addresses the primary stated difficulty/request of issue #4123:
>Currently all teams >= 9 get teal as color. data/core/team-colors.cfg knows 6 more colors though, which can be set by WML. (even more with the terrain colors, which I didn't look at)
>Proposal: moving the border to 15.