### PR TITLE
TSG, PaP: disable hints about Reduced RNG

### DIFF
--- a/data/campaigns/Of_Pearls_and_Pirates/utils/savescumming.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/utils/savescumming.cfg
@@ -95,56 +95,56 @@
         [/allow_undo]
     [/event]
 
-    [event]
-        name=preload
-        first_time_only=no
-        {FILTER_CONDITION({VARIABLE_CONDITIONAL enable_tutorial_elements equals yes})}
-        {GET_GLOBAL_VARIABLE gamestate_global}
-        [if] {VARIABLE_CONDITIONAL global_tmp not_equals $gamestate_local}
-            [then]
-                {GLOBAL_VARIABLE_OP saveloads_this_turn add 1}
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE global_tmp}
-        # if we've save-loaded 4 times this turn
-        {GET_GLOBAL_VARIABLE saveloads_this_turn}
-        [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
-            [then]
-                # and we haven't already shown this tip
-                {GET_GLOBAL_VARIABLE pap_saveload_info}
-                [if] {VARIABLE_CONDITIONAL global_tmp not_equals yes}
-                    [then]
-                        {SET_GLOBAL_VARIABLE pap_saveload_info yes}
-                        [display_tip]
-                            title=_"Save-Loading and RNG"
-                            image=tutor/saveload.png
-                            message=_"I notice you’ve been loading a lot of saved games.
-If this is how you prefer to play, power to you!
-
-But if you’re save-loading because hits and misses
-feel unfair, try restarting the campaign and 
-selecting <i><b>“Reduced RNG”</b></i> instead of <i><b>“Default RNG”</b></i>.
-You’re also welcome to turn down the difficulty:
-when you load a “start-of-scenario” save, there’s 
-a little <i><b>“change difficulty”</b></i> box you can check.
-
-Alternatively, you may want to go back to a previous
-turn or even scenario, to choose a different strategy
-or carry over additional gold.
-
-We balance campaigns around minimal save-loading 
-and have completed all campaigns without any 
-save-loading during development. It’s not expected to 
-beat campaigns without losses.
-
-Save-load all you want if it makes the game more fun,
-but don’t feel like you’re required to save-load in 
-order to win!"
-                        [/display_tip]
-                    [/then]
-                [/if]
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE global_tmp}
-    [/event]
+    #     [event]
+    #         name=preload
+    #         first_time_only=no
+    #         {FILTER_CONDITION({VARIABLE_CONDITIONAL enable_tutorial_elements equals yes})}
+    #         {GET_GLOBAL_VARIABLE gamestate_global}
+    #         [if] {VARIABLE_CONDITIONAL global_tmp not_equals $gamestate_local}
+    #             [then]
+    #                 {GLOBAL_VARIABLE_OP saveloads_this_turn add 1}
+    #             [/then]
+    #         [/if]
+    #         {CLEAR_VARIABLE global_tmp}
+    #         # if we've save-loaded 4 times this turn
+    #         {GET_GLOBAL_VARIABLE saveloads_this_turn}
+    #         [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+    #             [then]
+    #                 # and we haven't already shown this tip
+    #                 {GET_GLOBAL_VARIABLE pap_saveload_info}
+    #                 [if] {VARIABLE_CONDITIONAL global_tmp not_equals yes}
+    #                     [then]
+    #                         {SET_GLOBAL_VARIABLE pap_saveload_info yes}
+    #                         [display_tip]
+    #                             title=_"Save-Loading and RNG"
+    #                             image=tutor/saveload.png
+    #                             message=_"I notice you’ve been loading a lot of saved games.
+    # If this is how you prefer to play, power to you!
+    #
+    # But if you’re save-loading because hits and misses
+    # feel unfair, try restarting the campaign and
+    # selecting <i><b>“Reduced RNG”</b></i> instead of <i><b>“Default RNG”</b></i>.
+    # You’re also welcome to turn down the difficulty:
+    # when you load a “start-of-scenario” save, there’s
+    # a little <i><b>“change difficulty”</b></i> box you can check.
+    #
+    # Alternatively, you may want to go back to a previous
+    # turn or even scenario, to choose a different strategy
+    # or carry over additional gold.
+    #
+    # We balance campaigns around minimal save-loading
+    # and have completed all campaigns without any
+    # save-loading during development. It’s not expected to
+    # beat campaigns without losses.
+    #
+    # Save-load all you want if it makes the game more fun,
+    # but don’t feel like you’re required to save-load in
+    # order to win!"
+    #                         [/display_tip]
+    #                     [/then]
+    #                 [/if]
+    #             [/then]
+    #         [/if]
+    #         {CLEAR_VARIABLE global_tmp}
+    #     [/event]
 #enddef

