### PR TITLE
Do not consider logical presentation when getting the render output size

### DIFF
--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -139,7 +139,9 @@ point window::get_size()
 point window::get_output_size()
 {
 	point res;
-	SDL_GetCurrentRenderOutputSize(*this, &res.x, &res.y);
+	// Not using SDL_GetCurrentRenderOutputSize because that returns the size of the rendering target adjusted for current logical presentation state.
+	// This function returns the size of the rendering target ignoring logical presentation, which is what Wesnoth requires to detect window resizes.
+	SDL_GetRenderOutputSize(*this, &res.x, &res.y);
 
 	return res;
 }


### PR DESCRIPTION
Wesnoth requires this in order to trigger window resizes.

In the interests of disclosure, I had LLM assistance to track this down, but I wrote the commentary myself. It appears @Pentarctagon was simply following the official migration guide when changing from SDL2's `SDL_GetRendererOutputSize` to SDL3's `SDL_GetCurrentRenderOutputSize`.

>  ...it's not that whoever ported this code picked the wrong one of two confusingly-named functions — SDL's own official migration guide (docs/README-migration.md) literally states:

> SDL_GetRendererOutputSize() => SDL_GetCurrentRenderOutputSize(), returns bool

> That's the documented, recommended 1:1 rename. The [Wesnoth] port followed it to the letter. The catch is that the rename isn't really 1:1 — it's a name carried over onto a function with a quietly different contract. In SDL2, `SDL_RenderSetLogicalSize()` worked by directly mutating the renderer's viewport/scale state, so `SDL_GetRendererOutputSize()` (**which always ignored viewport/scale**) was untouched by it — it always gave you the true pixel size. In SDL3, logical presentation was redesigned to be tracked as its own persistent state rather than baked into viewport/scale, and in that redesign `SDL_GetCurrentRenderOutputSize()` picked up "adjusted for logical presentation" as part of its meaning. SDL3 also added a new function, `SDL_GetRenderOutputSize()` (no "Current"), that carries the old ignore-logical-presentation behaviour — but the migration guide's rename table doesn't mention it or flag that the semantics shifted.

Resolves #11266.
