### PR TITLE
Cache Chat Log

### DIFF
--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -359,6 +359,11 @@ void replay::remove_command(int index)
 
 const std::vector<chat_msg>& replay::build_chat_log() const
 {
+	// Don't rebuild if no new messages.	
+	if(last_message_location_count == message_locations.size()) {
+		return message_log;
+	}
+
 	message_log.clear();
 	std::vector<int>::const_iterator loc_it;
 	int last_location = 0;

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -357,10 +357,6 @@ void replay::remove_command(int index)
 	}
 }
 
-// cached message log
-static std::vector< chat_msg > message_log;
-
-
 const std::vector<chat_msg>& replay::build_chat_log() const
 {
 	message_log.clear();
@@ -375,6 +371,7 @@ const std::vector<chat_msg>& replay::build_chat_log() const
 		add_chat_log_entry(speak, chat_log_appender);
 
 	}
+	last_message_location_count = message_locations.size();
 	return message_log;
 }
 

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -359,7 +359,7 @@ void replay::remove_command(int index)
 
 const std::vector<chat_msg>& replay::build_chat_log() const
 {
-	// Don't rebuild if no new messages.	
+	// Don't rebuild if no new messages.
 	if(last_message_location_count == message_locations.size()) {
 		return message_log;
 	}

--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -163,6 +163,9 @@ private:
 	replay_recorder_base* base_;
 	int sent_upto_;
 	std::vector<int> message_locations;
+	// Cache for build_chat_log().
+	mutable std::vector<chat_msg> message_log;
+	mutable std::size_t last_message_location_count = 0;
 };
 
 enum REPLAY_RETURN


### PR DESCRIPTION
Attempts to address #1086. Re-scopes `message_log` and its new corresponding counter/gauge to the `replay` class, then determines whether to rebuild the chat log depending on whether that counter/gauge has changed.