### PR TITLE
Explicitly set font for monospace family

### DIFF
--- a/fonts/fonts.conf
+++ b/fonts/fonts.conf
@@ -35,7 +35,8 @@ hintstyle for all platforms while at it.
 
 Windows is forced to rely on this file as there is no system fontconfig available
 to resolve generic CSS-style family names. So define monospace explicitly here.
-See GitHub #7462.
+DejaVu Sans Mono is already included in this fonts/ directory and is included in
+Windows installations. See GitHub #7462.
 
 -->
 

--- a/fonts/fonts.conf
+++ b/fonts/fonts.conf
@@ -33,6 +33,21 @@ hintstyle for all platforms while at it.
 
 <!-- 
 
+Windows is forced to rely on this file as there is no system fontconfig available
+to resolve generic CSS-style family names. So define monospace explicitly here.
+See GitHub #7462.
+
+-->
+
+<alias>
+	<family>monospace</family>
+	<prefer>
+		<family>DejaVu Sans Mono</family>
+	</prefer>
+</alias>
+
+<!-- 
+
 Scale down Noto Sans JP. 
 It is bit taller than Lato and causes slight problems (See #10063). 
 


### PR DESCRIPTION
Needed since Windows doesn't have a system fontconfig to fall back to.

Resolves #7462.

Disclosure: LLM-assisted analysis, but I wrote the changes myself.