### PR TITLE
Replace er(m) -> uh/um

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -778,7 +778,7 @@
         [/message]
         [message]
             speaker=unit
-            message= _ "Err, yes, we’re here to fight the lizards."
+            message= _ "Uhh, yes, we’re here to fight the lizards."
         [/message]
         [message]
             speaker=Gweddry

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1248,7 +1248,7 @@ I shall not fall here."
         [/message]
         [message]
             speaker=$our_unit_id
-            message= _ "Err, hello?"
+            message= _ "Uhh, hello?"
         [/message]
         [message]
             speaker=$their_unit_id

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
@@ -1641,7 +1641,7 @@ The darkness between worlds opens its maw."
         [/message]
         [message]
             speaker=unit
-            message= _ "Err... don’t mind me, I’m just taking a look around."
+            message= _ "Uhh... don’t mind me, I’m just taking a look around."
         [/message]
         [message]
             speaker=Study Guard

--- a/data/campaigns/Heir_To_The_Throne/overworld/00b_central_wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/overworld/00b_central_wesnoth.cfg
@@ -988,7 +988,7 @@
                     [/message]
                     [message]
                         speaker=Elrian
-                        message= _ "Err, well, it’s really more of a loan than a gift. To be repaid plus interest once you assume the throne. I had to offer very generous terms — apparently you’re a “high-risk investment.”"
+                        message= _ "Uhh, well, it’s really more of a loan than a gift. To be repaid plus interest once you assume the throne. I had to offer very generous terms — apparently you’re a “high-risk investment.”"
                     [/message]
                     [message]
                         speaker=Elrian

--- a/data/campaigns/Heir_To_The_Throne/overworld/00c_northlands.cfg
+++ b/data/campaigns/Heir_To_The_Throne/overworld/00c_northlands.cfg
@@ -516,7 +516,7 @@ all others gain regeneration for one turn.</b></span>"
         [/message]
         [message]
             role=wesmere_guard {FILTER_ADJACENT id=Konrad}
-            message=_"Err, well, I was told not to let anyone in... but surely you and any companions of yours are an exception. Go on, and speak to your granddaughter."
+            message=_"Uhh, well, I was told not to let anyone in... but surely you and any companions of yours are an exception. Go on, and speak to your granddaughter."
         [/message]
         {MOVE_UNDER_KONRAD( {MOVE_UNIT id=Kalenz $stored_konrad.x $stored_konrad.y} {PUT_TO_RECALL_LIST id=Kalenz} )}
         {VARIABLE bm_wesmere_unlocked yes}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/07_Muff_Malals_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/07_Muff_Malals_Peninsula.cfg
@@ -268,7 +268,7 @@
             message_Elrian=_"We should hurry if we’re hoping to save that warrior, Konrad! I sense magical power in him, but one man alone will not prevail against the hordes of undead that roam this peninsula."
             message_Seimus=_"We must make haste if we wish to save that warrior, Konrad! I sense magical power in him, but one man alone will not prevail against the hordes of undead that roam this peninsula."
             message_Ulfdain=_"20-’gainst-1 fer that warrior, now them’s long odds e’en if he were a dwarf! Tha’ long-staff sixpenny sorcerer’ll be having a change o’ heart — literally! — once we’re through with ’im!"
