### PR TITLE
Improve Separation of Mini-map Unit Marker Reds

### DIFF
--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -10,7 +10,7 @@
 # wmllint will translate incoming UMC to use them.
 [color_range]
     id=red
-    rgb=FF0000,FFFFFF,000000,D80000
+    rgb=FF0000,FFFFFF,000000,FF0000
     name= _ "Red"
     default=yes
 [/color_range]

--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -108,7 +108,7 @@
 
 [color_range]
     id=lightred
-    rgb=D1620D,FFFFFF,000000,FF0000
+    rgb=D1620D,FFFFFF,000000,D1620D
     name= _ "Light Red"
     default=yes
 [/color_range]


### PR DESCRIPTION
Addresses the primary concern of #11286 by modifying the fourth/final `rgb` values of red, light red, and dark red.
<img width="96" height="35" alt="Screenshot 2026-06-18 102931" src="https://github.com/user-attachments/assets/1384ff35-22c7-4ecc-87a4-c8e5b253b1ac" />
[Color pallette](https://color.adobe.com/create/color-wheel?color-palette=8A0000%2CD80000%2CF02020&color-palette-name=Wesnoth-11286-reds) chosen to maximize separation. Assessment can be most easily be made by enabling these colors manually (in-place, as of this initial commit) and launching a local multiplayer campaign with at least three sides.