### PR TITLE
Android/reachmap: hide reachmap after deselection

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1138,7 +1138,10 @@ void mouse_handler::touch_action(const map_location touched_hex, bool browse)
 	if(touched_hex.valid() && unit.valid() && !unit->get_hidden()) {
 		if(touched_hex == selected_hex_) {
 			deselect_hex();
+			gui().unhighlight_reach();
+			disable_units_highlight();
 		} else {
+			enable_units_highlight();
 			select_or_action(browse);
 		}
 	}


### PR DESCRIPTION
Hiding the reachmap clearly indicates the unit is deselected and avoids confusion.

[NB: used Claude to understand what the relevant code in `mouse_events.cpp` was doing.]

Explanation:
`gui().unhighlight_reach()` clears the reachmap, but the redraw happens via mouse_motion events that follow, which only stops drawing reachmap if `preventing_units_highlight_` is false. So I turn it off after deselection, and turn it back on again when the unit is selected.

Resolves #11354.