### PR TITLE
Fix: prevent sound effects slider from affecting music tracks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Translations
 ### Units
 ### User interface
+   * Fix sound effect slider which was incorrectly affecting the music track volume.
 ### WML Engine
 ### Miscellaneous and Bug Fixes
 ### Android

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -989,9 +989,9 @@ void set_sound_volume(int vol)
 		}
 
 		// Bell, timer and UI have separate tracks which we can't set up from this
+		// Also separating music track from being modified
 		for(unsigned i = 0; i < n_of_tracks; ++i) {
-			if(!(i >= UI_sound_track_id_start && i <= UI_sound_track_id_last) && i != bell_track_id && i != timer_track_id) {
-				MIX_SetTrackGain(sound::tracks[i].get(), vol);
+			if(i != music_track_id && !(i >= UI_sound_track_id_start && i <= UI_sound_track_id_last) && i != bell_track_id && i != timer_track_id) {				MIX_SetTrackGain(sound::tracks[i].get(), vol);
 			}
 		}
 	}


### PR DESCRIPTION
This change makes sure that the sound effects volume slider no longer incorrectly modifies the music track.