### PR TITLE
fix #11408 wrong math in biased rng

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -662,8 +662,8 @@ private:
 
 	bool use_prng_;
 
-	int bias_attacker_;
-	int bias_defender_;
+	utils::optional<int> bias_attacker_;
+	utils::optional<int> bias_defender_;
 };
 
 attack::unit_info::unit_info(const map_location& loc, int weapon, unit_map& units)
@@ -737,8 +737,8 @@ attack::attack(const map_location& attacker,
 
 	//new experimental prng mode.
 	, use_prng_(resources::classification->random_mode == "biased" && randomness::generator->is_networked() == false)
-	, bias_attacker_(0)
-	, bias_defender_(0)
+	, bias_attacker_()
+	, bias_defender_()
 {
 	if(use_prng_) {
 		LOG_NG << "Using experimental PRNG for combat";
@@ -871,10 +871,14 @@ bool attack::perform_hit(bool attacker_turn, statistics_attack_context& stats)
 			// TODO: should we call randomness::generator->get_random_int() anyways to stay in sync? (doing so would mean we are calling rng the same amount of times in the biased and defaultmode
 			ran_num = 50;
 		} else {
-			int& bias = attacker_turn ? bias_attacker_ : bias_defender_;
+			auto& bias_opt = attacker_turn ? bias_attacker_ : bias_defender_;
+			if(!bias_opt) {
+				bias_opt = randomness::generator->get_random_int(0,  100 * attacker.n_attacks_ - 1);
+			}
+			int& bias = *bias_opt;
 			// attacker.n_attacks_ is the number of strikes left.
-			int expected_hits = attacker.cth_ * attacker.n_attacks_ + bias;
-			bool does_hit = randomness::generator->get_random_int(0,  100 * attacker.n_attacks_ - 1) < expected_hits;
+			int expected_hits = (attacker.cth_ * attacker.n_attacks_ + bias) / 100;
+			bool does_hit = randomness::generator->get_random_int(0,  attacker.n_attacks_ - 1) < expected_hits;
 			bias += (attacker.cth_ - 100 * int(does_hit));
 			ran_num = does_hit ? 0 : 99;
 		}

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -873,7 +873,7 @@ bool attack::perform_hit(bool attacker_turn, statistics_attack_context& stats)
 		} else {
 			auto& bias_opt = attacker_turn ? bias_attacker_ : bias_defender_;
 			if(!bias_opt) {
-				bias_opt = randomness::generator->get_random_int(0,  100 * attacker.n_attacks_ - 1);
+				bias_opt = randomness::generator->get_random_int(0,  99);
 			}
 			int& bias = *bias_opt;
 			// attacker.n_attacks_ is the number of strikes left.


### PR DESCRIPTION
We now make one random roll at the start to determine whether we do one more hit in total or not, This makes the code behave like the old biased rng, and in partiuclar fixes the expected value of hits to match the unbiased expected value of hits. So the new algorithm is:

(the following explanation code uses probabilities instead of 100-based percentages)

```

var extra_hit_roll := randf()
var hits_done := 0
var expected_hits_done := 0

func roll(probability: float, strikes_left: int) -> bool:

    let expected_hits_left = strikes_left * probability
    let expected_hits_total = expected_hits_left + expected_hits_done
    let hits_total = floor(expected_hits_total + extra_hit_roll)
    let remaining_hits = hits_total - hits_done

    let hits = randf() * strikes_left < remaining_hits
    expected_hits_done += probability
    hits_done += hits
    return hits
```
clearly the three tracking variaiables can be replaced by one variable `extra_hit_roll + expected_hits_done  - hits_done ` which is what teh actual code does.