### PR TITLE
Feature implementation of two new structures into Wesnoth

### DIFF
--- a/data/core/macros/terrain-utils.cfg
+++ b/data/core/macros/terrain-utils.cfg
@@ -71,3 +71,23 @@
     [/random_placement]
     {CLEAR_VARIABLE random_placement_location}
 #enddef
+
+#define SINGLE_USE_SUMMONING_PORTAL TERRAIN REPLACE_WITH
+    [event]
+        name=recruit
+        first_time_only=no
+
+        [if]
+            [have_location]
+                x,y=$x2,$y2
+                terrain={TERRAIN}
+            [/have_location]
+            [then]
+                [terrain]
+                    x,y=$x2,$y2
+                    terrain={REPLACE_WITH}
+                [/terrain]
+            [/then]
+        [/if]
+    [/event]
+#enddef

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -400,6 +400,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 #Crude villages (grassland)
 {NEW:VILLAGE_TOD         *^Vc                                                      village/hut}
 {NEW:OVERLAY             *^Yp                                                      village/hut}
+{NEW:OVERLAY             *^Yg                                                      village/human-city}
 
 {NEW:VILLAGE             *^Vca                                                     village/hut-snow}
 

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -399,6 +399,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 #Crude villages (grassland)
 {NEW:VILLAGE_TOD         *^Vc                                                      village/hut}
+{NEW:OVERLAY             *^Yp                                                      village/hut}
 
 {NEW:VILLAGE             *^Vca                                                     village/hut-snow}
 

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -3463,6 +3463,18 @@ Most units have 50 to 60% defense in villages, whereas cavalry receive only 40%.
     hidden=yes
 [/terrain_type]
 
+[terrain_type]
+    symbol_image=village/hut-tile
+    id=summoning_portal
+    name= _ "Summoning Portal"
+    editor_name= _ "Summoning Portal"
+    heals_adjacent=5
+    string=^Yp
+    aliasof=_bas
+    recruit_from=yes
+    editor_group=special
+[/terrain_type]
+
 ###################################################
 # deprecated terrains for compatibility, do not use
 ###################################################

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -3468,10 +3468,23 @@ Most units have 50 to 60% defense in villages, whereas cavalry receive only 40%.
     id=summoning_portal
     name= _ "Summoning Portal"
     editor_name= _ "Summoning Portal"
-    heals_adjacent=5
     string=^Yp
     aliasof=_bas
+    default_base=Ke
     recruit_from=yes
+    editor_group=special
+[/terrain_type]
+
+[terrain_type]
+    symbol_image=village/human-city-tile
+    id=mercenary_guild
+    name= _ "Mercenary Guild"
+    editor_name= _ "Mercenary Guild"
+    string=^Yg
+    aliasof=_bas
+    default_base=Ke
+    recruit_from=yes
+    guild_recruits=Footpad,Spearman,Bowman,Horseman,Heavy Infantryman,Cavalryman
     editor_group=special
 [/terrain_type]
 

