### PR TITLE
HttT S50: Avoid using negative values for current_time

### DIFF
--- a/changelog_entries/httt-negative-schedule.md
+++ b/changelog_entries/httt-negative-schedule.md
@@ -1,0 +1,3 @@
+### Campaigns
+   * Heir to the Throne
+      * S50 "The Battle for Wesnoth": Avoid setting negative time values for time areas

--- a/data/campaigns/Heir_To_The_Throne/scenarios/50_The_Battle_for_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/50_The_Battle_for_Wesnoth.cfg
@@ -3,9 +3,9 @@
 
 # timed roughly so that if we rush straight towards Asheivere, we arrive at Dawn/Morning, which helps to discourage rushing her immediately
 # it's very hard to estimate this, since the player could have all different kinds of units, and since the schedule is different for each season,
-# but this is my rough guess
+# but my rough guess is 9 turns. The modulo calculation in utils/schedule.cfg expects TOD_OFFSET + 7 to be non-negative, so use -3 here instead.
 #define TOD_OFFSET
--9#enddef
+-3#enddef
 
 [scenario]
     name=_"scenario name^The Battle for Wesnoth"


### PR DESCRIPTION
Although the campaign's own modulo calculation handles negative TOD_OFFSET values, it expects adding 7 to be enough. The related engine bug will also be fixed, but the engine might start printing deprecation messages or errors about what HttT was doing.

Workaround for #11425

The engine bug is fixed by #11428