### PR TITLE
Units/Dark Sorceress: sync description with Dark Sorcerer

### DIFF
--- a/data/core/units/undead/Necro_Dark_Sorcerer.cfg
+++ b/data/core/units/undead/Necro_Dark_Sorcerer.cfg
@@ -15,9 +15,10 @@
     advances_to=Lich,Necromancer
     cost=34
     usage=mixed fighter
+    #po: changes in 1.19.26: only the following word replaced: masters -> master.
     description= _ "The dread inspired by black magic is enhanced by the secrecy and fell rumors which surround it. Dark Sorcerers have begun to unlock the secrets of life and death, the latter of which is all too easy to inflict. This labor gives the first glimmerings of the connection between the soul and inert matter, and the first successful experiments in manipulating this bond. The terrible unknown that lurks beyond death is glimpsed, and will inevitably be fathomed.
 
-Despite any design they may have of using this to wrest their own immortality from nature’s grasp, the first results of their work have immediate, and unpleasant applications. The life they breathe into dead matter can create servants for them, servants which will work, but which will also kill, and will never question their masters. These creations have a loyalty any tyrant would dream of, and it is tempting to those with even the slightest desire for power."
+Despite any design they may have of using this to wrest their own immortality from nature’s grasp, the first results of their work have immediate, and unpleasant applications. The life they breathe into dead matter can create servants for them, servants which will work, but which will also kill, and will never question their master. These creations have a loyalty any tyrant would dream of, and it is tempting to those with even the slightest desire for power."
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM "units/undead-necromancers/dark-sorcerer-defend.png" "units/undead-necromancers/dark-sorcerer.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [recruiting_anim]
@@ -142,9 +143,10 @@ Despite any design they may have of using this to wrest their own immortality fr
         gender=female
         image="units/undead-necromancers/dark-sorcerer+female.png"
         profile="portraits/humans/necromancer+female.webp"
-        description= _ "The dread inspired by black magic comes chiefly from how little is known about it by the common man. Dark sorceresses have begun to unlock the secrets of life and death, the latter of which is all too easy to inflict. This labor gives the first glimmerings of the connection between the soul and inert matter, and the first successful experiments in manipulating this bond. The terrible unknown that lurks beyond death is glimpsed, and will inevitably be fathomed.
+        #po: changes in 1.19.26: the first sentence is changed to be the same as the male variant. In addition, merest -> slightest in the last sentence.
+        description= _ "The dread inspired by black magic is enhanced by the secrecy and fell rumors which surround it. Dark Sorceresses have begun to unlock the secrets of life and death, the latter of which is all too easy to inflict. This labor gives the first glimmerings of the connection between the soul and inert matter, and the first successful experiments in manipulating this bond. The terrible unknown that lurks beyond death is glimpsed, and will inevitably be fathomed.
 
-Despite any design they may have of using this to wrest their own immortality from nature’s grasp, the first results of their work have immediate, and unpleasant applications. The life they breathe into dead matter can create servants for them, servants which will work, but which will also kill, and will never question their mistress. These creations have a loyalty any tyrant would dream of, and it is tempting to those with even the merest desire for power."
+Despite any design they may have of using this to wrest their own immortality from nature’s grasp, the first results of their work have immediate, and unpleasant applications. The life they breathe into dead matter can create servants for them, servants which will work, but which will also kill, and will never question their mistress. These creations have a loyalty any tyrant would dream of, and it is tempting to those with even the slightest desire for power."
         die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
         {DEFENSE_ANIM "units/undead-necromancers/dark-sorcerer+female-defend.png" "units/undead-necromancers/dark-sorcerer+female.png" {SOUND_LIST:HUMAN_FEMALE_HIT} }
         [recruiting_anim]


### PR DESCRIPTION
c5a70496a23c39007a4d29605bda3508380ae98e updated Dark Sorcerer but the Sorceress was never updated. Also pluralized mistress -> mistresses to match the plural in the male variant.