### PR TITLE
Sound source sdl3 bugfix [LLM Assisted]

### DIFF
--- a/changelog_entries/soundsource-sdl3-fixes.md
+++ b/changelog_entries/soundsource-sdl3-fixes.md
@@ -1,0 +1,8 @@
+### Miscellaneous and Bug Fixes
+   * Fixed several audio regressions from the SDL3 migration (issue #11395):
+      * Restored positional [sound_source] fading, so sounds attenuate with distance again.
+      * Fixed reading back and scaling of the sound, music, bell and UI volume levels.
+      * Fixed one-time sounds alternating at half volume.
+   * Fixed a looping [sound_source] jumping abruptly to full volume when scrolled into range instead of fading in.
+   * Sound sources now update their volume when zooming while the view is against a map edge.
+   * [sound_source] volume now fades smoothly with pixel distance rather than in whole-hex steps.

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1747,6 +1747,9 @@ bool display::set_zoom(unsigned int amount, const bool validate_value_and_set_in
 	redraw_background_ = true;
 	invalidate_all();
 
+	// Zooming can move the screen centre without a scroll, e.g. when pinned against a map edge.
+	scroll_event_.notify_observers();
+
 	return true;
 }
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -942,6 +942,12 @@ static void play_sound_internal(const std::string& files,
 } // end anon namespace
 
 namespace sound {
+// The volume sliders range 0..128; MIX_SetTrackGain expects a 0.0..1.0 gain.
+static float volume_to_gain(int vol)
+{
+	return (vol > 128 ? 128 : vol) / 128.0f;
+}
+
 void play_sound(const std::string& files, sound_tracks::type group, unsigned int repeats)
 {
 	if(prefs::get().sound()) {
@@ -983,7 +989,7 @@ void play_UI_sound(const std::string& files)
 int get_music_volume()
 {
 	if(mix_ok) {
-		return MIX_SetTrackGain(sound::tracks[music_track_id].get(), -1);
+		return static_cast<int>(MIX_GetTrackGain(sound::tracks[music_track_id].get()) * 128.0f);
 	}
 
 	return 0;
@@ -992,11 +998,7 @@ int get_music_volume()
 void set_music_volume(int vol)
 {
 	if(mix_ok && vol >= 0) {
-		if(vol > 1.0f) {
-			vol = 1.0f;
-		}
-
-		MIX_SetTrackGain(sound::tracks[music_track_id].get(), vol);
+		MIX_SetTrackGain(sound::tracks[music_track_id].get(), volume_to_gain(vol));
 	}
 }
 
@@ -1004,7 +1006,7 @@ int get_sound_volume()
 {
 	if(mix_ok) {
 		// Since set_sound_volume sets all main tracks to the same, just return the volume of any main track
-		return MIX_SetTrackGain(sound::tracks[source_track_id_start].get(), -1);
+		return static_cast<int>(MIX_GetTrackGain(sound::tracks[source_track_id_start].get()) * 128.0f);
 	}
 	return 0;
 }
@@ -1012,14 +1014,13 @@ int get_sound_volume()
 void set_sound_volume(int vol)
 {
 	if(mix_ok && vol >= 0) {
-		if(vol > 1.0f) {
-			vol = 1.0f;
-		}
+		float gain = volume_to_gain(vol);
 
 		// Bell, timer and UI have separate tracks which we can't set up from this
 		// Also separating music track from being modified
 		for(unsigned i = 0; i < n_of_tracks; ++i) {
-			if(i != music_track_id && !(i >= UI_sound_track_id_start && i <= UI_sound_track_id_last) && i != bell_track_id && i != timer_track_id) {				MIX_SetTrackGain(sound::tracks[i].get(), vol);
+			if(i != music_track_id && !(i >= UI_sound_track_id_start && i <= UI_sound_track_id_last) && i != bell_track_id && i != timer_track_id) {
+				MIX_SetTrackGain(sound::tracks[i].get(), gain);
 			}
 		}
 	}
@@ -1031,24 +1032,18 @@ void set_sound_volume(int vol)
 void set_bell_volume(int vol)
 {
 	if(mix_ok && vol >= 0) {
-		if(vol > 1.0f) {
-			vol = 1.0f;
-		}
-
-		MIX_SetTrackGain(sound::tracks[bell_track_id].get(), vol);
-		MIX_SetTrackGain(sound::tracks[timer_track_id].get(), vol);
+		float gain = volume_to_gain(vol);
+		MIX_SetTrackGain(sound::tracks[bell_track_id].get(), gain);
+		MIX_SetTrackGain(sound::tracks[timer_track_id].get(), gain);
 	}
 }
 
 void set_UI_volume(int vol)
 {
 	if(mix_ok && vol >= 0) {
-		if(vol > 1.0f) {
-			vol = 1.0f;
-		}
-
+		float gain = volume_to_gain(vol);
 		for(unsigned i = UI_sound_track_id_start; i <= UI_sound_track_id_last; ++i) {
-			MIX_SetTrackGain(sound::tracks[i].get(), vol);
+			MIX_SetTrackGain(sound::tracks[i].get(), gain);
 		}
 	}
 }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -771,28 +771,48 @@ void write_music_play_list(config& snapshot)
 	}
 }
 
+static MIX_Point3D distance_to_position(unsigned int distance)
+{
+	// SDL3_mixer attenuates as 1/distance; invert that so the audible fade stays linear, like SDL2's Mix_SetDistance.
+	MIX_Point3D pos;
+	pos.x = 0.0f;
+	pos.y = static_cast<float>(DISTANCE_SILENT) / (DISTANCE_SILENT - distance);
+	pos.z = 0.0f;
+	return pos;
+}
+
 void reposition_sound(unsigned id, unsigned int distance)
 {
-	for(unsigned ch = 0; ch < tracks.size(); ++ch) {
-		if(ch != id) {
-			continue;
+	int track;
+	{
+		std::scoped_lock lock(soundsource_map_mutex);
+		auto it = soundsource_map.find(id);
+		if(it == soundsource_map.end()) {
+			return;
 		}
+		track = it->second;
+	}
 
-		if(distance == DISTANCE_SILENT) {
-			MIX_StopTrack(tracks[ch].get(), 0);
-		} else {
-			MIX_Point3D pos;
-			pos.x = 0;
-			pos.y = distance;
-			pos.z = 0;
-			MIX_SetTrack3DPosition(tracks[ch].get(), &pos);
-		}
+	if(distance >= DISTANCE_SILENT) {
+		MIX_StopTrack(tracks[track].get(), 0);
+	} else {
+		MIX_Point3D pos = distance_to_position(distance);
+		MIX_SetTrack3DPosition(tracks[track].get(), &pos);
 	}
 }
 
 bool is_sound_playing(int id)
 {
-	return MIX_TrackPlaying(tracks[id].get());
+	int track;
+	{
+		std::scoped_lock lock(soundsource_map_mutex);
+		auto it = soundsource_map.find(id);
+		if(it == soundsource_map.end()) {
+			return false;
+		}
+		track = it->second;
+	}
+	return MIX_TrackPlaying(tracks[track].get());
 }
 
 void stop_sound(unsigned id)
@@ -810,7 +830,7 @@ static void play_sound_internal(const std::string& files,
 		const std::chrono::milliseconds& loop_ticks = 0ms,
 		const std::chrono::milliseconds& fadein_ticks = 0ms)
 {
-	if(files.empty() || !mix_ok) {
+	if(files.empty() || distance >= DISTANCE_SILENT || !mix_ok) {
 		return;
 	}
 
@@ -848,11 +868,10 @@ static void play_sound_internal(const std::string& files,
 	const auto localized = filesystem::get_localized_path(filename.value_or(""));
 	std::string real_path = localized.value_or(filename.value());
 
-	MIX_Point3D pos;
-	pos.x = 0;
-	pos.y = distance;
-	pos.z = 0;
-	MIX_SetTrack3DPosition(tracks[free_track].get(), &pos);
+	if(group == sound_tracks::type::sound_source) {
+		MIX_Point3D pos = distance_to_position(distance);
+		MIX_SetTrack3DPosition(tracks[free_track].get(), &pos);
+	}
 
 	std::shared_ptr<MIX_Audio> sound;
 	if(sound_cache.count(real_path) != 0) {
@@ -861,6 +880,11 @@ static void play_sound_internal(const std::string& files,
 	} else {
 		sound.reset(MIX_LoadAudio(mixer, real_path.c_str(), false), &MIX_DestroyAudio);
 		DBG_AUDIO << "cache miss for " << real_path;
+	}
+
+	if(!sound) {
+		ERR_AUDIO << "Could not load sound file '" << real_path << "' : " << SDL_GetError();
+		return;
 	}
 
 	MIX_SetTrackAudio(tracks[free_track].get(), sound.get());

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -397,7 +397,7 @@ bool init_sound()
 			track_map.emplace(i, sound_tracks::type::sound_ui);
 		}
 
-		for(std::size_t i = n_reserved_tracks_id_start; i <= n_reserved_tracks_id_end; i++) {
+		for(std::size_t i = n_reserved_tracks_id_start; i < n_reserved_tracks_id_end; i++) {
 			std::shared_ptr<MIX_Track> sound_fx_track(MIX_CreateTrack(mixer), &MIX_DestroyTrack);
 			MIX_TagTrack(sound_fx_track.get(), sound_tracks::sound_fx);
 			tracks.push_back(sound_fx_track);

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -19,6 +19,8 @@
 #include "sound.hpp"
 #include "soundsource.hpp"
 
+#include <cmath>
+
 namespace soundsource {
 
 using namespace std::chrono_literals;
@@ -195,9 +197,14 @@ int positional_source::calculate_volume(const map_location &loc, const display &
 	if((check_shrouded_ && disp.shrouded(loc)) || (check_fogged_ && disp.fogged(loc)))
 		return DISTANCE_SILENT;
 
+	// Pixel distance from the screen centre to the hex, in hex_size units, with
+	// the x axis scaled by hex_size/hex_width to correct the column spacing.
 	rect area = disp.map_area();
-	map_location center = disp.hex_clicked_on(area.x + area.w / 2, area.y + area.h / 2);
-	int distance = distance_between(loc, center);
+	const double hex = disp.hex_size();
+	point src = disp.get_location(loc);
+	double dx = ((src.x + hex / 2.0) - (area.x + area.w / 2.0)) * hex / disp.hex_width();
+	double dy = (src.y + hex / 2.0) - (area.y + area.h / 2.0);
+	double distance = std::sqrt(dx * dx + dy * dy) / hex;
 
 	if(distance <= range_) {
 		return 0;
@@ -207,8 +214,10 @@ int positional_source::calculate_volume(const map_location &loc, const display &
 		return DISTANCE_SILENT;
 	}
 
-	return static_cast<int>((((distance - range_)
-			/ static_cast<double>(faderange_)) * DISTANCE_SILENT));
+	int volume = static_cast<int>(((distance - range_)
+			/ static_cast<double>(faderange_)) * DISTANCE_SILENT);
+
+	return volume >= DISTANCE_SILENT ? DISTANCE_SILENT : volume;
 }
 
 void positional_source::write_config(config& cfg) const

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -138,34 +138,42 @@ bool positional_source::is_global() const
 
 void positional_source::update(const std::chrono::steady_clock::time_point& time, const display &disp)
 {
-	if (time - last_played_ < min_delay_ || sound::is_sound_playing(id_))
+	if(sound::is_sound_playing(id_))
 		return;
 
-	int i = randomness::rng::default_instance().get_random_int(1, 100);
+	// The min_delay/chance gate spaces out and randomizes one-shot ambient
+	// triggers; looping sources skip it and play whenever they are in range.
+	const bool looping = loops_ != 0;
 
-	if(i <= chance_) {
-		last_played_ = time;
-
-		// If no locations have been specified, treat the source as if
-		// it was present everywhere on the map
-		if(locations_.empty()) {
-			sound::play_sound_positioned(files_, loops_, 0, id_);	// max volume
-			return;
-		}
-
-		int distance_volume = DISTANCE_SILENT;
-		for(const map_location& l : locations_) {
-			int v = calculate_volume(l, disp);
-			if(v < distance_volume) {
-				distance_volume = v;
-			}
-		}
-
-		if(distance_volume >= DISTANCE_SILENT)
+	if(!looping) {
+		if(time - last_played_ < min_delay_)
 			return;
 
-		sound::play_sound_positioned(files_, loops_, distance_volume, id_);
+		if(randomness::rng::default_instance().get_random_int(1, 100) > chance_)
+			return;
 	}
+
+	last_played_ = time;
+
+	// If no locations have been specified, treat the source as if
+	// it was present everywhere on the map
+	if(locations_.empty()) {
+		sound::play_sound_positioned(files_, loops_, 0, id_);	// max volume
+		return;
+	}
+
+	int distance_volume = DISTANCE_SILENT;
+	for(const map_location& l : locations_) {
+		int v = calculate_volume(l, disp);
+		if(v < distance_volume) {
+			distance_volume = v;
+		}
+	}
+
+	if(distance_volume >= DISTANCE_SILENT)
+		return;
+
+	sound::play_sound_positioned(files_, loops_, distance_volume, id_);
 }
 
 void positional_source::update_positions(const std::chrono::steady_clock::time_point& time, const display &disp)


### PR DESCRIPTION
This is a bugfix for https://github.com/wesnoth/wesnoth/issues/11395

I found 5 bugs and 1 "improvement" for the sound handling. Added them each as separate commits. 

1. sound_source spatialization — look up the mixer track through soundsource_map instead of indexing by source id, and invert SDL3's 1/distance attenuation so falloff stays linear
2. Volume sliders — read gain via MIX_GetTrackGain (the MIX_SetTrackGain(…,-1) getter idiom is gone in SDL3) and stop clamping the integer slider value against 1.0f
3. Zoom — notify observers on set_zoom so zooming (which can change the screen centre) re-evaluates sound source volumes, not just scrolling
4. Fade smoothing (improvement rather than bugfix) — compute source distance in fractional hexes from pixel offset instead of whole-hex steps, so volume fades smoothly while scrolling
5. Looping sources — skip the min_delay/chance gate for looping sound sources so they become audible immediately on entering range instead of snapping to full volume after a delay
6. Sound-effect tracks — fix an off-by-one that created one extra fx track outside the volume-controlled range, leaving it stuck at full gain and making every other effect louder

I will get back to have another look at this code and add a change log file. Edit: Done.

I have tested all these bug fixes in game and can confirm that the bugs all existed before and are all fixed now.

Edit: Testing this requires a CMake rebuild.