### PR TITLE
Preferences: Don't show advanced preferences on initial set-up

### DIFF
--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -815,7 +815,7 @@ void preferences_dialog::initialize_callbacks()
 	connect_signal_notify_modified(advanced,
 		[this, &advanced](auto&&...) { on_advanced_prefs_list_select(advanced); });
 
-	on_advanced_prefs_list_select(advanced);
+	on_advanced_prefs_list_select(advanced, true);
 
 	//
 	// HOTKEYS PANEL
@@ -1052,12 +1052,15 @@ void preferences_dialog::hotkey_filter_callback()
 	find_widget<listbox>("list_hotkeys").set_row_shown(res);
 }
 
-void preferences_dialog::on_advanced_prefs_list_select(listbox& list)
+void preferences_dialog::on_advanced_prefs_list_select(listbox& list, const bool initial)
 {
 	const int selected_row = list.get_selected_row();
 	const auto& pref = prefs::get().get_advanced_preferences()[selected_row];
 
-	if(pref.type == preferences::option::avd_type::SPECIAL) {
+	// In Japanese language sorting, Reach Map Options becomes the first item and is selected
+	// automatically before the user has made any choice. Skip SPECIAL preferences if
+	// Preferences is still being built (initial == true). GitHub #11136.
+	if(!initial && pref.type == preferences::option::avd_type::SPECIAL) {
 		if(pref.field == "logging") {
 			gui2::dialogs::log_settings::display();
 		} else if(pref.field == "orb_color") {

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -91,7 +91,7 @@ private:
 	void update_friends_list_controls(listbox& list);
 
 	/** Callback for selection changes */
-	void on_advanced_prefs_list_select(listbox& tree);
+	void on_advanced_prefs_list_select(listbox& tree, const bool initial = false);
 
 	/** Special callback functions */
 	void handle_res_select();


### PR DESCRIPTION
Resolves #11136.

Disclosure: LLM-assisted investigation, but I wrote the code changes.

Apparently, the way the advanced preferences dialogues were being sorted in Japanese brought Reach Map Options to the top of the list and being a `SPECIAL` preference, it was being auto-displayed before the main Preferences dialogue was shown. This skips the trigger of the `SPECIAL` preferences while the main Preferences dialogue is still being built.