### PR TITLE
Deprecate [drains] default value

### DIFF
--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -180,6 +180,7 @@
     # [specials] clause.
     [drains]
         id=drains
+        value=50
         name= _ "drains"
         description= _ "This unit drains health from living units, healing itself for half the amount of damage it deals (rounded down)."
         special_note={INTERNAL:SPECIAL_NOTES_DRAIN}

--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -156,6 +156,8 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
                                 id=empathic_weapon
                                 name=_"Empathic Weapon"
                                 description=_"All damage dealt by this attack to a living target is dealt to the user as well"
+                                # TODO: just use value=-100 instead?
+                                value=50
                                 multiply=-2
                             [/drains]
                             [heal_on_hit]
@@ -565,6 +567,8 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
                                 id=empathic_weapon
                                 name=_"Empathic Weapon"
                                 description=_"All damage dealt by this attack to a living target is dealt to the user as well"
+                                # TODO: just use value=-100 instead?
+                                value=50
                                 multiply=-2
                             [/drains]
                             [heal_on_hit]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -536,6 +536,7 @@
                 apply_to=new_ability
                 [abilities]
                     [drains]
+                        value=50
                     [/drains]
                 [/abilities]
             [/effect]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_attack_no_defense.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_attack_no_defense.cfg
@@ -28,6 +28,7 @@
                 [abilities]
                     [drains]
                         id=test_ability_drain
+                        value=50
                     [/drains]
                 [/abilities]
             [/effect]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -325,6 +325,7 @@
                 apply_to=new_ability
                 [abilities]
                     [drains]
+                        value=50
                         id=ability_drain_blade
                         [filter_opponent]
                             [filter_weapon]
@@ -497,6 +498,7 @@
                 [abilities]
                     [drains]
                         id=ability_drain_blade
+                        value=50
                         [filter_student]
                             [filter_weapon]
                                 special_id_active=ability_drain_blade

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_cumulative.cfg
@@ -22,8 +22,8 @@
             [effect]
                 apply_to = new_ability
                 [abilities]
-                    {TEST_ABILITY_NO_VALUE drains (add=1) ID=1 SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (add=1) ID=1 CUMULATIVE=yes SELF=yes}
+                    {TEST_ABILITY drains 50 (add=1) ID=1 SELF=yes}
+                    {TEST_ABILITY drains 50 (add=1) ID=1 CUMULATIVE=yes SELF=yes}
                 [/abilities]
             [/effect]
         [/modify_unit]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials.cfg
@@ -23,9 +23,9 @@
                 apply_to = new_ability
                 [abilities]
                     {TEST_ABILITY drains 5 () SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (add=1
+                    {TEST_ABILITY drains 0 (add=1
                     {OVERWRITE_SPECIALS sub=1-4 ()}) SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                    {TEST_ABILITY drains 0 (sub=2) SELF=yes}
                 [/abilities]
             [/effect]
         [/modify_unit]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_no_match.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_no_match.cfg
@@ -24,9 +24,9 @@
                 apply_to = new_ability
                 [abilities]
                     {TEST_ABILITY drains 5 () SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (add=3
+                    {TEST_ABILITY drains 0  (add=3
                     {OVERWRITE_SPECIALS sub=1-4 affect=opponent}) SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                    {TEST_ABILITY drains 0 (sub=2) SELF=yes}
                 [/abilities]
             [/effect]
         [/modify_unit]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_succeed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_add_overwrite_specials_affect_side_succeed.cfg
@@ -24,9 +24,9 @@
                 apply_to = new_ability
                 [abilities]
                     {TEST_ABILITY drains 5 () SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (add=1
+                    {TEST_ABILITY drains 0 (add=1
                     {OVERWRITE_SPECIALS sub=1-4 affect=self}) SELF=yes}
-                    {TEST_ABILITY_NO_VALUE drains (sub=2) SELF=yes}
+                    {TEST_ABILITY drains 0 (sub=2) SELF=yes}
                 [/abilities]
             [/effect]
         [/modify_unit]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_no_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_no_value.cfg
@@ -12,6 +12,7 @@
 # The leader of side 1 heals 50 hp total since it has full hp when its first strike is made
 # The leader of side 2 heals 100 hp total since it was damaged when its first strike was made
 #####
+# TODO: [drains] with no value was deprecated for 1.20 and this test was updated to use a value, figure out what to do with this test.
 {COMMON_KEEP_A_B_UNIT_TEST "drains_no_value" (
     [event]
         name = start
@@ -24,6 +25,7 @@
                 [abilities]
                     [drains]
                         id = "test-drains"
+                        value=50
                         name = _"test-drains"
                         affect_self = yes
                         affect_allies = no

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/reflexive_drains.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/reflexive_drains.cfg
@@ -89,6 +89,7 @@
                     mode=append
                     [drains]
                         id=drains
+                        value=50
                         name= _ "drains"
                         description= _ "Reverse drains, gives the drain ability to the opponent."
                         apply_to=opponent

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -246,6 +246,11 @@ void unit_ability_t::do_compat_fixes(config& cfg, const std::string& tag, bool i
 		cfg.remove_children("filter_weapon");
 	}
 
+	if (tag == "drains" && cfg["value"].empty()) {
+		deprecated_message("the default value of 50 of [drains]value= is deprecated", DEP_LEVEL::FOR_REMOVAL, version_info("1.21"), "Specify value=50 directly.");
+		cfg["value"] = 50;
+	}
+
 	if(!cfg["overwrite_specials"].blank() || cfg.optional_child("overwrite")) {
 		deprecated_message("overwrite_specials= or [overwrite] in weapon specials", DEP_LEVEL::INDEFINITE, "", "Use [overwrite_specials] instead.");
 	}


### PR DESCRIPTION
See also #10920

The current default values of drains is quite arbitrary, futhermore the current default [drain] ability behaves unexpected when used together with other drain abilities, some examples:

```
[drains] [/drains]
```
result: 50

```
[drains] value=50 [/drains]
```
result: 50

```
[drains] [/drains]
[drains] value=30 [/drains]
```
result: 30

```
[drains] value=50 [/drains]
[drains] value=30 [/drains]
```
result: 50

```
[drains] add=30 [/drains]
```
result: 80

```
[drains] [/drains]
[drains] value=0   add=30 [/drains]
```
result: 30

So for example when someone wants to have a drains ability to add 30 drain percent, he really cant, if they try to use ` [drains] add=30 [/drains] `, you get a value of 80 because, if they however write `[drains] value=0   add=30  [/drains]` it also won't work because as in my last case above, the value=0 will overwrite the default 50 from other drain abilities.