### PR TITLE
Disable show/hide languages option if all languages are always shown

### DIFF
--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -93,6 +93,13 @@ void language_selection::pre_show()
 	connect_signal_mouse_left_click(show_all_toggle, std::bind(
 			&language_selection::shown_filter_callback, this));
 
+	// Disable show all languages toggle when --all-translations or --translations-over 0
+	// command line options are used, since in these cases there is no difference in the
+	// languages shown between toggles, making it redundant.
+	if(get_min_translation_percent() <= 0) {
+		show_all_toggle.set_active(false);
+	}
+
 	const language_def& current_language = get_language();
 
 	for(const auto& lang : langs_) {


### PR DESCRIPTION
Related to second point of #9013.

Incidentally, I didn't know about the `--translations-over` option until the LLM pointed it out. Curiously, there's no validation of the input there - it appears negative numbers get wrapped around during the comparison against the percentage values. Either way, for the case where all translations get shown regardless, the option is disabled.