### PR TITLE
Update image copyrights

### DIFF
--- a/copyrights.csv
+++ b/copyrights.csv
@@ -479,6 +479,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/campaigns/Dead_Water/images/items/underwater_rock1.png,GNU GPL v2+,unknown,,,c96234099fb68a71fa77d2caea359fe1
 2022/04/13,data/campaigns/Dead_Water/images/maps/dw.webp,GNU GPL v2+,Lari Nieminen(zookeeper),,,a8be1410bbffa1ce57894a7082ae3f2f
 2022/04/13,data/campaigns/Dead_Water/images/maps/l10n/de/dw--overlay.webp,GNU GPL v2+,unknown,,,9b8f538c0283d414696b2220d1708b13
+2026/06/28,data/campaigns/Dead_Water/images/maps/l10n/es/dw--overlay.webp,GNU GPL v2+,Sebas38760,,,1fe0522faee4b5cda8e7f05089ebf1c9
 2022/04/13,data/campaigns/Dead_Water/images/maps/l10n/gl/dw--overlay.webp,GNU GPL v2+,unknown,,,bf74fe97a07096ba42a45378978c10d9
 2022/04/13,data/campaigns/Dead_Water/images/maps/l10n/it/dw--overlay.webp,GNU GPL v2+,unknown,,,2ec364d40419279a90ed9d070062606d
 2022/04/13,data/campaigns/Dead_Water/images/maps/l10n/pt/dw--overlay.webp,GNU GPL v2+,unknown,,,ac1ec9fcba742e7fa357605d7dc82fa0
@@ -528,6 +529,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2019/01/30,data/campaigns/Descent_Into_Darkness/images/items/potion-clear.png,CC BY-SA 4.0,Nemaara Lang(nemaara),,,9a7eb2372502d4bef4be1cbd14ee8e5c
 2022/04/13,data/campaigns/Descent_Into_Darkness/images/maps/did.webp,GNU GPL v2+,Lari Nieminen(zookeeper),,,81a4343d7b3c3c50043d8a01613a87b0
 2022/04/13,data/campaigns/Descent_Into_Darkness/images/maps/l10n/de/did--overlay.webp,GNU GPL v2+,unknown,,,1d8639bb9199447e1758c0a9054a20ed
+2026/06/28,data/campaigns/Descent_Into_Darkness/images/maps/l10n/es/did--overlay.webp,GNU GPL v2+,Sebas38760,,,cfea6db592b3b8088eb90604cc6b71af
 2022/04/13,data/campaigns/Descent_Into_Darkness/images/maps/l10n/gl/did--overlay.webp,GNU GPL v2+,unknown,,,fabe316059ee28f8551213216a7d63ba
 2022/04/13,data/campaigns/Descent_Into_Darkness/images/maps/l10n/it/did--overlay.webp,GNU GPL v2+,unknown,,,18fb97bc3063c2451cdd1fe2907c26f4
 2022/04/13,data/campaigns/Descent_Into_Darkness/images/maps/l10n/lt/did--overlay.webp,GNU GPL v2+,unknown,,,e5d3cae81160716c3cef1205468a380a
@@ -755,6 +757,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2023/09/15,data/campaigns/Eastern_Invasion/images/items/yeti-meat.png,CC BY-SA 4.0,Nemaara Lang(nemaara),,,ce883b8e21d2dcfb55f268476e0b9d07
 2023/09/15,data/campaigns/Eastern_Invasion/images/maps/ei.webp,GNU GPL v2+,Lari Nieminen(zookeeper);(dalas),,,2dd97aa9b8358057fa149cf3e72262e1
 2022/04/13,data/campaigns/Eastern_Invasion/images/maps/l10n/de/ei--overlay.webp,GNU GPL v2+,unknown,,,630d20d4a616cd3807e67289e5820b60
+2026/06/28,data/campaigns/Eastern_Invasion/images/maps/l10n/es/ei--overlay.webp,GNU GPL v2+,Sebas38760,,,e7f02b2748338f03ae123e88f20379bf
 2024/03/16,data/campaigns/Eastern_Invasion/images/maps/l10n/it/ei--overlay.webp,GNU GPL v2+,Antonio Rosella,,,3410bf6f1d7169f1a224b222521dcc2e
 2022/04/13,data/campaigns/Eastern_Invasion/images/maps/l10n/pt/ei--overlay.webp,GNU GPL v2+,unknown,,,3a11d92fb80fbf01187b29e4ce6efd86
 2022/04/13,data/campaigns/Eastern_Invasion/images/maps/l10n/ru/ei--overlay.webp,GNU GPL v2+,unknown,,,a900312001d4724f3e74e7d1e52a8e51
