### PR TITLE
SotBE-S11: patch AI bad behavior things

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
@@ -69,6 +69,11 @@
             grouping=no
             village_value=0.0
             leader_value=50.0
+
+            [avoid]
+                x=13,14,15,23,24,25,11,12,13,25,26,27
+                y=17,17,17,17,17,17,18,18,18,18,18,18
+            [/avoid]
         [/ai]
         recruit=Elvish Captain, Elvish Fighter, Elvish Archer, Elvish Marksman, Elvish Druid, Elvish Scout
         team_name=villains
@@ -91,6 +96,11 @@
             villages_per_scout=0
             grouping=no
             village_value=20
+
+            [avoid]
+                x=13,14,15,23,24,25,11,12,13,25,26,27
+                y=17,17,17,17,17,17,18,18,18,18,18,18
+            [/avoid]
 
             [aspect]
                 id=recruitment_instructions
@@ -151,6 +161,9 @@
             grouping=no
             leader_value=20
             village_value=20
+            # note: if this is not added, he just rushes out near edge of the moat
+            # and gets smashed by the player veterans recalled at the bridge
+            passive_leader=yes
         [/ai]
         recruit=Swordsman, Red Mage, Pikeman, Heavy Infantryman, Fencer, Bowman
         team_name=villains


### PR DESCRIPTION
- Prevents premature suicide by Lan Bech (apparently some one proved he can be killed in turn 2 in S11). Which causes a very nasty continuity bug
- Prevents AI enemies from blocking side 4 units boarding ships