### PR TITLE
Revert "Dunefolk: keep weapon name consistent over level ups"

### DIFF
--- a/data/core/units/dunefolk/Blademaster.cfg
+++ b/data/core/units/dunefolk/Blademaster.cfg
@@ -25,7 +25,7 @@ This game has more practical implications in real battles. No matter how elusive
     {DEFENSE_ANIM "{PATH_TEMP}blademaster.png" "{PATH_TEMP}blademaster.png" {SOUND_LIST:HUMAN_HIT} }
 
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -34,7 +34,7 @@ This game has more practical implications in real battles. No matter how elusive
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -46,7 +46,7 @@ This game has more practical implications in real battles. No matter how elusive
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=sword
         [/filter_attack]
         start_time=-200
         [frame]

--- a/data/core/units/dunefolk/Paragon.cfg
+++ b/data/core/units/dunefolk/Paragon.cfg
@@ -26,7 +26,7 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
     {DEFENSE_ANIM "{PATH_TEMP}paragon.png" "{PATH_TEMP}paragon.png" {SOUND_LIST:HUMAN_HIT} }
 
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -35,7 +35,7 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -56,7 +56,7 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=sword
         [/filter_attack]
         start_time=-200
         [frame]

--- a/data/core/units/dunefolk/Swordsman.cfg
+++ b/data/core/units/dunefolk/Swordsman.cfg
@@ -22,7 +22,7 @@ units/dunefolk/soldier/#enddef
     {DEFENSE_ANIM "{PATH_TEMP}swordsman-defend2.png" "{PATH_TEMP}swordsman-defend1.png" {SOUND_LIST:HUMAN_HIT} }
 
     [attack]
-        name=scimitar
+        name=scimitar_force
         description= _ "scimitar"
         type=blade
         range=melee
@@ -31,7 +31,7 @@ units/dunefolk/soldier/#enddef
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=scimitar
+        name=scimitar_balance
         description= _ "scimitar"
         type=blade
         range=melee
@@ -43,7 +43,7 @@ units/dunefolk/soldier/#enddef
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=scimitar_balance
         [/filter_attack]
         start_time=-200
         [frame]
@@ -53,7 +53,7 @@ units/dunefolk/soldier/#enddef
     [/attack_anim]
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=scimitar_force
         [/filter_attack]
         start_time=-300
         [frame]


### PR DESCRIPTION
The reverted commit renamed the scimitar to sword, but didn't rename the scimitar of the Captain or Warmaster, so it failed the stated aim of keeping the weapon name consistent over level ups.

It also broke the Swordsman's animation selection. Although the Swordsman currently uses the same frame for both types of attack due to lack of artwork, the code is written to allow two different animations. Using the same name for both attacks would prevent those animations from being added after the API freeze.

This reverts commit f646c66095382a291537be1cc0c223c871bccb26.