-            message_Jeniver=_"Oh, oh my. That magical warrior looks rather, err, powerful, doesn’t he? But that’s also a lot, really quite many undead surrounding him. We’d better hurry if we want to save him."
+            message_Jeniver=_"Oh, oh my. That magical warrior looks rather, uhh, powerful, doesn’t he? But that’s also a lot, really quite many undead surrounding him. We’d better hurry if we want to save him."
             message_Dosh=_"Dat holy man be lookin’ mighty strong, but Dosh is thinking there’s too many o’ dem undead e’en for him. We’d better be helpin’ him out, Konrad."
             fallback_Konrad=_"We’d better move quickly and help fight! That warrior looks powerful, but the necromancer has the advantage of numbers."
         [/companion_message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/08b_Isle_of_the_Damned_part2.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08b_Isle_of_the_Damned_part2.cfg
@@ -311,7 +311,7 @@
         [message]
             speaker=Konrad
             #po: saying "500 years" is important, as the vampire lady says it takes her 500 years to regenerate after being destroyed. 500 years ago is when Haldric arrived and destroyed her the first time
-            message=_"I wonder who built this place, and for what purpose? The handiwork doesn’t look dwarvish, but it’s far too old to have been tunneled by men. Their— err, our kind has barely been on the Great Continent for 500 years!"
+            message=_"I wonder who built this place, and for what purpose? The handiwork doesn’t look dwarvish, but it’s far too old to have been tunneled by men. Their— uhh, our kind has barely been on the Great Continent for 500 years!"
         [/message]
         [companion_message]
             message_Ulfdain=_"Aye, ain’t no dwarf-tunnels, that’s for sure. Jus’ look at them ugly, lumpy walls! Whoever made this place weren’t no troll, neither."
@@ -319,7 +319,7 @@
             message_Elrian=_"I detect powerful magic down in these tunnels, Konrad, very old magic. But I can’t speak as to its origin."
             message_Seimus=_"I detect powerful magic down in these tunnels, Konrad, very old magic. But I can’t speak as to its origin."
             message_Moremirmu=_"There is a dark presence here, Konrad, foul; something that has rejected the Light and hides deep within this place. Beyond that I cannot say."
-            message_Jeniver=_"Well, err — the architecture is... ah, old. Mermish? Elvish, perhaps? But these caves are certainly natural. Someone found the caves and took up, err, residence?"
+            message_Jeniver=_"Well, uhh — the architecture is... ah, old. Mermish? Elvish, perhaps? But these caves are certainly natural. Someone found the caves and took up, uhh, residence?"
             message_Dosh=_"Dis not a troll hole, Konrad. But not a dwarf hole neither. An’ Dosh dunno who else be livin’ in caves."
         [/companion_message]
     [/event]
@@ -460,7 +460,7 @@
         [/message]
         [message]
             speaker=Konrad
-            message=_"You’re the leader of the outlaws? Err, we came to rescue you, and to put an end to the undead threat on the isle. What happened in this place?!"
+            message=_"You’re the leader of the outlaws? Uhh, we came to rescue you, and to put an end to the undead threat on the isle. What happened in this place?!"
         [/message]
         [message]
             speaker=Harper

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_Elensefar_After.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_Elensefar_After.cfg
@@ -368,7 +368,7 @@
             message_Ulfdain=_"Look there, boy! One o’ ’em city-folk’s gone yellow. I think he’s sneakin’ out to see us."
             message_Harper=_"Look, Konrad! Someone’s fording the river, sneakin’ out to see us. How is he movin’ across the deep water?!"
             message_Moremirmu=_"Hark, Konrad! One of the cityfolk steals across the river towards our shore!"
-            message_Jeniver=_"Oh, hello? Err... I think I see — yes, Konrad, someone’s sneaking across the river towards us."
+            message_Jeniver=_"Oh, hello? Uhh... I think I see — yes, Konrad, someone’s sneaking across the river towards us."
             message_Dosh=_"Look there, Konrad. Dosh is seein’ a softskin sneakin’ across dis river towards us."
             fallback_Konrad=_"Look, someone’s fording the river! I think he’s sneaking out of the city towards us."
         [/companion_message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Gryphon_Mountain.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Gryphon_Mountain.cfg
@@ -209,7 +209,7 @@
         )} {/IF}
         [message]
             speaker=Burlin
-            message=_"Err... look, Your Highness, this is just business. I’ve got nothin’ ’gainst neither you nor Asheviere, but I do want to keep my word an’ do my job."
+            message=_"Uhh... look, Your Highness, this is just business. I’ve got nothin’ ’gainst neither you nor Asheviere, but I do want to keep my word an’ do my job."
         [/message]
         [message]
             speaker=Burlin

