### PR TITLE
Revert the behavior change to IS_LOYAL

### DIFF
--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -352,6 +352,14 @@ _"No gold carried over to the next scenario."#enddef
 
 #define IS_LOYAL
 #deprecated 2 1.21 loyal units get now the icon automatically from the trait
+    [+modifications]
+        [object]
+            [effect]
+                apply_to=overlay
+                add="misc/loyal-icon.png"
+            [/effect]
+        [/object]
+    [/modifications]
 #enddef
 
 ## TODO: this was moved to the loyal trait but a few codes used with without the loyal trait,


### PR DESCRIPTION
The macro is documented to just change icons, and can be used when the icon is wanted without the actual loyal trait. For 1.20, mark it as deprecated but leave the player-visible behavior unchanged.

This means that the icon will still appear for old code that uses `upkeep=loyal` or `upkeep=0` instead of the trait.

This partially reverts commit b61bfed33fb9a3e507c0afcae753ef5eff012ca9.

(The first revision of this PR also reverted 71783a00c61321a2fdec73baaadfacaafd50d2e8 and bb99ffd82fa2dd35e46924dc5ef816f195d1a996 and removed the deprecation.)