### PR TITLE
Only show the tutorial hint about Biased RNG when Default RNG is active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,17 @@
 ### Add-ons client
 ### Add-ons server
 ### Campaigns
+   * Of Pearls and Pirates
+     * Don’t show the tutorial hint about save-loading when Biased RNG is active
    * The Deceivers Gambit
      * Fix missing siphon attack sound, which would cause a crash anytime the attack was used.
+   * The South Guard
+     * Don’t show some of the tutorial hints about RNG when Biased RNG is active
 ### Editor
 ### Multiplayer
 ### Lua API
    * `text_box` gui widget now has the gettable and settable properties `selection_start` and `selection_length` for cursor position/selection start and length of text selection respectively.
+   * Added getter `wesnoth.game_config.random_mode`, which is only intended to be used for the tutorial hints.
 ### Packaging
 ### Terrain
 ### Translations

--- a/data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/scenarios/01_Pirates.cfg
@@ -17,6 +17,7 @@
     {EXTRA_SCENARIO_MUSIC battle.ogg}
     {EXTRA_SCENARIO_MUSIC knolls.ogg}
     {EXTRA_SCENARIO_MUSIC traveling_minstrels.ogg}
+    {RESET_SAVELOAD_TIP}
 
     [story]
         [part]

--- a/data/campaigns/Of_Pearls_and_Pirates/utils/savescumming.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/utils/savescumming.cfg
@@ -108,7 +108,14 @@
         {CLEAR_VARIABLE global_tmp}
         # if we've save-loaded 4 times this turn
         {GET_GLOBAL_VARIABLE saveloads_this_turn}
-        [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+        [if]
+            {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+            [and]
+                [lua]
+                    # True when Default RNG is active (it's represented by an empty string)
+                    code=<< return ("" == wesnoth.game_config.random_mode) >>
+                [/lua]
+            [/and]
             [then]
                 # and we haven't already shown this tip
                 {GET_GLOBAL_VARIABLE pap_saveload_info}

--- a/data/campaigns/The_South_Guard/utils/savescumming.cfg
+++ b/data/campaigns/The_South_Guard/utils/savescumming.cfg
@@ -108,7 +108,14 @@
         {CLEAR_VARIABLE global_tmp}
         # if we've save-loaded 4 times this turn
         {GET_GLOBAL_VARIABLE saveloads_this_turn}
-        [if] {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+        [if]
+            {VARIABLE_CONDITIONAL global_tmp greater_than_equal_to 4}
+            [and]
+                [lua]
+                    # True when Default RNG is active (it's represented by an empty string)
+                    code=<< return ("" == wesnoth.game_config.random_mode) >>
+                [/lua]
+            [/and]
             [then]
                 # and we haven't already shown this tip
                 {GET_GLOBAL_VARIABLE sg_saveload_info}

--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -313,10 +313,16 @@ in the next scenario, so don’t delay!"
             speaker=unit
             message= _ "A good commander understands the odds, and knows how to both exploit good luck and mitigate bad luck. After all, both good and bad luck are equally likely!"
         [/message]
-        [display_tip]
-            title=_"Managing Luck"
-            image=tutor/luck.png
-            message=_"Wesnoth is a game about flexible strategy,
+        [if]
+            [lua]
+                # True when Default RNG is active (it's represented by an empty string)
+                code=<< return ("" == wesnoth.game_config.random_mode) >>
+            [/lua]
+            [then]
+                [display_tip]
+                    title=_"Managing Luck"
+                    image=tutor/luck.png
+                    message=_"Wesnoth is a game about flexible strategy,
 not deterministic calculation.
 Anyone can win when things go as planned.
 Wesnoth’s skill &amp; mastery lie in creating
@@ -333,7 +339,9 @@ That said, if you really prefer a more
 deterministic experience, try selecting
 <i><b>“Reduced RNG”</b></i> when starting a new 
 campaign."
-        [/display_tip]
+                [/display_tip]
+            [/then]
+        [/if]
         {VARIABLE sg_rnginfo_1 yes}
     [/event]
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1396,6 +1396,11 @@ GAME_CONFIG_SETTER("do_healing", bool, game_lua_kernel) {
 	game_config_glk_tag k2{k.ref};
 	k2.pc().gamestate().do_healing_ = value;}
 
+GAME_CONFIG_GETTER("random_mode", std::string, game_lua_kernel) {
+	game_config_glk_tag k2{k.ref};
+	return k2.pc().get_classification().random_mode;
+}
+
 GAME_CONFIG_GETTER("theme", std::string, game_lua_kernel) {
 	game_config_glk_tag k2{k.ref};
 	return k2.gamedata().get_theme();


### PR DESCRIPTION
Adds a new Lua getter for `wesnoth.game_config`. This could also have gone into `wesnoth.scenario`.

While this will be accessible to UMC, I'm not anticipating anyone using it for UMC. If a UMC author really wanted to, they could already have detected Biased RNG by checking combat statistics.

The `{RESET_SAVELOAD_TIP}` expansion was missing from PaP, so it never showed up (or maybe showed up once per Wesnoth install) even when restarting the campaign.