--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Northern_Winter.cfg
@@ -173,7 +173,7 @@
             {/IF}
             [message]
                 speaker=Konrad
-                message=_"Err, hello? HELLO!"
+                message=_"Uhh, hello? HELLO!"
             [/message]
             {IF} {VARIABLE_CONDITIONAL s23_from equals e}
             {THEN({MODIFY_UNIT id=Jeniver facing se})}
@@ -189,7 +189,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message=_"Ah, I’m glad you asked! You see, I’m an — err, how should I say it — alchemist, yes, yes, alchemist is right. A researcher!"
+                message=_"Ah, I’m glad you asked! You see, I’m an — u, how should I say it — alchemist, yes, yes, alchemist is right. A researcher!"
             [/message]
             [message]
                 speaker=Konrad
@@ -201,7 +201,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message=_"Most of the herbs, you see, I’ve had no trouble collecting. Err, but, well, the local fauna — as you may surmise, the fauna has proven somewhat less cooperative than for which I was prepared... Right! But now you’re here to help!"
+                message=_"Most of the herbs, you see, I’ve had no trouble collecting. Uhh, but, well, the local fauna — as you may surmise, the fauna has proven somewhat less cooperative than for which I was prepared... Right! But now you’re here to help!"
             [/message]
             [message]
                 speaker=Jeniver
@@ -223,7 +223,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message=_"I only need three more ingredients to complete my experiments. Icemonax bile. Giant Spider venom — that one’s a doozy. And, err, believe it or not, Yeti tongue. If Yetis exist."
+                message=_"I only need three more ingredients to complete my experiments. Icemonax bile. Giant Spider venom — that one’s a doozy. And, uhh, believe it or not, Yeti tongue. If Yetis exist."
             [/message]
             [message]
                 speaker=Konrad
@@ -361,7 +361,7 @@
             {CLEAR_VARIABLE msg}
             [message]
                 speaker=Jeniver
-                message=_"Hmm? Oh, ah, did I forget to mention the chill? Silly me — there’s, err, yes there’s virtually always a storm blowing here; you’ll all be slowed down quite often, trying to keep warm while trudging through the deepening snowbanks. The local fauna are, of course, quite impervious to the cold."
+                message=_"Hmm? Oh, ah, did I forget to mention the chill? Silly me — there’s, uhh, yes there’s virtually always a storm blowing here; you’ll all be slowed down quite often, trying to keep warm while trudging through the deepening snowbanks. The local fauna are, of course, quite impervious to the cold."
             [/message]
             [companion_message]
                 message_Elrian=_"Brrr... this is a far cry from the warm shores of Alduin. Unless we have very fast warriors, we may have to split up if we want to collect all of Jeniver’s ingredients before we run out of time and the cold drives us away. The northeastern mountains look especially hard to reach."
@@ -380,7 +380,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message=_"But— err, of course I suppose I wouldn’t really be of much use to you unless you can gather at least some ingredients so that I can get my — you know — alchemical concoctions prepared. The more the better!"
+                message=_"But— uhh, of course I suppose I wouldn’t really be of much use to you unless you can gather at least some ingredients so that I can get my — you know — alchemical concoctions prepared. The more the better!"
             [/message]
         [/event]
         # Jeniver's slow would normally end on side 2 turn end. But that makes it look like she's not getting slowed at all, so sync her up to side 1 instead
@@ -598,7 +598,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message=_"Err, well, no, not quite. It’s more of a... distillation — yes, a process for refining and extracting more value out of your existing coin. But “transmutation” is a much more exciting word for alchemists. And etymology aside, my discovery will certainly help boost your income!"
+                message=_"Uhh, well, no, not quite. It’s more of a... distillation — yes, a process for refining and extracting more value out of your existing coin. But “transmutation” is a much more exciting word for alchemists. And etymology aside, my discovery will certainly help boost your income!"
             [/message]
             {MOVE_UNIT id=Jeniver 16 13}
             [object]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/30_The_Sceptre_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/30_The_Sceptre_of_Fire.cfg
