### PR TITLE
SotBE AMLA: fix identical amla advancement bug

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg
@@ -254,7 +254,7 @@
         {SOTBE_AMLA_GENERIC_DAMAGE (
             name=spear
             range=ranged
-        ) ("spear") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
+        ) ("spear-thrown") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
     [/modify_unit_type]
 #enddef
 
@@ -273,7 +273,7 @@
         {SOTBE_AMLA_GENERIC_DAMAGE (
             name=spear
             range=ranged
-        ) ("spear") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
+        ) ("spear-thrown") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
     [/modify_unit_type]
 #enddef
 


### PR DESCRIPTION
- attack name argument and damage increment argument values are used to create an amla advancement id
- attack name argument is a non-translatable so no string freeze violation
- affected cases fixed and patched: Saurian Flanker and Saurian Javelineer.
- they both had 1_spear in the advancement id suffice only the latest (+1 ranged) showed up accessible
