### PR TITLE
Dunefolk: use sword as technical weapon name for unit line

### DIFF
--- a/data/core/units/dunefolk/Blademaster.cfg
+++ b/data/core/units/dunefolk/Blademaster.cfg
@@ -34,7 +34,7 @@ This game has more practical implications in real battles. No matter how elusive
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=sword
+        name=sword_precise
         description= _ "scimitar"
         type=blade
         range=melee
@@ -47,6 +47,17 @@ This game has more practical implications in real battles. No matter how elusive
     [attack_anim]
         [filter_attack]
             name=sword
+        [/filter_attack]
+        start_time=-200
+        [frame]
+            image="{PATH_TEMP}blademaster.png:300"
+        [/frame]
+        {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
+    [/attack_anim]
+
+    [attack_anim]
+        [filter_attack]
+            name=sword_precise
         [/filter_attack]
         start_time=-200
         [frame]

--- a/data/core/units/dunefolk/Captain.cfg
+++ b/data/core/units/dunefolk/Captain.cfg
@@ -24,7 +24,7 @@ units/dunefolk/soldier/#enddef
     {LEADING_ANIM "{PATH_TEMP}captain-leading2.png" "{PATH_TEMP}captain-leading1.png" (-18,-36)}
 
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -35,7 +35,7 @@ units/dunefolk/soldier/#enddef
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=sword
         [/filter_attack]
         start_time=-200
         [frame]

--- a/data/core/units/dunefolk/Paragon.cfg
+++ b/data/core/units/dunefolk/Paragon.cfg
@@ -35,7 +35,7 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=sword
+        name=sword_precise
         description= _ "scimitar"
         type=blade
         range=melee
@@ -64,6 +64,18 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         [/frame]
         {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
     [/attack_anim]
+
+    [attack_anim]
+        [filter_attack]
+            name=sword_precise
+        [/filter_attack]
+        start_time=-200
+        [frame]
+            image="{PATH_TEMP}paragon.png:300"
+        [/frame]
+        {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
+    [/attack_anim]
+
     [attack_anim]
         [filter_attack]
             name=pommel strike

--- a/data/core/units/dunefolk/Soldier.cfg
+++ b/data/core/units/dunefolk/Soldier.cfg
@@ -26,7 +26,7 @@ units/dunefolk/soldier/#enddef
     [/resistance]
 
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -37,7 +37,7 @@ units/dunefolk/soldier/#enddef
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=sword
         [/filter_attack]
         start_time=-200
         [frame]

--- a/data/core/units/dunefolk/Swordsman.cfg
+++ b/data/core/units/dunefolk/Swordsman.cfg
@@ -22,7 +22,7 @@ units/dunefolk/soldier/#enddef
     {DEFENSE_ANIM "{PATH_TEMP}swordsman-defend2.png" "{PATH_TEMP}swordsman-defend1.png" {SOUND_LIST:HUMAN_HIT} }
 
     [attack]
-        name=scimitar_force
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -31,7 +31,7 @@ units/dunefolk/soldier/#enddef
         icon=attacks/scimitar.png
     [/attack]
     [attack]
-        name=scimitar_balance
+        name=sword_precise
         description= _ "scimitar"
         type=blade
         range=melee
@@ -43,7 +43,7 @@ units/dunefolk/soldier/#enddef
 
     [attack_anim]
         [filter_attack]
-            name=scimitar_balance
+            name=sword_precise
         [/filter_attack]
         start_time=-200
         [frame]
@@ -51,9 +51,10 @@ units/dunefolk/soldier/#enddef
         [/frame]
         {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
     [/attack_anim]
+
     [attack_anim]
         [filter_attack]
-            name=scimitar_force
+            name=sword
         [/filter_attack]
         start_time=-300
         [frame]

--- a/data/core/units/dunefolk/Warmaster.cfg
+++ b/data/core/units/dunefolk/Warmaster.cfg
@@ -25,7 +25,7 @@ units/dunefolk/soldier/#enddef
     {DEFENSE_ANIM "{PATH_TEMP}warmaster.png" "{PATH_TEMP}warmaster.png" {SOUND_LIST:HUMAN_HIT} }
 
     [attack]
-        name=scimitar
+        name=sword
         description= _ "scimitar"
         type=blade
         range=melee
@@ -36,7 +36,7 @@ units/dunefolk/soldier/#enddef
 
     [attack_anim]
         [filter_attack]
-            name=scimitar
+            name=sword
         [/filter_attack]
         start_time=-200
         [frame]


### PR DESCRIPTION
New take on https://github.com/wesnoth/wesnoth/commit/f646c66095382a291537be1cc0c223c871bccb26, using the other previously used name:

Standardises on sword instead of scimitar.
Additionally, it uses scimitar for the secondary attack, instead of using the same name, to keep it distinguishable,
useful if you want to remove one of the attacks by an object.

These units all belong to the Soldier line.

This is not directly visible from the diff, compared to 1.19.25 it changes:
- secondary attack name for the three units which have it (to be distinct form the primary)
- primary attack of L1 Soldier, L2 Swordsman, L2 Captain, L3 Warmaster
- it does not change primary attack name of the L3 Blademaster / L4 Paragon

(The previous approach didn't modify L1 Soldier, L2 Captain, L3 Warmaster instead.)