@@ -622,9 +622,9 @@
             message_Seimus=_"I sense it too... there is a strangeness in the air. A fire in the soul of this place. But where? The cave is empty!"
             message_Ulfdain=_"Aye, tha’s nice... except there’s nothin’ here, ye cloud-headed flapdragon! It’s an empty cave!"
             message_Haldiel=_"But where is it, o’ great Delfador? The cave here is empty. Do we stand in the wrong place?"
-            message_Harper=_"Err... is this one o’ those confusing wizard things? Where’s the Sceptre? Th’ cave looks pretty empty to me."
+            message_Harper=_"Uhh... is this one o’ those confusing wizard things? Where’s the Sceptre? Th’ cave looks pretty empty to me."
             message_Moremirmu=_"Yea, truly there is a strangeness in the air here... not of the Light, but of something else entirely. But where is the source? The cave stands empty."
-            message_Jeniver=_"Err... it— it does? I don’t see anything... Oh! Is this a metaphor? The real treasure is the friends we made along the way?"
+            message_Jeniver=_"Uhh... it— it does? I don’t see anything... Oh! Is this a metaphor? The real treasure is the friends we made along the way?"
             message_Dosh=_"Dey say trolls are slow, but even Dosh can see dere’s nothing here. Flat and empty. Nothing for us to take, is dere?"
             fallback_Konrad=_"But where is it? I don’t see a thing!"
         [/companion_message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/42_A_Crisis_of_Leadership.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/42_A_Crisis_of_Leadership.cfg
@@ -422,7 +422,7 @@
                 speaker=faghmok
                 image_pos=right
                 mirror=yes
-                message=_"Ready? Pick a wagon, get in, and hide under the hay. Err... maybe we can find something less flammable than hay to cover up that fire thing."
+                message=_"Ready? Pick a wagon, get in, and hide under the hay. Uhh... maybe we can find something less flammable than hay to cover up that fire thing."
             [/message]
         [/then]
         {/ELSEIF}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/43_Cliffs_of_Thoria.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/43_Cliffs_of_Thoria.cfg
@@ -452,7 +452,7 @@ Gliders, send word to the first intendant of his ascension by fate."
                 [/message]
                 [message]
                     speaker=Jeniver
-                    message= _ "With more specimens, I’m sure I could learn something practical. If you could kill, say, err, thirty drakes — not including this one, that is — then I’m sure their fire could show me how to improve my flashpowder."
+                    message= _ "With more specimens, I’m sure I could learn something practical. If you could kill, say, uhh, thirty drakes — not including this one, that is — then I’m sure their fire could show me how to improve my flashpowder."
                 [/message]
                 {MOVE_UNIT id=Jeniver $coordX $coordY}
             )}
@@ -487,7 +487,7 @@ Gliders, send word to the first intendant of his ascension by fate."
                     [/message]
                     [message]
                         speaker=Jeniver
-                        message= _ "Err, and, well, of course I’ve extracted some particular reagents that could be useful on the battlefield as well. As promised."
+                        message= _ "Uhh, and, well, of course I’ve extracted some particular reagents that could be useful on the battlefield as well. As promised."
                     [/message]
                     {FIRE_EVENT jeniver_doubleattack_flashpowder}
                 )} {/IF}
@@ -645,7 +645,7 @@ Gliders, send word to the first intendant of his ascension by fate."
             message_Moremirmu=_"Forget not that he, like the others who fought us underground, came north with you to kill Konrad. If rescued shall he join our alliance, or shall he betray us to Asheviere?"
             #po: reference to this fable: https://en.wikipedia.org/wiki/The_Scorpion_and_the_Frog
             message_Ulfdain=_"Aye, so said the scorpion to the frog! Dinnae forget, that ninnyhammerin’ cad tried to kill Konrad not so long ago, same as all them other chuckle-heads who fought us underground! He’ll betray us to Asheviere quick as a wink."
