### PR TITLE
Make dragging units work again

### DIFF
--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -118,6 +118,8 @@ bool mouse_handler_base::mouse_motion_default(int x, int y, bool /*update*/)
 		float mx = pos.x;
 		float my = pos.y;
 		uint32_t mouse_state = dragging_left_ || dragging_right_ ? sdl::get_mouse_state(&mx, &my) : 0;
+		pos.x = static_cast<int>(mx);
+		pos.y = static_cast<int>(my);
 
 #ifdef MOUSE_TOUCH_EMULATION
 		if(dragging_left_ && (mouse_state & SDL_BUTTON_MASK(SDL_BUTTON_RIGHT))) {


### PR DESCRIPTION
It would probably be better to change drag_from_ and pos to be floats instead of ints. However, this is a step in that direction, and it's a minimal fix of #11415 for the release.

Other callers of sdl::get_mouse_location were changed similarly in the SDL3 changes.