### PR TITLE
Make RNG persistant and set "biased" as default mode [LLM Assisted]

### DIFF
--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -45,6 +45,9 @@ namespace
 	const std::string PAGE_ID_GET_ADDONS = "////addons////";
 	const std::string PAGE_ID_LANDING_PAGE = "////landing-page////";
 	const std::string PAGE_ID_MISSING_CAMPAIGNS = "////missing-campaign////";
+
+	// The campaign_rng_mode preference stores a string mirroring the savefile's random_mode RNG.
+	const std::vector<std::string> rng_mode_prefs{"default", "deterministic", "biased"};
 };
 
 REGISTER_DIALOG(campaign_selection)
@@ -459,6 +462,16 @@ void campaign_selection::pre_show()
 	}
 
 	//
+	// Set up RNG mode dropdown
+	//
+	// New installs default to "Reduced RNG"; existing installs restore the last selection.
+	menu_button& rng_menu = find_widget<menu_button>("rng_menu");
+	auto rng_it = std::find(rng_mode_prefs.begin(), rng_mode_prefs.end(), prefs::get().campaign_rng_mode());
+	rng_menu.set_selected(rng_it != rng_mode_prefs.end()
+		? static_cast<unsigned>(std::distance(rng_mode_prefs.begin(), rng_it))
+		: static_cast<unsigned>(RNG_DEFAULT));
+
+	//
 	// Set up Difficulty dropdown
 	//
 	menu_button& diff_menu = find_widget<menu_button>("difficulty_menu");
@@ -569,6 +582,8 @@ void campaign_selection::proceed()
 
 
 	rng_mode_ = RNG_MODE(std::clamp<unsigned>(find_widget<menu_button>("rng_menu").get_value(), RNG_DEFAULT, RNG_BIASED));
+
+	prefs::get().set_campaign_rng_mode(rng_mode_prefs[rng_mode_]);
 
 	prefs::get().set_modifications(engine_.active_mods(), false);
 }

--- a/src/gui/dialogs/migrate_version_selection.cpp
+++ b/src/gui/dialogs/migrate_version_selection.cpp
@@ -136,6 +136,9 @@ void migrate_version_selection::post_show()
 		// otherwise the copied files won't be used and also will get overwritten/deleted when Wesnoth closes
 
 		prefs::get().reload_preferences();
+
+		// TODO: remove after 1.20. (Not used after that. Needs no replacement.)
+		prefs::get().set_campaign_rng_mode_default_for_migration();
 	}
 }
 

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -211,6 +211,16 @@ void prefs::migrate_preferences(const std::string& migrate_prefs_file)
 		}
 	}
 }
+
+// TODO: remove after 1.20. Keeps pre-1.20 profiles (which lack the pref) on "Default RNG" to keep old players happy.
+void prefs::set_campaign_rng_mode_default_for_migration()
+{
+	if(!preferences_.has_attribute(prefs_list::campaign_rng_mode)) {
+		preferences_[prefs_list::campaign_rng_mode] = "default";
+		write_preferences();
+	}
+}
+
 void prefs::reload_preferences()
 {
 	clear_preferences();

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -208,6 +208,7 @@ public:
 	void write_preferences();
 	void load_advanced_prefs(const game_config_view& gc);
 	void migrate_preferences(const std::string& prefs_dir);
+	void set_campaign_rng_mode_default_for_migration(); // TODO: remove after 1.20. (Not used after that. Needs no replacement.)
 	void reload_preferences();
 	std::set<std::string> all_attributes();
 

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -541,6 +541,7 @@ public:
 	PREF_GETTER_SETTER(grid, bool, false)
 	PREF_GETTER_SETTER(disable_auto_moves, bool, false)
 	PREF_GETTER_SETTER(damage_prediction_allow_monte_carlo_simulation, bool, true)
+	PREF_GETTER_SETTER(campaign_rng_mode, std::string, std::string("biased"))
 	PREF_GETTER_SETTER(addon_manager_saved_order_name, std::string, std::string(""))
 	PREF_GETTER_SETTER(selected_achievement_group, std::string, std::string(""))
 	/** The most recently selected add-on id from the editor. May be an empty string. */
@@ -733,6 +734,7 @@ private:
 		prefs_list::ally_sighted_interrupts,
 		prefs_list::auto_save_max,
 		prefs_list::blindfold_replay,
+		prefs_list::campaign_rng_mode,
 		prefs_list::campaign_server,
 		prefs_list::chat_lines,
 		prefs_list::chat_timestamp,

--- a/src/preferences/preferences_list.hpp
+++ b/src/preferences/preferences_list.hpp
@@ -58,6 +58,8 @@ struct preferences_list_defines
 	ADDPREF(bell_volume)
 	/** whether to show the map before being given a side in online multiplayer */
 	ADDPREF(blindfold_replay)
+	/** the most recently selected RNG mode in the campaign selection dialog */
+	ADDPREF(campaign_rng_mode)
 	/** the add-ons server name, ie: add-ons.wesnoth.org */
 	ADDPREF(campaign_server)
 	/** the number of lines of chat to display in-game */
@@ -418,6 +420,7 @@ struct preferences_list_defines
 		auto_save_max,
 		bell_volume,
 		blindfold_replay,
+		campaign_rng_mode,
 		campaign_server,
 		chat_lines,
 		chat_timestamp,


### PR DESCRIPTION
Separated out from https://github.com/wesnoth/wesnoth/pull/11308 on request.

1. Sets reduced RNG as the default for new players.
2. Makes the RNG choice persistent by adding a stored preference for it (also adds version migration handling for it)