@@ -1116,9 +1119,11 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2023/09/15,data/campaigns/Eastern_Invasion/sounds/magic-twilight.ogg,GNU GPL v2+,unknown;(dalas),,,6399b904acff450455d1f82dc3c08fec
 2023/09/15,data/campaigns/Eastern_Invasion/sounds/warhammer.ogg,GNU GPL v2+,unknown;Nemaara Lang(nemaara),,,ba59c7ad531f57d02f33fde568f908a7
 2023/09/15,data/campaigns/Eastern_Invasion/sounds/wind.ogg,CC BY-SA 4.0,(hackerb9);(dalas),,,69160ff47b13bb2b527f670247c85a6a
+2026/06/28,data/campaigns/Heir_To_The_Throne/images/bigmap/l10n/es/preview-shroud.png,GNU GPL v2+,Sebas38760,,,643b2eb719b231d69aab9344778baa6f
 2012/08/25,data/campaigns/Heir_To_The_Throne/images/campaign_image.png,GNU GPL v2+,Emilien Rotival(LordBob),,,68f33759844727e5fd489fb22efa7346
 2022/04/13,data/campaigns/Heir_To_The_Throne/images/maps/httt.webp,GNU GPL v2+,Lari Nieminen(zookeeper),,,e5c46c93612a3be48f379f5094347ef7
 2022/04/13,data/campaigns/Heir_To_The_Throne/images/maps/l10n/de/httt--overlay.webp,GNU GPL v2+,unknown,,,2b0dd824f60331d9d7c738da9d92264d
+2026/06/28,data/campaigns/Heir_To_The_Throne/images/maps/l10n/es/httt--overlay.webp,GNU GPL v2+,Sebas38760,,,45a1beabac55083f3341911808e812bb
 2022/04/13,data/campaigns/Heir_To_The_Throne/images/maps/l10n/gd/httt--overlay.webp,GNU GPL v2+,unknown,,,c7aca3a21f6afa4b2b72debece3fa2a9
 2022/04/13,data/campaigns/Heir_To_The_Throne/images/maps/l10n/gl/httt--overlay.webp,GNU GPL v2+,unknown,,,926eb5fd3dc920bb2a6cf562e5e4d093
 2022/04/13,data/campaigns/Heir_To_The_Throne/images/maps/l10n/it/httt--overlay.webp,GNU GPL v2+,unknown,,,e17bf3b92a4bc21551678dc78a0eb36f
@@ -1280,6 +1285,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/campaigns/Legend_of_Wesmere/images/l10n/ru/low-map--overlay.webp,GNU GPL v2+,unknown,,,5303e2f21ad97904b01241936afb7eb4
 2022/04/13,data/campaigns/Legend_of_Wesmere/images/l10n/zh_CN/low-map--overlay.webp,GNU GPL v2+,unknown,,,e3e854986a1d2b3534a51b52777004ca
 2014/03/02,data/campaigns/Legend_of_Wesmere/images/low-map.png,GNU GPL v2+,unknown,,,82d520be1d9d733cd9d6e06e2e187029
+2026/06/28,data/campaigns/Legend_of_Wesmere/images/maps/l10n/es/low--overlay.webp,GNU GPL v2+,Sebas38760,,,25189d7bb92b515d841b14908f23d08b
 2022/04/13,data/campaigns/Legend_of_Wesmere/images/portraits/aldar.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,d23149317894f5657b6c6d03e7161cf3
 2022/04/13,data/campaigns/Legend_of_Wesmere/images/portraits/cleodil.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,9e67c48084eaf67e1d0e7f2127d5c7a5
 2022/04/13,data/campaigns/Legend_of_Wesmere/images/portraits/crelanu.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,94751e2e58025dddfd8f206e791c1778