-            message_Jeniver=_"It’s good to save a life and all, of course. But, err, well, you know, wasn’t he fighting underground trying to kill Konrad not too long ago? Is he going to join our alliance? What if he betrays us to Asheviere?"
+            message_Jeniver=_"It’s good to save a life and all, of course. But, uhh, well, you know, wasn’t he fighting underground trying to kill Konrad not too long ago? Is he going to join our alliance? What if he betrays us to Asheviere?"
             message_Dosh=_"Dosh don’t think dat be so smart. He was unnerground tryin’ to kill Konrad not too long ago, wasn’t he? Now we want to help him? Dosh thinks he’ll run quick as a wink back to dat queen, an’ we’ll be all da worse for it."
             fallback_Konrad=_"Do not forget that he, like all the others who fought us underground, once tried his utmost to kill me. Will he follow you, or will he choose to betray us to Asheviere?"
         [/companion_message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/44_Underground_Channels.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/44_Underground_Channels.cfg
@@ -340,7 +340,7 @@
         [/message]
         [message]
             speaker=Jeniver
-            message=_"Now, err, well, of course sap extraction would be problematic from a live specimen, them being our allies and all. But, ah, we are on a battlefield. <b><i>We</i></b> don’t have to be the ones doing the cutting."
+            message=_"Now, uhh, well, of course sap extraction would be problematic from a live specimen, them being our allies and all. But, ah, we are on a battlefield. <b><i>We</i></b> don’t have to be the ones doing the cutting."
         [/message]
         [message]
             speaker=Konrad
@@ -378,7 +378,7 @@
         [/object]
         [message]
             speaker=Jeniver
-            message=_"It works! It works! Oh, I knew it! Now, err, I suppose I’d better quickly get back to the battle before the woses wonder what I was doing with their friend."
+            message=_"It works! It works! Oh, I knew it! Now, uhh, I suppose I’d better quickly get back to the battle before the woses wonder what I was doing with their friend."
         [/message]
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/utils/smalltalk.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/smalltalk.cfg
@@ -408,7 +408,7 @@
         [/message]
         [message]
             speaker=Seimus
-            message= _ "Err, are you— who are you again? Many aspire to join the ranks of the magi, but few have the skill."
+            message= _ "Uhh, are you— who are you again? Many aspire to join the ranks of the magi, but few have the skill."
         [/message]
     )
     }
@@ -555,7 +555,7 @@
         [/message]
         [message]
             speaker=Konrad
-            message= _ "... err, but you can still tell me again. Your parts especially, Harper! I’d always be happy to listen."
+            message= _ "... uhh, but you can still tell me again. Your parts especially, Harper! I’d always be happy to listen."
         [/message]
     )
     }
@@ -725,7 +725,7 @@
         {FILTER_CONDITION({HAVE_UNIT( id=Jeniver {NOT({FILTER_WML_OBJECT_ID disable_blowgun})} )})}
         [message]
             speaker=Jeniver
-            message= _ "Oh! Is that another giant spider? I could use some more spider poison, err, venom — I suppose it’s not really poison — for my blowdarts. Can you kill one for me?"
+            message= _ "Oh! Is that another giant spider? I could use some more spider poison, uhh, venom — I suppose it’s not really poison — for my blowdarts. Can you kill one for me?"
         [/message]
         [event]
             name=die
@@ -862,7 +862,7 @@
         [/message]
         [message]
             speaker=Jeniver
-            message= _ "Oh! Oh, well then, Dosh, can I trouble you for a few pieces of your flesh? It’ll grow back, I’m sure. I have this, err, theory I want to try with regeneration, you see..."
+            message= _ "Oh! Oh, well then, Dosh, can I trouble you for a few pieces of your flesh? It’ll grow back, I’m sure. I have this, uhh, theory I want to try with regeneration, you see..."
         [/message]
         [message]
             speaker=Dosh
@@ -890,7 +890,7 @@
 
         [message]
             speaker=Jeniver