--- a/data/campaigns/The_South_Guard/utils/savescumming.cfg
+++ b/data/campaigns/The_South_Guard/utils/savescumming.cfg
@@ -95,56 +95,56 @@
         [/allow_undo]
     [/event]
 
-    [event]
-        name=preload
-        first_time_only=no
-        {FILTER_CONDITION({VARIABLE_CONDITIONAL enable_tutorial_elements equals yes})}
-        {GET_GLOBAL_VARIABLE gamestate_global}
-        [if] {VARIABLE_CONDITIONAL global_tmp not_equals $gamestate_local}
-            [then]
-                {GLOBAL_VARIABLE_OP saveloads_this_turn add 1}
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE global_tmp}
-        # if we've save-loaded 4 times this turn
-        {GET_GLOBAL_VARIABLE saveloads_this_turn}
-        [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
-            [then]
-                # and we haven't already shown this tip
-                {GET_GLOBAL_VARIABLE sg_saveload_info}
-                [if] {VARIABLE_CONDITIONAL global_tmp not_equals yes}
-                    [then]
-                        {SET_GLOBAL_VARIABLE sg_saveload_info yes}
-                        [display_tip]
-                            title=_"Save-Loading and RNG"
-                            image=tutor/saveload.png
-                            message=_"I notice you’ve been loading a lot of saved games.
-If this is how you prefer to play, power to you!
-
-But if you’re save-loading because hits and misses
-feel unfair, try restarting the campaign and 
-selecting <i><b>“Reduced RNG”</b></i> instead of <i><b>“Default RNG”</b></i>.
-You’re also welcome to turn down the difficulty:
-when you load a “start-of-scenario” save, there’s 
-a little <i><b>“change difficulty”</b></i> box you can check.
-
-Alternatively, you may want to go back to a previous
-turn or even scenario, to choose a different strategy
-or carry over additional gold.
-
-We balance campaigns around minimal save-loading 
-and have completed all campaigns without any 
-save-loading during development. It’s not expected to 
-beat campaigns without losses.
-
-Save-load all you want if it makes the game more fun,
-but don’t feel like you’re required to save-load in 
-order to win!"
-                        [/display_tip]
-                    [/then]
-                [/if]
-            [/then]
-        [/if]
-        {CLEAR_VARIABLE global_tmp}
-    [/event]
+    #     [event]
+    #         name=preload
+    #         first_time_only=no
+    #         {FILTER_CONDITION({VARIABLE_CONDITIONAL enable_tutorial_elements equals yes})}
+    #         {GET_GLOBAL_VARIABLE gamestate_global}
+    #         [if] {VARIABLE_CONDITIONAL global_tmp not_equals $gamestate_local}
+    #             [then]
+    #                 {GLOBAL_VARIABLE_OP saveloads_this_turn add 1}
+    #             [/then]
+    #         [/if]
+    #         {CLEAR_VARIABLE global_tmp}
+    #         # if we've save-loaded 4 times this turn
+    #         {GET_GLOBAL_VARIABLE saveloads_this_turn}
+    #         [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+    #             [then]
+    #                 # and we haven't already shown this tip
+    #                 {GET_GLOBAL_VARIABLE sg_saveload_info}
+    #                 [if] {VARIABLE_CONDITIONAL global_tmp not_equals yes}
+    #                     [then]
+    #                         {SET_GLOBAL_VARIABLE sg_saveload_info yes}
+    #                         [display_tip]
+    #                             title=_"Save-Loading and RNG"
+    #                             image=tutor/saveload.png
+    #                             message=_"I notice you’ve been loading a lot of saved games.
+    # If this is how you prefer to play, power to you!
+    #
+    # But if you’re save-loading because hits and misses
+    # feel unfair, try restarting the campaign and
+    # selecting <i><b>“Reduced RNG”</b></i> instead of <i><b>“Default RNG”</b></i>.
+    # You’re also welcome to turn down the difficulty:
+    # when you load a “start-of-scenario” save, there’s
+    # a little <i><b>“change difficulty”</b></i> box you can check.
+    #
+    # Alternatively, you may want to go back to a previous
+    # turn or even scenario, to choose a different strategy
+    # or carry over additional gold.
+    #
+    # We balance campaigns around minimal save-loading
+    # and have completed all campaigns without any
+    # save-loading during development. It’s not expected to
+    # beat campaigns without losses.
+    #
+    # Save-load all you want if it makes the game more fun,
+    # but don’t feel like you’re required to save-load in
+    # order to win!"
+    #                         [/display_tip]
+    #                     [/then]
+    #                 [/if]
+    #             [/then]
+    #         [/if]
+    #         {CLEAR_VARIABLE global_tmp}
+    #     [/event]
 #enddef

--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -313,27 +313,27 @@ in the next scenario, so don’t delay!"
             speaker=unit
             message= _ "A good commander understands the odds, and knows how to both exploit good luck and mitigate bad luck. After all, both good and bad luck are equally likely!"
         [/message]
-        [display_tip]
-            title=_"Managing Luck"
-            image=tutor/luck.png
-            message=_"Wesnoth is a game about flexible strategy,
-not deterministic calculation.
-Anyone can win when things go as planned.
-Wesnoth’s skill &amp; mastery lie in creating
-a strategy that <i><b>mitigates bad luck</b></i>, while
-simultaneously <i><b>exploits good luck</b></i>. Both
-bad and good luck are inevitable, so be 
-ready to handle both!
-
-Expert players are so skilled at this that
-they can prevail in every campaign on even 
-the highest difficulty, without save-loading!
-
-That said, if you really prefer a more
-deterministic experience, try selecting
-<i><b>“Reduced RNG”</b></i> when starting a new 
-campaign."
-        [/display_tip]
+        #         [display_tip]
+        #             title=_"Managing Luck"
+        #             image=tutor/luck.png
+        #             message=_"Wesnoth is a game about flexible strategy,
+        # not deterministic calculation.
+        # Anyone can win when things go as planned.
+        # Wesnoth’s skill &amp; mastery lie in creating
+        # a strategy that <i><b>mitigates bad luck</b></i>, while
+        # simultaneously <i><b>exploits good luck</b></i>. Both
+        # bad and good luck are inevitable, so be
+        # ready to handle both!
+        #
+        # Expert players are so skilled at this that
+        # they can prevail in every campaign on even
+        # the highest difficulty, without save-loading!
+        #
+        # That said, if you really prefer a more
+        # deterministic experience, try selecting
+        # <i><b>“Reduced RNG”</b></i> when starting a new
+        # campaign."
+        #         [/display_tip]
         {VARIABLE sg_rnginfo_1 yes}
     [/event]
 


### PR DESCRIPTION
Once #11308 merges, new players will default to Reduced RNG, and hints suggesting the option to switch to Reduced RNG will be redundant.

I'm commenting out these hints instead of removing them entirely, with the intention of editing and restoring them in 1.21 after the string freeze.