### PR TITLE
Frost Stoat: arcane resist -20% -> 0%

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
 ### Translations
    * Updated translations: Bengali, British English, Bulgarian, Czech, French, Galician, German, Hungarian, Italian, Polish, Russian, Serbian
 ### Units
+   * Frost Stoat
+     * Arcane Resist: -20% -> 0%
 ### User interface
    * Fix sound effect slider which was incorrectly affecting the music track volume.
 ### WML Engine

--- a/data/core/units/monsters/Frost_Stoat.cfg
+++ b/data/core/units/monsters/Frost_Stoat.cfg
@@ -41,7 +41,7 @@
     [/defense]
     [resistance]
         cold=60
-        arcane=120
+        arcane=100
     [/resistance]
     [standing_anim]
         start_time=-50


### PR DESCRIPTION
This brings it more inline with other semi-magical creatures, like Fire Ants or the Dark Horse.

Balance team vote passed 3 in favor, 1 veto.