@@ -1315,6 +1321,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/campaigns/Liberty/images/halo/shadow-mage-halo8.png,GNU GPL v2+,unknown,,,a1edf3d74db9462a2c7738929b3eff75
 2011/03/11,data/campaigns/Liberty/images/halo/shadow-mage-halo9.png,GNU GPL v2+,unknown,,,a04c2805e939927ae76dd0588fa0ebfe
 2022/04/13,data/campaigns/Liberty/images/maps/l10n/de/liberty--overlay.webp,GNU GPL v2+,unknown,,,d81d8351fd6ff4aa9b5343fa818904b2
+2026/06/28,data/campaigns/Liberty/images/maps/l10n/es/liberty--overlay.webp,GNU GPL v2+,Sebas38760,,,bb2d233d98c058abedde85fb69563f51
 2022/04/13,data/campaigns/Liberty/images/maps/l10n/gl/liberty--overlay.webp,GNU GPL v2+,unknown,,,3143a4c16302bd16157c22404883d0cd
 2022/04/13,data/campaigns/Liberty/images/maps/l10n/it/liberty--overlay.webp,GNU GPL v2+,unknown,,,6eccb2d6035831c2611e7431e6d5c9e9
 2022/04/13,data/campaigns/Liberty/images/maps/l10n/pt/liberty--overlay.webp,GNU GPL v2+,unknown,,,2f97d82cb6de113f90ae8bedfd20b213
@@ -1368,6 +1375,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2020/05/19,data/campaigns/Northern_Rebirth/images/campaign_image.png,GNU GPL v2+,unknown,,,8215c768ecd71b3f1b911e685b5f95d8
 2011/03/11,data/campaigns/Northern_Rebirth/images/floor-corpse.png,GNU GPL v2+,unknown,,,3d7454caf1b7a7dbbdb2a172b14fbbfa
 2022/04/13,data/campaigns/Northern_Rebirth/images/maps/l10n/de/nr--overlay.webp,GNU GPL v2+,unknown,,,917c96d874f11174c97eea3565ada05c
+2026/06/28,data/campaigns/Northern_Rebirth/images/maps/l10n/es/nr--overlay.webp,GNU GPL v2+,Sebas38760,,,c72a06a09b66c9d5053ea862a7b31551
 2022/04/13,data/campaigns/Northern_Rebirth/images/maps/l10n/gd/nr--overlay.webp,GNU GPL v2+,unknown,,,8b86114bd09c83ee608ca7d7521c812d
 2022/04/13,data/campaigns/Northern_Rebirth/images/maps/l10n/gl/nr--overlay.webp,GNU GPL v2+,unknown,,,55c769f938aaff8c7d2f7dc11fe33c46
 2022/04/13,data/campaigns/Northern_Rebirth/images/maps/l10n/it/nr--overlay.webp,GNU GPL v2+,unknown,,,d6128a37475f58b2cab7c16e4d93123c
@@ -1395,6 +1403,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2019/12/30,data/campaigns/Sceptre_of_Fire/images/items/gold.png,GNU GPL v2+,(RusHHouR);(doofus-01),,,5589a69de4d292e45390b89c7f07dacf
 2019/12/30,data/campaigns/Sceptre_of_Fire/images/items/ruby.png,CC BY-SA 4.0,(doofus-01),,,6d37f5056b7b2d96c9ff1618da9bf222
 2022/04/13,data/campaigns/Sceptre_of_Fire/images/maps/l10n/de/sof--overlay.webp,GNU GPL v2+,unknown,,,486b30a30c989f8c4af1fa8a164206ba
+2026/06/28,data/campaigns/Sceptre_of_Fire/images/maps/l10n/es/sof--overlay.webp,GNU GPL v2+,Sebas38760,,,6536fd02d73d4d986337bb3495f20c54
 2022/04/13,data/campaigns/Sceptre_of_Fire/images/maps/l10n/gl/sof--overlay.webp,GNU GPL v2+,unknown,,,1feb3a4c75d63eed5d95243bf0915c23
 2022/04/13,data/campaigns/Sceptre_of_Fire/images/maps/l10n/it/sof--overlay.webp,GNU GPL v2+,unknown,,,4418b40de60f5fa73153565530d84f4f
 2022/04/13,data/campaigns/Sceptre_of_Fire/images/maps/l10n/pt/sof--overlay.webp,GNU GPL v2+,unknown,,,d368fa8e5b4dc742e823aa7cd139fe33
