### PR TITLE
Include Kme in the encampment-keeps transition graphics

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -778,7 +778,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 # Aquatic castle
 
-{NEW:CASTLEWALL             Cm            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/aquatic-castle/castle}
+{NEW:CASTLEWALL             Cm            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/aquatic-castle/castle}
 {NEW:CASTLEWALL2            Km            !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/aquatic-castle/keep-castle}
 {NEW:CASTLEWALL             Km            (!,Km,Xu*,Xo*)        K*                castle/aquatic-castle/keep}
 
@@ -790,35 +790,35 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 # Elven castle
 
-{NEW:CASTLEWALL             Cv            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/elven/castle}
+{NEW:CASTLEWALL             Cv            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/elven/castle}
 {NEW:CASTLEWALL2            Kv            !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/elven/keep-castle}
 {NEW:CASTLEWALL             Kv            (!,K*,Xu*,Xo*)        K*                castle/elven/keep}
 
-{NEW:CASTLEWALL             Cvr           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/elven-ruin/castle}
+{NEW:CASTLEWALL             Cvr           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/elven-ruin/castle}
 {NEW:CASTLEWALL2            Kvr           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/elven-ruin/keep-castle}
 {NEW:CASTLEWALL             Kvr           (!,K*,Xu*,Xo*)        K*                castle/elven-ruin/keep}
 
-{NEW:CASTLEWALL             Cva           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/winter-elven/castle}
+{NEW:CASTLEWALL             Cva           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/winter-elven/castle}
 {NEW:CASTLEWALL2            Kva           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/winter-elven/keep-castle}
 {NEW:CASTLEWALL             Kva           (!,K*,Xu*,Xo*)        K*                castle/winter-elven/keep}
 
 # Orcish castles
 
-{NEW:CASTLEWALL             Co            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/orcish/fort}
+{NEW:CASTLEWALL             Co            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/orcish/fort}
 {NEW:CASTLEWALL2            Ko            !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/orcish/keep-fort}
 {NEW:CASTLEWALL             Ko            (!,K*,Xu*,Xo*)        K*                castle/orcish/keep}
 
-{NEW:CASTLEWALL             Coa           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/winter-orcish/fort}
+{NEW:CASTLEWALL             Coa           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/winter-orcish/fort}
 {NEW:CASTLEWALL2            Koa           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/winter-orcish/keep-fort}
 {NEW:CASTLEWALL             Koa           (Ke,Kea,!,K*,Xu*,Xo*) K*                castle/winter-orcish/keep}
 
 # Desert castles
 
-{NEW:CASTLEWALL             Cd            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/sand/castle}
+{NEW:CASTLEWALL             Cd            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/sand/castle}
 {NEW:CASTLEWALL2            Kd            !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/sand/keep-castle}
 {NEW:CASTLEWALL             Kd            (!,K*,Xu*,Xo*)        K*                castle/sand/keep}
 
-{NEW:CASTLEWALL             Cdr           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/sand/ruin-castle}
+{NEW:CASTLEWALL             Cdr           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/sand/ruin-castle}
 {NEW:CASTLEWALL2            Kdr           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/sand/ruin-keep-castle}
 {NEW:CASTLEWALL             Kdr           (Ke,Kea,!,K*,Xu*,Xo*) K*                castle/sand/ruin-keep}
 
@@ -826,11 +826,11 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 # Human castles
 #
 
-{NEW:CASTLEWALL             Ch            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/castle}
+{NEW:CASTLEWALL             Ch            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/castle}
 {NEW:CASTLEWALL2            Kh            !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/keep-castle}
 {NEW:CASTLEWALL             Kh            (!,K*,Xu*,Xo*)        K*                castle/keep}
 
-{NEW:CASTLEWALL             Cha           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/snowy/castle}
+{NEW:CASTLEWALL             Cha           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/snowy/castle}
 {NEW:CASTLEWALL2            Kha           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/snowy/keep-castle}
 {NEW:CASTLEWALL             Kha           (Ke,Kea,!,K*,Xu*,Xo*) K*                castle/snowy/keep}
 
@@ -840,7 +840,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 # (!,Chr,Chs,!,Ch*) is used to catch convex transitions between Chw and Ch*
 # without lots of additional rules
-{NEW:CASTLEWALL             (!,Chr,Chs,Ce*,Ke*,!,Ch*) (W*)      !,Ket,!,C*,Ke*    castle/sunken-ruin}
+{NEW:CASTLEWALL             (!,Chr,Chs,Ce*,Ke*,!,Ch*) (W*)      !,Ket,!,C*,Ke*,Kme    castle/sunken-ruin}
 
 {NEW:CASTLEWALL2_P          Khw,Khs       Ch*                   W*,Ss       75    castle/sunken-ruinkeep1-castle}
 {NEW:CASTLEWALL2            Khw,Khs       Ch*                   W*,Ss             castle/sunkenkeep-castle}
@@ -852,7 +852,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 # There are no more human castles left, so we can just use Ch* here, which makes sure
 # that all ruin<->non-ruin transitions are drawn
-{NEW:CASTLEWALL             Ch*           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/ruin}
+{NEW:CASTLEWALL             Ch*           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/ruin}
 
 {NEW:CASTLEWALL2_P          (Khr,Khw,Khs) (C*)         (!,Ch*,Kh*,Xu*,Xo*) 75     castle/ruinkeep1-castle}
 {NEW:CASTLEWALL2            (Khr,Khw,Khs) (C*)         (!,Ch*,Kh*,Xu*,Xo*)        castle/keep-castle}
@@ -862,15 +862,15 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 
 # Dwarf outside castles (similar appearance, but different rules and transitions than classic cave version)
 
-{NEW:CASTLEWALL             Cfa,Kfa       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/winter-dwarven/dwarven-castle}
-{NEW:CASTLEWALL             Cfr,Kfr       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/ruin-dwarven/dwarven-castle}
-{NEW:CASTLEWALL             Cf*,Kf*       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/outside-dwarven/dwarven-castle}
+{NEW:CASTLEWALL             Cfa,Kfa       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/winter-dwarven/dwarven-castle}
+{NEW:CASTLEWALL             Cfr,Kfr       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/ruin-dwarven/dwarven-castle}
+{NEW:CASTLEWALL             Cf*,Kf*       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/outside-dwarven/dwarven-castle}
 
 # Encampment
 
-{NEW:CASTLEWALL             Ce,Ke         (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/encampment/regular}
-{NEW:CASTLEWALL             Cer,Ker       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/encampment-ruin/regular}
-{NEW:CASTLEWALL             Cea,Kea       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/encampment/snow}
+{NEW:CASTLEWALL             Ce,Ke         (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/encampment/regular}
+{NEW:CASTLEWALL             Cer,Ker       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/encampment-ruin/regular}
+{NEW:CASTLEWALL             Cea,Kea       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*,Kme    castle/encampment/snow}
 {NEW:CASTLEWALL2            Ket           (!,Ket,!,C*,Ke*)                  (!,C*,K*,Xu*,Xo*) castle/encampment/tall-keep-castle}
 {NEW:CASTLEWALL             Ket           (!,Ket,!,Ke*,!,K*,Xu*,Xo*)        K*                castle/encampment/tall-keep}
 


### PR DESCRIPTION
Fixes #11256.  Hat-tip to #11398 for the reminder.
<img width="928" height="692" alt="Screenshot_20260725a" src="https://github.com/user-attachments/assets/83e94559-2d2d-422d-968d-a2bf4135a233" />