-            message= _ "Oh, a troll! Err, Konrad, you know, they say trolls have amazing powers of regeneration... in fact, I have something of a theory about the curative properties of troll-flesh..."
+            message= _ "Oh, a troll! Uhh, Konrad, you know, they say trolls have amazing powers of regeneration... in fact, I have something of a theory about the curative properties of troll-flesh..."
         [/message]
         [allow_undo]
         [/allow_undo]
@@ -933,7 +933,7 @@
             [/message]
             [message]
                 speaker=Jeniver
-                message= _ "I was— well, I was <b><i>trying</i></b> to unlock the secrets of the rapid curation of venoms; the curing of poison and bolstering of the body and so-on. But trollish regeneration seems, err, well— incompatible with my methods."
+                message= _ "I was— well, I was <b><i>trying</i></b> to unlock the secrets of the rapid curation of venoms; the curing of poison and bolstering of the body and so-on. But trollish regeneration seems, uhh, well— incompatible with my methods."
             [/message]
             [message]
                 speaker=Jeniver

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/13_The_Dwarven_Doors.cfg
@@ -318,7 +318,7 @@ end
 
                 [message]
                     role=Outlaw_Advisor
-                    message= _ "My uncle used to smuggle... err... I mean... trade food for the dwarves. He could get grain carts in under the very noses of those ugly orcs."
+                    message= _ "My uncle used to smuggle... uhh... I mean... trade food for the dwarves. He could get grain carts in under the very noses of those ugly orcs."
                 [/message]
                 [message]
                     role=Outlaw_Advisor

--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -391,7 +391,7 @@
 
         [message]
             speaker=unit
-            message= _ "Um... err... well actually we are presently busy fighting our way through hordes of trolls and skeletons trying to find the dwarves... if there are any left."
+            message= _ "Um... uhh... well actually we are presently busy fighting our way through hordes of trolls and skeletons trying to find the dwarves... if there are any left."
         [/message]
 
         [message]
@@ -401,7 +401,7 @@
 
         [message]
             speaker=unit
-            message= _ "Er... let’s go..."
+            message= _ "Uh... let’s go..."
         [/message]
 
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -2228,7 +2228,7 @@
 
         [message]
             speaker=Abhai
-            message= _ "Wouldn’t miss it. Maybe after he is destroyed my kind and I can live... er... be dead peacefully."
+            message= _ "Wouldn’t miss it. Maybe after he is destroyed my kind and I can live... uh... be dead peacefully."
         [/message]
 
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/07a_Settling_Disputes.cfg
@@ -394,7 +394,7 @@
             [then]
                 [message]
                     speaker=Camerin
