### PR TITLE
Default Fallback/Overflow Color Altered

### DIFF
--- a/src/team.cpp
+++ b/src/team.cpp
@@ -977,7 +977,7 @@ std::string team::get_side_color_id(unsigned side)
 		static const std::string fallback_id = "lightred";
 
 		// Validate that the fallback color exists
-		if(team_rgb_range.find(fallback_id) != team_rgb_range.end()) {
+		if(utils::contains(game_config::team_rgb_range, fallback_id)) {
 			return fallback_id;
 		}
 

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -974,6 +974,13 @@ std::string team::get_side_color_id(unsigned side)
 		// is being called to set up said side data. :P
 		return game_config::default_colors.at(index);
 	} catch(const std::out_of_range&) {
+		static const std::string fallback_id = "lightred";
+
+		// Validate that the fallback color exists
+		if(team_rgb_range.find(fallback_id) != team_rgb_range.end()) {
+			return fallback_id;
+		}
+
 		// Side index was invalid! Coloring will fail!
 		return "";
 	}


### PR DESCRIPTION
Addresses #11283. Dependent on #11282. Light Red moved up to ninth place in `team-colors.cfg`.