### PR TITLE
HttT: disable "Lightfoot" achievement

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/achievements.cfg
+++ b/data/campaigns/Heir_To_The_Throne/achievements.cfg
@@ -66,7 +66,7 @@ red#endarg
 
     # campaign completion
     {ACHIEVEMENT "{CORE}/attacks/thunderstick.png"                         "h2tt_s50a" _"Canon"                  _"Complete <i>The Battle for Wesnoth</i> with Jotha, a free Elensefar, and an inspired Doors."}
-    {ACHIEVEMENT "{FRAMED {CORE}/units/dwarves/guard-se-run3.png}"         "h2tt_s50b" _"Lightfoot"              _"Complete <i>The Battle for Wesnoth</i> before winter of year 519."}
+    # {ACHIEVEMENT "{FRAMED {CORE}/units/dwarves/guard-se-run3.png}"         "h2tt_s50b" _"Lightfoot"              _"Complete <i>The Battle for Wesnoth</i> before winter of year 519."}
     # this achievement can only be completed on Easy/Normal. On Hard/Nightmare, Li'sar leaves the Crossroads before you have time to complete Blackwater Port and Flight of the Elves
     {ACHIEVEMENT "{FRAMED {CORE}/units/goblins/spearman-idle-9.png}"       "h2tt_s50c" _"Asleep at the Wheel"    _"Complete <i>The Battle for Wesnoth</i> after autumn of year 524."}
     {ACHIEVEMENT "{FRAMED {CAMPAIGN}/units/elvish-civilian/elf.png}"       "h2tt_s50d" _"Road Less Traveled"     _"Complete <i>The Battle for Wesnoth</i> without playing Flight of the Elves, Blackwater Port, or Bay of Pearls."}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/50_The_Battle_for_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/50_The_Battle_for_Wesnoth.cfg
@@ -2289,12 +2289,14 @@
             [/then]
         [/if]
 
-        [if]
-            {VARIABLE_CONDITIONAL bm_turns less_than 6}
-            [then]
-                {ACHIEVE s50b}
-            [/then]
-        [/if]
+        # TODO: the Lightfoot achievement's description should read "year 518", not "year 519"
+        # can't change this now due to the 1.19 string freeze, so I've disabled it for now and will fix & re-enable in 1.21
+        # [if]
+        #     {VARIABLE_CONDITIONAL bm_turns less_than 6}
+        #     [then]
+        #         {ACHIEVE s50b}
+        #     [/then]
+        # [/if]
 
         # this achievement requires you to use the whirlpool, so we bypass {ACHIEVE}'s bm_whirlpool_disable_achievements check
         [if]


### PR DESCRIPTION
Unfortunately this achievement's description is wrong - it should trigger on year 518, not 519.

The string freeze blocks changing the description, but we also can't leave a clearly wrong achievement in the game, so I've disabled the achievement with a note to fix & re-enable in 1.21.