### PR TITLE
[Very WIP] enable preliminary gui2/map simultaneous interaction

### DIFF
--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -91,7 +91,14 @@ void controller_base::long_touch_callback(int x, int y)
 
 void controller_base::handle_event(const SDL_Event& event)
 {
-	if(gui2::is_in_dialog()) {
+	int x = -1;
+	int y = -1;
+	if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+		x = event.button.x;
+		y = event.button.y;
+	}
+
+	if(display::get_singleton() == nullptr || gui2::is_in_dialog(x, y)) {
 		return;
 	}
 

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -120,7 +120,7 @@ static uint32_t timer_sdl_poll_events(uint32_t, void*)
  */
 class sdl_event_handler : public events::sdl_handler
 {
-	friend bool gui2::is_in_dialog();
+	friend bool gui2::is_in_dialog(int x, int y);
 
 public:
 	sdl_event_handler();
@@ -516,8 +516,8 @@ void sdl_event_handler::connect(dispatcher* dispatcher)
 	DBG_GUI_E << "adding dispatcher " << static_cast<void*>(dispatcher);
 
 	if(dispatchers_.empty()) {
-		LOG_GUI_E << "creating new dispatcher event context";
-		event_context = std::make_unique<events::event_context>();
+		// LOG_GUI_E << "creating new dispatcher event context";
+		// event_context = std::make_unique<events::event_context>();
 		join();
 	}
 
@@ -1123,9 +1123,19 @@ std::ostream& operator<<(std::ostream& stream, const ui_event event)
 
 } // namespace event
 
-bool is_in_dialog()
+bool is_in_dialog(int x, int y)
 {
-	return !event::get_all_dispatchers().empty();
+	const auto& dispatchers = event::get_all_dispatchers();
+	if (dispatchers.empty() || x < 0 || y < 0) {
+		return false;
+	} else {
+		for (const auto& d : dispatchers) {
+			if (d->is_at({x, y})) {
+				return true;
+			}
+		}
+		return false;
+	}
 }
 
 } // namespace gui2

--- a/src/gui/core/event/handler.hpp
+++ b/src/gui/core/event/handler.hpp
@@ -281,6 +281,6 @@ std::ostream& operator<<(std::ostream& stream, const ui_event event);
  *
  * @note added as backwards compatibility for gui::is_in_dialog.
  */
-bool is_in_dialog();
+bool is_in_dialog(int x = -1, int y = -1);
 
 } // namespace gui2


### PR DESCRIPTION
**Reason:**
GUI2 always pushes a new event_context when a dialog opens, and the map goes to the middle **of** event context stack which does not receive events, hence the map becomes non-interactive whenever a GUI2 dialog opens (such as right click context menu or objectives).

Additionally, `gui2::is_in_dialog` doesn't check if the click is outside the dialog or not, it just checks if a dispatcher is present, not if it's outside the dispatchers serviceable area.

LLM assisted analysis but code is self-written.

Proof-of-concept changes for testing:
* disable new event context creation in gui2 handler
* updated gui2::is_in_controller to check coordinates
After this map click/hover works even when a GUI2 dialog present.