### PR TITLE
TDG: fix missing siphon attack sound

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 ### Add-ons client
 ### Add-ons server
 ### Campaigns
+   * The Deceivers Gambit
+     * Fix missing siphon attack sound, which would cause a crash anytime the attack was used.
 ### Editor
 ### Multiplayer
 ### Lua API

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -858,21 +858,34 @@ Recruited elementals dissipate at the end of each scenario."
 #enddef
 #define ANIMATIONS_ENERVATE PATH
     [attack_anim]
-        {FILTER_ATTACK name=enervate}
+        [filter_attack]
+            name=enervate
+        [/filter_attack]
+        [sound_frame]
+            sound=magicmissile.wav
+        [/sound_frame]
         start_time=-350
-        {FRAME sound,image=siphon.ogg,{PATH}/delfador-ranged[1,2,1].png:[50,400,50]}
+        [frame]
+            image=units/delfador/L3/delfador-ranged[1,2,1].png:[50,400,50]
+        [/frame]
         overlay_start_time=-350
-        {OVERLAY_FRAME  offset,halo=1.0,"halo/elven/nature-halo[8~1].png~CS(50,-30,-50)~O([80%*2,60%,40%,30%,20%*3]):75"}
-        {IF}
+        [overlay_frame]
+            offset=1.0
+            halo="halo/elven/nature-halo[8~1].png~CS(50,-30,-50)~O([80%*2,60%,40%,30%,20%*3]):75"
+        [/overlay_frame]
+        [if]
             hits=yes
             overlay2_start_time=-200
-            {OVERLAY2_FRAME offset,halo=0.0,"halo/elven/nature-halo[1~8].png~CS(50,-30,-50)~O([20%*3,30%,40%,60%,80%*2]):75"}
+            [overlay_frame]
+                offset=0.0
+                halo="halo/elven/nature-halo[1~8].png~CS(50,-30,-50)~O([20%*3,30%,40%,60%,80%*2]):75"
+            [/overlay_frame]
             missile_start_time=-200
             [missile_frame]
                 image="halo/elven/druid-healing[8~1].png~CS(50,-30,-50):50"
                 offset=1.0~0.0
             [/missile_frame]
-        {/IF}
+        [/if]
         [else]
             hits=no
             missile_start_time=-200


### PR DESCRIPTION
This fixes the immediate issue raised in #11316 and prevents TDG from causing crashes (and cleans up some low-quality WML). But as the core concern is related to SDL3, I'll still leave the original bug report open.