### PR TITLE
Do not show translation percentage for system default language

### DIFF
--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -106,7 +106,11 @@ void language_selection::pre_show()
 				{ "use_markup", "true" }
 			}},
 			{ "translated_total", {
-				{ "label", markup::span_color(game_config::red_to_green(lang.percent), lang.percent, "%") },
+				{
+					"label",
+					lang.localename.empty() ? "" :	// do not show 100% for system default language
+						markup::span_color(game_config::red_to_green(lang.percent), lang.percent, "%")
+				},
 				{ "use_markup", "true" }
 			}},
 		});


### PR DESCRIPTION
Removes confusion over / resolves #8898.

<img width="736" height="968" alt="image" src="https://github.com/user-attachments/assets/b107b43f-a0e8-4f79-b9ca-21e3cde87b4e" />