@@ -1676,6 +1685,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/campaigns/Son_Of_The_Black_Eye/images/flags/black-flag-icon.png,GNU GPL v2+,unknown,,,9b29b0dbd0958af7e3878888eb43bf71
 2011/03/11,data/campaigns/Son_Of_The_Black_Eye/images/items/barrel-floating.png,GNU GPL v2+,unknown,,,a9477c3791a7943670d367e8feb585ee
 2022/04/13,data/campaigns/Son_Of_The_Black_Eye/images/maps/l10n/de/sotbe--overlay.webp,GNU GPL v2+,unknown,,,9a5b5082d1321f4adcbc03238c53ac91
+2026/06/28,data/campaigns/Son_Of_The_Black_Eye/images/maps/l10n/es/sotbe--overlay.webp,GNU GPL v2+,Sebas38760,,,374f95c8caaa6bee45ffd8e3840f863f
 2022/04/13,data/campaigns/Son_Of_The_Black_Eye/images/maps/l10n/gl/sotbe--overlay.webp,GNU GPL v2+,unknown,,,978a0e8907f986aef3fdea7096aa8d99
 2022/04/13,data/campaigns/Son_Of_The_Black_Eye/images/maps/l10n/it/sotbe--overlay.webp,GNU GPL v2+,unknown,,,7608e84e98b6dfa3df23a2baec130bc7
 2022/04/13,data/campaigns/Son_Of_The_Black_Eye/images/maps/l10n/pt/sotbe--overlay.webp,GNU GPL v2+,unknown,,,d9ff775e1add203a8f4b8d55aecfdc3f
@@ -1725,6 +1735,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/campaigns/The_Hammer_of_Thursagan/images/halo/karrag-ranged9_halo.png,GNU GPL v2+,unknown,,,d26859bc24c068e309ebf26283d94a59
 2011/03/11,data/campaigns/The_Hammer_of_Thursagan/images/halo/karrag_halo.png,GNU GPL v2+,unknown,,,71596fbfb46a23de61f73c0058dd3dc9
 2022/04/13,data/campaigns/The_Hammer_of_Thursagan/images/maps/l10n/de/thot--overlay.webp,GNU GPL v2+,unknown,,,486b30a30c989f8c4af1fa8a164206ba
+2026/06/28,data/campaigns/The_Hammer_of_Thursagan/images/maps/l10n/es/thot--overlay.webp,GNU GPL v2+,Sebas38760,,,df6b9e90c0578ed15f9a24ed1c94f064
 2022/04/13,data/campaigns/The_Hammer_of_Thursagan/images/maps/l10n/gl/thot--overlay.webp,GNU GPL v2+,unknown,,,1feb3a4c75d63eed5d95243bf0915c23
 2022/04/13,data/campaigns/The_Hammer_of_Thursagan/images/maps/l10n/it/thot--overlay.webp,GNU GPL v2+,unknown,,,4418b40de60f5fa73153565530d84f4f
 2022/04/13,data/campaigns/The_Hammer_of_Thursagan/images/maps/l10n/pt/thot--overlay.webp,GNU GPL v2+,unknown,,,d368fa8e5b4dc742e823aa7cd139fe33
@@ -1893,6 +1904,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/great_continent.webp,GNU GPL v2+,Lari Nieminen(zookeeper),,,e9473ee5d6e1b6cf1a3d42db4d33bf00
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/green_isle.webp,GNU GPL v2+,Lari Nieminen(zookeeper),,,1fcab677c157b33df037d119f60d87c6
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/l10n/de/green_isle--overlay.webp,GNU GPL v2+,unknown,,,d1460abfe3334760fbd3baed0bbe3c4a
+2026/06/28,data/campaigns/The_Rise_Of_Wesnoth/images/maps/l10n/es/trow--overlay.webp,GNU GPL v2+,Sebas38760,,,f634ed21698495ebf054eeddb1359e57
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/l10n/hu/green_isle--overlay.webp,GNU GPL v2+,unknown,,,2b43a87035f849da7d5e252e51517d66
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/l10n/it/green_isle--overlay.webp,GNU GPL v2+,unknown,,,a0864249436de7f53de2347d242cfa40
 2022/04/13,data/campaigns/The_Rise_Of_Wesnoth/images/maps/l10n/pt/green_isle--overlay.webp,GNU GPL v2+,unknown,,,a675c4d4e5a96890ce2fd858d28e4b05