--- a/data/test/scenarios/behavioral_tests/mercenary_guild_recruit.cfg
+++ b/data/test/scenarios/behavioral_tests/mercenary_guild_recruit.cfg
@@ -1,0 +1,192 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [terrain_type]guild_recruits=, actions::get_recruits, check_recruit_location
+##
+# These tests exercise the "Mercenary Guild" terrain, which grants a fixed
+# list of recruitable unit types to any leader standing on a keep hex that
+# uses that terrain, in addition to (not instead of) their normal recruit
+# list.
+#####
+
+#define GUILD_SETUP
+    [event]
+        name=start
+        [gold]
+            side,amount=1,1000
+        [/gold]
+        [gold]
+            side,amount=2,1000
+        [/gold]
+        # Turn side 1's keep into a Mercenary Guild. Side 2's keep is left
+        # as a plain keep for comparison/control purposes.
+        [terrain]
+            x,y=7,3
+            terrain=^Yg
+            layer=overlay
+        [/terrain]
+    [/event]
+#enddef
+
+#####
+# Actions:
+# A leader with an empty recruit list stands on a Mercenary Guild keep.
+# Recruit a Spearman, which is only obtainable through the guild list.
+##
+# Expected end state:
+# The recruit succeeds and a Spearman appears on the board.
+#####
+{GENERIC_UNIT_TEST mercenary_guild_recruit_from_guild_list (
+    {GUILD_SETUP}
+    [event]
+        name=side 1 turn 1
+        [do_command]
+            [recruit]
+                type="Spearman"
+                x,y=7,4
+                [from]
+                    x,y=7,3
+                [/from]
+            [/recruit]
+        [/do_command]
+        {ASSERT (
+            [have_unit]
+                x,y=7,4
+                type=Spearman
+                side=1
+            [/have_unit]
+        )}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# Actions:
+# A leader with an empty recruit list stands on a Mercenary Guild keep.
+# Attempt to recruit an Orcish Grunt, which is neither in the leader's
+# recruit list nor in the guild's fixed roster.
+##
+# Expected end state:
+# The recruit is rejected and no unit appears on the board.
+#####
+{GENERIC_UNIT_TEST mercenary_guild_recruit_fail_outside_guild_list (
+    {GUILD_SETUP}
+    [event]
+        name=side 1 turn 1
+        [do_command]
+            [recruit]
+                type="Orcish Grunt"
+                x,y=7,4
+                [from]
+                    x,y=7,3
+                [/from]
+            [/recruit]
+        [/do_command]
+        {ASSERT (
+            [not]
+                [have_unit]
+                    x,y=7,4
+                    side=1
+                [/have_unit]
+            [/not]
+        )}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# Actions:
+# Side 2's leader stands on a plain keep (no Mercenary Guild).
+# Attempt to recruit a Spearman, which is part of the guild roster but not
+# part of side 2's own recruit list, and side 2 is not on a guild keep.
+##
+# Expected end state:
+# The recruit is rejected; the guild roster only applies to leaders
+# standing on the Mercenary Guild terrain itself.
+#####
+{GENERIC_UNIT_TEST mercenary_guild_recruit_fail_without_guild_keep (
+    {GUILD_SETUP}
+    [event]
+        name=side 1 turn 1
+        [end_turn]
+        [/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn 1
+        [do_command]
+            [recruit]
+                type="Spearman"
+                x,y=13,4
+                [from]
+                    x,y=13,3
+                [/from]
+            [/recruit]
+        [/do_command]
+        {ASSERT (
+            [not]
+                [have_unit]
+                    x,y=13,4
+                    side=2
+                [/have_unit]
+            [/not]
+        )}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# Actions:
+# A leader stands on a Mercenary Guild keep and is allowed to recruit
+# Orcish Grunt through the normal [allow_recruit] mechanism (not the guild
+# list). Recruit both an Orcish Grunt (own list) and a Bowman (guild list)
+# in the same game to confirm the two lists are combined, not replaced.
+##
+# Expected end state:
+# Both recruits succeed.
+#####
+{GENERIC_UNIT_TEST mercenary_guild_recruit_combines_with_own_list (
+    {GUILD_SETUP}
+    [event]
+        name=start
+        [allow_recruit]
+            side=1
+            type=Orcish Grunt
+        [/allow_recruit]
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [do_command]
+            [recruit]
+                type="Orcish Grunt"
+                x,y=7,4
+                [from]
+                    x,y=7,3
+                [/from]
+            [/recruit]
+        [/do_command]
+        {ASSERT (
+            [have_unit]
+                x,y=7,4
+                type="Orcish Grunt"
+                side=1
+            [/have_unit]
+        )}
+        [do_command]
+            [recruit]
+                type="Bowman"
+                x,y=6,3
+                [from]
+                    x,y=7,3
+                [/from]
+            [/recruit]
+        [/do_command]
+        {ASSERT (
+            [have_unit]
+                x,y=6,3
+                type=Bowman
+                side=1
+            [/have_unit]
+        )}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -33,6 +33,7 @@
 #include "gettext.hpp"
 #include "log.hpp"
 #include "map/map.hpp"
+#include "terrain/terrain.hpp"
 #include "pathfind/pathfind.hpp"
 #include "play_controller.hpp"
 #include "recall_list_manager.hpp"
@@ -77,13 +78,18 @@ std::set<std::string> get_recruits(int side, const map_location &recruit_loc)
 	unit_map::const_iterator find_it = resources::gameboard->units().find(recruit_loc);
 	if ( find_it != u_end ) {
 		if ( find_it->can_recruit()  &&  find_it->side() == side  &&
-		     resources::gameboard->map().is_keep(recruit_loc) )
+			 resources::gameboard->map().is_keep(recruit_loc) )
 		{
 			// We have been requested to get the recruit list for this
 			// particular leader.
 			leader_in_place = true;
 			local_result.insert(find_it->recruits().begin(),
-			                    find_it->recruits().end());
+								find_it->recruits().end());
+
+			// Add any fixed recruits declared by the keep terrain itself.
+			const terrain_type& keep_terrain = resources::gameboard->map().get_terrain_info(recruit_loc);
+			const auto& guild = keep_terrain.guild_recruits();
+			local_result.insert(guild.begin(), guild.end());
 		}
 		else if ( find_it->is_visible_to_team(current_team, false) )
 		{
@@ -103,6 +109,11 @@ std::set<std::string> get_recruits(int side, const map_location &recruit_loc)
 			if (allow_local && dynamic_cast<game_state&>(*resources::filter_con).can_recruit_on(*u, recruit_loc)) {
 				leader_in_place= true;
 				local_result.insert(u->recruits().begin(), u->recruits().end());
+
+				// Add any fixed recruits declared by the keep terrain itself.
+				const terrain_type& keep_terrain = resources::gameboard->map().get_terrain_info(u->get_location());
+				const auto& guild = keep_terrain.guild_recruits();
+				local_result.insert(guild.begin(), guild.end());
 			}
 			else if ( !leader_in_place )
 				global_result.insert(u->recruits().begin(), u->recruits().end());
@@ -379,8 +390,12 @@ namespace { // Helpers for check_recruit_location()
 			return RECRUIT_NO_LEADER;
 
 		if ( !unit_type.empty() ) {
-			// Make sure the specified type is in the unit's recruit list.
-			if ( !utils::contains(recruiter.recruits(), unit_type) )
+			// Make sure the specified type is in the unit's recruit list,
+			// or in the guild roster of the keep terrain the recruiter is standing on.
+			const terrain_type& keep_terrain = resources::gameboard->map().get_terrain_info(recruiter.get_location());
+			const auto& guild = keep_terrain.guild_recruits();
+			const bool in_guild = std::find(guild.begin(), guild.end(), unit_type) != guild.end();
+			if ( !utils::contains(recruiter.recruits(), unit_type) && !in_guild )
 				return RECRUIT_NO_ABLE_LEADER;
 		}
 

--- a/src/terrain/terrain.cpp
+++ b/src/terrain/terrain.cpp
@@ -17,6 +17,7 @@
 #include "game_version.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
+#include "serialization/string_utils.hpp"
 #include "terrain/terrain.hpp"
 #include "utils/general.hpp"
 
@@ -66,6 +67,7 @@ terrain_type::terrain_type()
 	, hide_help_(false)
 	, hide_in_editor_(false)
 	, hide_if_impassable_(false)
+	, guild_recruits_()
 {
 }
 
@@ -106,6 +108,7 @@ terrain_type::terrain_type(const config& cfg)
 	, hide_help_(cfg["hide_help"].to_bool(false))
 	, hide_in_editor_(cfg["hidden"].to_bool(false))
 	, hide_if_impassable_(cfg["hide_if_impassable"].to_bool(false))
+	, guild_recruits_(utils::split(cfg["guild_recruits"].str()))
 {
 /**
  *  @todo reenable these validations. The problem is that all MP
@@ -222,6 +225,7 @@ terrain_type::terrain_type(const terrain_type& base, const terrain_type& overlay
 	, hide_help_(true)
 	, hide_in_editor_(base.hide_in_editor_ || overlay.hide_in_editor_)
 	, hide_if_impassable_(base.hide_if_impassable_ || overlay.hide_if_impassable_)
+	, guild_recruits_(overlay.guild_recruits_.empty() ? base.guild_recruits_ : overlay.guild_recruits_)
 {
 	if(description_.empty()) {
 		description_ = base.description();
@@ -299,7 +303,8 @@ bool terrain_type::operator==(const terrain_type& other) const {
 		&& overlay_               == other.overlay_
 		&& editor_default_base_   == other.editor_default_base_
 		&& hide_in_editor_        == other.hide_in_editor_
-		&& hide_help_             == other.hide_help_;
+		&& hide_help_             == other.hide_help_
+		&& guild_recruits_        == other.guild_recruits_;
 }
 
 void merge_alias_lists(t_translation::ter_list& first, const t_translation::ter_list& second)

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -152,6 +152,9 @@ public:
 	bool is_castle() const { return castle_; }
 	bool is_keep() const { return keep_; }
 
+	/** Returns the fixed recruit list embedded in this terrain (e.g. a Mercenary Guild). Empty if none. */
+	const std::vector<std::string>& guild_recruits() const { return guild_recruits_; }
+
 	//these descriptions are shown for the terrain in the mouse over
 	//depending on the owner or the village
 	const t_string& income_description() const { return income_description_; }
@@ -270,4 +273,7 @@ private:
 	bool hide_help_;
 	bool hide_in_editor_;
 	bool hide_if_impassable_;
+
+	/** Unit types that can always be recruited from this terrain, regardless of side roster. */
+	std::vector<std::string> guild_recruits_;
 };

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -514,6 +514,13 @@
 0 recruit_facing_leader
 0 recruit_facing_center
 #
+# Mercenary guild tests
+#
+0 mercenary_guild_recruit_from_guild_list
+1 mercenary_guild_recruit_fail_outside_guild_list
+1 mercenary_guild_recruit_fail_without_guild_keep
+0 mercenary_guild_recruit_combines_with_own_list
+#
 # Interface tests
 #
 0 test_wml_menu_items_1


### PR DESCRIPTION
This was my attempt at creating a feature to add two new structures to Wesnoth. I do not have the sprites for them so they are currently using the stand ins, but this feature is the addition of 2 things: 
A portal that allows for the recruitment of a single before dissapearing.
A Mercenary guild that allows heroes to recruit fixed units regardless of faction allignment.