-                    message= _ "Ro’Sothian! How are you doing, my old friend! Boy, you sure look... erm... different!"
+                    message= _ "Ro’Sothian! How are you doing, my old friend! Boy, you sure look... um... different!"
                 [/message]
 
                 [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/09a_Introductions.cfg
@@ -309,7 +309,7 @@
 
                 [message]
                     speaker=Elenia
-                    message= _ "Er, Eryssa... there is a large elvish force moving this direction. By now they cannot be more than two days’ march from here. It seems that our father sent them to either free you or bargain for your release."
+                    message= _ "Uh, Eryssa... there is a large elvish force moving this direction. By now they cannot be more than two days’ march from here. It seems that our father sent them to either free you or bargain for your release."
                 [/message]
 
                 [message]

--- a/data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/scenarios/02_Swimming_with_Serpents.cfg
@@ -465,7 +465,7 @@ opponents can make a big difference."
         [/message]
         [message]
             speaker=Thea
-            message= _ "Constable Thea? I’m not— err..."
+            message= _ "Constable Thea? I’m not— uhh..."
         [/message]
         {MODIFY_UNIT id=Thea name _"Constable Thea"}
         [message]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
@@ -306,7 +306,7 @@
         [/message]
         [message]
             speaker="Grüü"
-            message= _ "Err... well..."
+            message= _ "Uhh... well..."
         [/message]
     [/event]
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
@@ -162,7 +162,7 @@
         [/message]
         [message]
             speaker="Kapou'e"
-            message= _ "Well, ermmm..."
+            message= _ "Well, ummm..."
         [/message]
         [message]
             speaker="Echarp"

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -576,7 +576,7 @@
         [message]
             speaker=Grüü
             image=portraits/gruu.webp~FL()~RIGHT()
-            message= _ "Err, sorry, there were some humans in way. We squash, no problem."
+            message= _ "Uhh, sorry, there were some humans in way. We squash, no problem."
         [/message]
 
         [message]

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg
@@ -183,7 +183,7 @@
         [/message]
         [message]
             speaker=Delfador
-            message=_"I’ve heard tell of tree-folk... you must be a wose! Err, I’m terribly sorry for the fireball. I couldn’t tell you apart from an ordinary oak."
+            message=_"I’ve heard tell of tree-folk... you must be a wose! Uhh, I’m terribly sorry for the fireball. I couldn’t tell you apart from an ordinary oak."
         [/message]
         [message]
             speaker=leader2

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/09_Omaranth.cfg
@@ -222,7 +222,7 @@
             [/message]
             [message]
                 speaker=Delfador
-                message=_"Us females? Err, yes, that’s right."
+                message=_"Us females? Uhh, yes, that’s right."
             [/message]
         [/event]
     [/event]

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/11x_Revelry.cfg
@@ -288,7 +288,7 @@ Mayhaps as High Advisor I can finally get someone to research that... (<i>yawn</
         {DELAY 500}
         [message]
             speaker=Delfador
-            message=_"Err... I’m not sure I follow, Your Highness—"
+            message=_"Uhh... I’m not sure I follow, Your Highness—"
         [/message]
 
         {RECALL_XY Garard 16 8}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
@@ -1018,7 +1018,7 @@
 
         [message]
             speaker=Lady Jessene
-            message= _ "Erm, yes... He was Caror, the arch rival of our dearly departed Lich-Lord Lenvan. He coveted the ruby, and was studying it. The only copy of his study, the Book of Fire and Darkness, was petrified along with him."
+            message= _ "Um, yes... He was Caror, the arch rival of our dearly departed Lich-Lord Lenvan. He coveted the ruby, and was studying it. The only copy of his study, the Book of Fire and Darkness, was petrified along with him."
         [/message]
 
         [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/15_A_New_Land.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/15_A_New_Land.cfg
@@ -422,7 +422,7 @@
         [/message]
         [message]
             speaker=Glimir
-            message= _ "We thought we were being invaded. We, erm, put our differences aside with the dwarves, for the moment, and decided to deal with this first."
+            message= _ "We thought we were being invaded. We, um, put our differences aside with the dwarves, for the moment, and decided to deal with this first."
         [/message]
         [message]
             speaker=Lady Dionli

--- a/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
@@ -171,7 +171,7 @@
             speaker=Deoran
             image=portraits/deoran-glad.webp
             #po: deoran is fresh out of training, bright-eyed and eager to prove himself
-            message= _ "Lieutenant Deoran, reporting for duty SIR! ...err, ma’am."
+            message= _ "Lieutenant Deoran, reporting for duty SIR! ...uhh, ma’am."
         [/message]
         [message]
             speaker=Mari

--- a/data/campaigns/The_South_Guard/scenarios/05c_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05c_Into_the_Depths.cfg
@@ -292,7 +292,7 @@ hard time."
         [/message]
         [message]
             speaker=Deoran
-            message= _ "Err, no need for any squishing, we don’t mean to trespass on your territory. We’re hunting the undead and have no quarrel with you."
+            message= _ "Uhh, no need for any squishing, we don’t mean to trespass on your territory. We’re hunting the undead and have no quarrel with you."
         [/message]
         [message]
             speaker=unit


### PR DESCRIPTION
It might just be me, but all these ers and erms make the characters sound British. I'm pretty sure there's a soft rule that we're supposed to use American English.

Obviously I don't expect this to be merged for the upcoming release though (we're in string freeze, right?)