### PR TITLE
Code style change in implementation of [filter_adjacent]

### DIFF
--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -163,14 +163,9 @@ struct unit_filter_adjacent : public unit_filter_base
 			++match_count;
 		}
 
+		static std::vector<std::pair<int,int>> default_counts = {{{1, std::numeric_limits<int>::max()}}};
 		config::attribute_value i_count = cfg_["count"];
-		if(i_count.empty() && match_count == 0) {
-			return false;
-		}
-		if(!i_count.empty() && !in_ranges<int>(match_count, utils::parse_ranges_unsigned(i_count.str()))) {
-			return false;
-		}
-		return true;
+		return in_ranges(match_count, !i_count.empty() ? utils::parse_ranges_unsigned(i_count) : default_counts);
 	}
 
 	const unit_filter_compound child_;


### PR DESCRIPTION
This isn't a behavior change. Looking at the replaced code, the second if was already guarded with !i_count.empty(), so the code will continue to return true. Cherry-picked from @newfrenchy83 's PR #11417 .

This matches the style in the rest of the file, and it's actually closer to the code in 1.18, except for increasing the range from "1-6", which will accommodate the new radius attribute's larger number of hexes. That old code was heavily tested in 1.18 - in the code for the old tutorial, there's no count attribute in the event that spawns the Quintain.

Diff against origin/1.18 :
```diff
@@ -152,5 +164,5 @@ struct unit_filter_adjacent : public unit_filter_base
                }
 
-               static std::vector<std::pair<int,int>> default_counts = utils::parse_ranges_unsigned("1-6");
+               static std::vector<std::pair<int,int>> default_counts = {{{1, std::numeric_limits<int>::max()}}};
                config::attribute_value i_count = cfg_["count"];
                return in_ranges(match_count, !i_count.blank() ? utils::parse_ranges_unsigned(i_count) : default_counts);
```