### PR TITLE
Favour unit unselection over context menu if right-clicking on a unit

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -853,6 +853,19 @@ pathfind::marked_route mouse_handler::get_route(const unit* un, map_location go_
 	return mark_route(route);
 }
 
+bool mouse_handler::right_click(int /*x*/, int /*y*/, const bool /*browse*/)
+{
+	// Right-click unselect fires between this call (button down) and right_mouse_up() (button up)
+	// which clears selected_hex_ before right_click_show_menu() can read it.
+	// So remember the unit selection here for the case where a right-click lands on a unit, so that
+	// unit unselection takes precedence over the context menu. Refer: GitHub #2905
+	if(selected_hex_.valid()) {
+		unselected_reach_ = true;
+	}
+
+	return true;
+}
+
 bool mouse_handler::right_click_show_menu(int x, int y, const bool /*browse*/)
 {
 	if(selected_hex_.valid() || unselected_reach_) {

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -128,6 +128,7 @@ protected:
 	 */
 	void mouse_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location()) override;
 	bool mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc, bool click = false) override;
+	bool right_click(int x, int y, const bool browse) override;
 	bool right_click_show_menu(int x, int y, const bool browse) override;
 //	bool left_click(int x, int y, const bool browse);
 	bool move_unit_along_current_route();


### PR DESCRIPTION
Resolves #2905.

Disclosure: LLM-assisted debugging, but I wrote the change myself.