### PR TITLE
Restore music fading guard block lost in SDL3 migration

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -672,6 +672,11 @@ void play_music_config(const config& music_node, bool allow_interrupt_current_tr
 
 void music_thinker::process()
 {
+	if(MIX_GetTrackFadeFrames(music_tracks[0]) != 0) {
+		// Do not block everything while fading.
+		return;
+	}
+
 	if(prefs::get().music_on()) {
 		// TODO: rethink the music_thinker design, especially the use of fade_out_time
 		auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
#8638 removed the music fading guard block:

```c++
	if(Mix_FadingMusic() != MIX_NO_FADING) {
		// Do not block everything while fading.
		return;
	}
```

This restores that removal with the SDL3 equivalent.

Resolves #11446.

Disclosure: LLM-assistance used for investigation, but code written and tested by me.

References:
https://wiki.libsdl.org/SDL2_mixer/Mix_FadingMusic
https://wiki.libsdl.org/SDL3_mixer/MIX_GetTrackFadeFrames