### PR TITLE
Fix aquatic encampment keep wall transitions

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -767,7 +767,9 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 #####################
 # Aquatic camp
 
-{NEW:CASTLEWALL             (Kme,Cme)     (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/aquatic-camp/castle}
+{NEW:CASTLEWALL             Cme           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/aquatic-camp/castle}
+{NEW:CASTLEWALL2            Kme           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/encampment/tall-keep-castle}
+{NEW:CASTLEWALL             Kme           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/aquatic-camp/castle}
 {AQUATIC:CAMPS              Kme           Cme                               castle/aquatic-camp}
 
 # Troll camp


### PR DESCRIPTION
Add the missing CASTLEWALL2 rule to the coral reef encampment terrain so keep-to-castle wall transitions are rendered correctly.

Use the existing aquatic castle transition sprite
as a temporary stand-in until dedicated artwork is available.

Fixes #11256