@@ -2082,6 +2094,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/campaigns/The_South_Guard/images/flag/SG-flag-4.png,GNU GPL v2+,unknown,,,10662268880248fe266e17c9f90c35c5
 2011/03/11,data/campaigns/The_South_Guard/images/flag/SG-flag-icon.png,GNU GPL v2+,unknown,,,ae6d2572c601f1e2cffdd297233cfcee
 2022/04/13,data/campaigns/The_South_Guard/images/maps/l10n/de/tsg--overlay.webp,GNU GPL v2+,unknown,,,06dbb7ac1aa23819f28d32e0038d34ca
+2026/06/28,data/campaigns/The_South_Guard/images/maps/l10n/es/tsg--overlay.webp,GNU GPL v2+,Sebas38760,,,4429ff0decfab60763e6cf4361dc1155
 2022/04/13,data/campaigns/The_South_Guard/images/maps/l10n/gd/tsg--overlay.webp,GNU GPL v2+,unknown,,,ad76e309d3bd0edf88ac8d5c453f6eed
 2022/04/13,data/campaigns/The_South_Guard/images/maps/l10n/gl/tsg--overlay.webp,GNU GPL v2+,unknown,,,2ec1f5919110b1184c78ad6206e5826f
 2022/04/13,data/campaigns/The_South_Guard/images/maps/l10n/it/tsg--overlay.webp,GNU GPL v2+,unknown,,,3630a47b58de7c866a275d29c112dc2f
@@ -2121,6 +2134,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2017/01/23,data/campaigns/The_South_Guard/images/units/infantry-lieutenant.png,GNU GPL v2+,(rhyging5),,,e30c231e0efc5e6410774902ceaf57e0
 2011/03/11,data/campaigns/Two_Brothers/images/campaign_image.png,GNU GPL v2+,Kathrin Polikeit(Kitty),,,4f1af312266e453abe38a9dee63f6cd0
 2022/04/13,data/campaigns/Two_Brothers/images/maps/l10n/de/tb--overlay.webp,GNU GPL v2+,unknown,,,d81d8351fd6ff4aa9b5343fa818904b2
+2026/06/28,data/campaigns/Two_Brothers/images/maps/l10n/es/tb--overlay.webp,GNU GPL v2+,Sebas38760,,,bb2d233d98c058abedde85fb69563f51
 2022/04/13,data/campaigns/Two_Brothers/images/maps/l10n/gl/tb--overlay.webp,GNU GPL v2+,unknown,,,3143a4c16302bd16157c22404883d0cd
 2022/04/13,data/campaigns/Two_Brothers/images/maps/l10n/it/tb--overlay.webp,GNU GPL v2+,unknown,,,6eccb2d6035831c2611e7431e6d5c9e9
 2022/04/13,data/campaigns/Two_Brothers/images/maps/l10n/pt/tb--overlay.webp,GNU GPL v2+,unknown,,,2f97d82cb6de113f90ae8bedfd20b213
@@ -3313,6 +3327,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/03/28,data/core/images/maps/background.webp,CC BY-SA 4.0,unknown,,,b88e35e6a2679128f0ff188761218c99
 2022/04/13,data/core/images/maps/l10n/de/titlescreen--overlay.webp,GNU GPL v2+,unknown,,,2b0dd824f60331d9d7c738da9d92264d
 2022/04/13,data/core/images/maps/l10n/de/wesnoth--overlay.webp,GNU GPL v2+,unknown,,,66f90e3c8d6583eae9e1f3d395dfd1e8
+2026/06/28,data/core/images/maps/l10n/es/titlescreen--overlay.webp,GNU GPL v2+,Sebas38760,,,45a1beabac55083f3341911808e812bb
 2022/04/13,data/core/images/maps/l10n/es/wesnoth--overlay.webp,GNU GPL v2+,unknown,,,ac8790a21ba9cc1a2e77453c44c91a4d
 2022/04/13,data/core/images/maps/l10n/fr/wesnoth--overlay.webp,GNU GPL v2+,unknown,,,5d09fb94786959eb3409f81bb99aaf4a
 2022/04/13,data/core/images/maps/l10n/gd/titlescreen--overlay.webp,GNU GPL v2+,unknown,,,c7aca3a21f6afa4b2b72debece3fa2a9


### PR DESCRIPTION
Attempting to fix broken 1.18 CI due to `copyrights.csv` not being updated in d6475e31e4ea8d5d584275d2fb298251f59c8751.

I don't know if the licence is correct, but just following the existing data.