### PR TITLE
phasing out IS_LOYAL / IS_HERO

### DIFF
--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_2.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_2.cfg
@@ -112,8 +112,10 @@
             type=Elvish Champion
             x,y=4,11
             random_traits=no
-            {IS_HERO}
             facing=ne
+            [modifications]
+                {TRAIT_LOYAL_HERO_NOSLOT}
+            [/modifications]
         [/unit]
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
@@ -78,7 +78,10 @@
             name= _ "Galim"
             x,y=12,11
             facing=se
-            # todo: is the unit loyal or not? before it had the {IS_LOYAL} but without the real loyal trait.
+            random_traits=no
+            [modifications]
+                {TRAIT_LOYAL}
+            [/modifications]
         [/unit]
     [/side]
 

--- a/data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg
@@ -83,11 +83,10 @@ no#endarg
     name= _ "Dulcatulos"
     profile=portraits/dulcatulos.png
     unrenamable=yes
-    {IS_HERO}
-    upkeep=free
     [modifications]
         {TRAIT_QUICK}
         {TRAIT_HEALTHY}
+        {TRAIT_LOYAL_HERO_NOSLOT}
     [/modifications]
 #enddef
 

--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -87,33 +87,30 @@
         [/leader]
         [unit]
             type=Drake Flameheart
-            {IS_HERO}
             [modifications]
                 {TRAIT_QUICK}
                 {TRAIT_RESILIENT}
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
             [/modifications]
             x,y=28,14
             facing=ne
         [/unit]
         [unit]
             type=Drake Warden
-            {IS_HERO}
             [modifications]
                 {TRAIT_RESILIENT}
                 {TRAIT_STRONG}
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
             [/modifications]
             x,y=20,20
             facing=ne
         [/unit]
         [unit]
             type=Hurricane Drake
-            {IS_HERO}
             [modifications]
                 {TRAIT_QUICK}
                 {TRAIT_STRONG}
-                {TRAIT_LOYAL}
+                {TRAIT_LOYAL_HERO}
             [/modifications]
             x,y=23,12
             facing=ne

--- a/data/campaigns/Winds_of_Fate/utils/characters.cfg
+++ b/data/campaigns/Winds_of_Fate/utils/characters.cfg
@@ -45,7 +45,6 @@
     unrenamable=yes
     gender=female
     type=Drake Glider
-    {IS_HERO}
     [modifications]
         {TRAIT_QUICK}
         {TRAIT_RESILIENT}
@@ -69,7 +68,6 @@
     name= _ "Arinexis"
     unrenamable=yes
     type=Saurian Ambusher
-    {IS_HERO}
     [modifications]
         {TRAIT_STRONG}
         {TRAIT_FEARLESS}
@@ -82,7 +80,6 @@
     name= _ "Zedrix"
     unrenamable=yes
     type=Saurian Soothsayer
-    {IS_HERO}
     [modifications]
         {TRAIT_STRONG}
         {TRAIT_RESILIENT}

--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -349,3 +349,7 @@ _"No gold carried over to the next scenario."#enddef
         [/background_layer]
     [/part]
 #enddef
+
+#define IS_LOYAL
+#deprecated 2 1.21 loyal units get now the icon automatically from the trait
+#enddef

--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -353,3 +353,22 @@ _"No gold carried over to the next scenario."#enddef
 #define IS_LOYAL
 #deprecated 2 1.21 loyal units get now the icon automatically from the trait
 #enddef
+
+## TODO: this was moved to the loyal trait but a few codes used with without the loyal trait,
+## so i'll leave it for now. since this icon is afaik not transparent though should not be a problem.
+## However, cases where this macro is before the loyal trait in the unit definition will have the wrong icon.
+#define IS_HERO
+#deprecated 3 1.21 give the unit TRAIT_LOYAL_HERO instead
+    [+modifications]
+        [object]
+            [effect]
+                apply_to=overlay
+                add="misc/hero-icon.png"
+            [/effect]
+            [effect]
+                apply_to=ellipse
+                ellipse="misc/ellipse-hero"
+            [/effect]
+        [/object]
+    [/modifications]
+#enddef

--- a/data/core/macros/image-utils.cfg
+++ b/data/core/macros/image-utils.cfg
@@ -15,24 +15,6 @@
     color="255,255,255"
 #enddef
 
-## TODO: this was moved to the loyal trait but a few codes used with witouht the loyal trait,
-## so i'll leave it for now. since this icon is afaik not transparent though should not be a problem.
-#define IS_HERO
-    # Embed this into a unit declaration to add a hero icon to the unit.
-    [+modifications]
-        [object]
-            [effect]
-                apply_to=overlay
-                add="misc/hero-icon.png"
-            [/effect]
-            [effect]
-                apply_to=ellipse
-                ellipse="misc/ellipse-hero"
-            [/effect]
-        [/object]
-    [/modifications]
-#enddef
-
 #define IS_EXPENDABLE_LEADER
     # Embed this into a unit declaration to add an expendable leader icon to the unit.
     [+modifications]

--- a/data/core/macros/image-utils.cfg
+++ b/data/core/macros/image-utils.cfg
@@ -33,18 +33,6 @@
     [/modifications]
 #enddef
 
-#define IS_LOYAL
-    # Embed this into a unit declaration to add a loyalty icon to the unit.
-    [+modifications]
-        [object]
-            [effect]
-                apply_to=overlay
-                add="misc/loyal-icon.png"
-            [/effect]
-        [/object]
-    [/modifications]
-#enddef
-
 #define IS_EXPENDABLE_LEADER
     # Embed this into a unit declaration to add an expendable leader icon to the unit.
     [+modifications]

--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -475,8 +475,8 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
             x,y=20,7
             type="Elvish Champion"
             generate_name=yes
-            {IS_HERO}
             [modifications]
+                {TRAIT_LOYAL_HERO_NOSLOT}
                 [object]
                     [effect]
                         apply_to=remove_attacks


### PR DESCRIPTION

IS_LOYAL used to be the macro to set the overlay icon for a unit. By now it is always already done, by use of TRAIT_LOYAL. Removing the macro content entirely, but still keeping it defined.

IS_HERO did set the overlay and ellipse. Intention is to replace it by TRAIT_LOYAL_HERO.
Or in cases one does not want to display the loyal trait, with TRAIT_LOYAL_HERO_NOSLOT.

Current situation is, that in case the IS_HERO macro and TRAIT_LOYAL are used together, that the macro appearing later in the file overwrites the icon of the former. So one should update the code to use the new macro.