### PR TITLE
Fix duplicate range definition for Shyde's melee attack

### DIFF
--- a/data/core/units/elves/Shyde.cfg
+++ b/data/core/units/elves/Shyde.cfg
@@ -26,7 +26,6 @@
         description=_"faerie touch"
         icon=attacks/touch-faerie.png
         type=impact
-        range=melee
         damage=6
         number=2
         range=melee


### PR DESCRIPTION
I was scrolling through the shyde's definition and noticed that the faerie touch had two range=melee definitions. This pr just removes the duplicate.

 I checked all other elves, no others have duplicates