### PR TITLE
Lua: getter/setter for cursor position and selection length

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Editor
 ### Multiplayer
 ### Lua API
+   * `text_box` gui widget now has the gettable and settable properties `selection_start` and `selection_length` for cursor position/selection start and length of text selection respectively.
 ### Packaging
 ### Terrain
 ### Translations

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -342,6 +342,7 @@ protected:
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
+public:
 	std::size_t get_selection_start() const
 	{
 		return selection_start_;
@@ -354,15 +355,14 @@ protected:
 	}
 	void set_selection_length(const int selection_length);
 
-	std::size_t get_composition_start() const
-	{
-		return ime_start_point_;
-	}
-
-public:
 	bool is_composing() const
 	{
 		return ime_composing_;
+	}
+
+	std::size_t get_composition_start() const
+	{
+		return ime_start_point_;
 	}
 
 	void interrupt_composition();

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -634,6 +634,29 @@ WIDGET_SETTER("max_input_length", int, gui2::text_box)
 	try_invalidate_layout(w);
 }
 
+WIDGET_GETTER("selection_start", int, gui2::text_box_base)
+{
+	return w.get_selection_start() + 1;
+}
+
+WIDGET_GETTER("selection_length", int, gui2::text_box_base)
+{
+	return w.get_selection_length();
+}
+
+WIDGET_SETTER("selection_start", int, gui2::text_box_base)
+{
+	if(value < 1) {
+		throw std::invalid_argument("selection_start must be >= 1");
+	}
+	w.set_selection_start(value - 1);
+}
+
+WIDGET_SETTER("selection_length", int, gui2::text_box_base)
+{
+	w.set_selection_length(value);
+}
+
 WIDGET_GETTER("step_size", int, gui2::slider)
 {
 	return w.get_step_size();

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -188,6 +188,8 @@ function gui.add_widget_definition(type, id, content) end
 ---@field hint_text tstring
 ---@field history string
 ---@field max_input_length integer
+---@field selection_start integer Cursor position in the text. Index of the first selected code point, or the code point just after the insertion point. Can be one greater than the length of the text, if the insertion point is at the end.
+---@field selection_length integer Number of code points in the selected text. If negative, counts back from the start position instead of forward.
 ---@field on_modified fun()
 
 ---A label that wraps its text and also has a vertical scrollbar


### PR DESCRIPTION
Added Lua getter and setters for new properties `selection_start` and `selection_length` on `gui2::text_box_base` (aka any text box based widgets).

Note: `selection_start` is the cursor position.

Resolves #11215