### PR TITLE
schema_validation.sh: Automatically revert patch on exit or termination

### DIFF
--- a/utils/CI/schema_validation.sh
+++ b/utils/CI/schema_validation.sh
@@ -80,6 +80,22 @@ validate_campaign() {
 
 RET=0
 
+revert_patch() {
+    # get exit code
+    local exit_code=$?
+
+    # revert the changes made by schema_validation.patch
+    patch -R -p 1 < utils/CI/schema_validation.patch
+
+    exit $exit_code
+}
+
+# trap to revert changes when script finishes or gets terminated 
+trap revert_patch EXIT
+# exit 1 will trigger EXIT trap
+trap 'exit 1' INT TERM
+
+
 # remove any_tag to actually see errors in action WML
 patch -p 1 < utils/CI/schema_validation.patch || RET=1
 

--- a/utils/CI/schema_validation.sh
+++ b/utils/CI/schema_validation.sh
@@ -81,19 +81,12 @@ validate_campaign() {
 RET=0
 
 revert_patch() {
-    # get exit code
-    local exit_code=$?
-
     # revert the changes made by schema_validation.patch
     patch -R -p 1 < utils/CI/schema_validation.patch
-
-    exit $exit_code
 }
 
 # trap to revert changes when script finishes or gets terminated 
 trap revert_patch EXIT
-# exit 1 will trigger EXIT trap
-trap 'exit 1' INT TERM
 
 
 # remove any_tag to actually see errors in action WML


### PR DESCRIPTION
Fixes #9967. 

`schema_validation.sh` applies `schema_validation.patch` to temporarily remove `any_tag=yes` from `data/schema/core/actionwml.cfg` and `data/schema/core/conditionalwml.cfg` files. However, the changes are not undone after that.


I added a `revert_patch` function that reverses the patch and registered it via trap so it runs automatically regardless of how the script exits:

- `trap revert_patch EXIT` will do the revert on normal completion, or on any validation failure.
- `trap 'exit 1' INT TERM` will also do the same cleanup if the script is interrupted or terminated, by triggering the EXIT trap, which runs `revert_patch`. (Edit: removed this line in my recent commit, this isn't needed for bash)
- Also, the original exit code is captured at the top of `revert_patch` and re-asserted at the end, so the script's success/failure status is preserved. (Edit: Removed this in my recent commit, according to [this](https://stackoverflow.com/questions/41619629/exit-code-of-traps-in-bash) the exit code will be preserved after the function is done)

I tested the changes locally by running the script without a wesnoth binary (so many validation steps failed), and confirmed `git status` is clean after the script exits, with the correct exit code still preserved.