### PR TITLE
Force fontconfig in Windows since the environment variable isn't holding in MSYS2 builds

### DIFF
--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -29,6 +29,9 @@
 
 
 #include <fontconfig/fontconfig.h>
+#ifdef _WIN32
+#include <pango/pangocairo.h>
+#endif
 
 static lg::log_domain log_font("font");
 #define DBG_FT LOG_STREAM(debug, log_font)
@@ -138,6 +141,23 @@ manager::manager()
 	{
 		LOG_FT << "Local font configuration loaded";
 	}
+
+#ifdef _WIN32
+	// Pango's default Windows back-end is the native win32/GDI one, which never
+	// consults fontconfig and thus never sees the custom fonts registered above.
+	// Setting PANGOCAIRO_BACKEND=fontconfig in main() is meant to prevent this,
+	// but on some Windows builds it has not reliably taken effect (since the
+	// SDL3 migration) before Pango's default font map is first created, so force
+	// it explicitly here instead of relying on that environment variable being
+	// seen in time.
+	PangoFontMap* fc_font_map = pango_cairo_font_map_new_for_font_type(CAIRO_FONT_TYPE_FT);
+	if(fc_font_map) {
+		pango_cairo_font_map_set_default(PANGO_CAIRO_FONT_MAP(fc_font_map));
+		g_object_unref(fc_font_map);
+	} else {
+		ERR_FT << "Could not create a fontconfig-backed Pango font map";
+	}
+#endif
 }
 
 manager::~manager()

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -992,18 +992,26 @@ int main(int argc, char** argv)
 	assert(!args.empty());
 
 #ifdef _WIN32
+	// Different Windows builds of Pango/GLib have been observed to read this
+	// back via different mechanisms: the official mingw-w64 build only sees a
+	// value set via the real Win32 environment block (SetEnvironmentVariableA),
+	// while an MSVC/vcpkg build has only been confirmed to see a value set via
+	// the C run-time's own _putenv(). Since neither alone is known to work across
+	// both, set it both ways.
 	_putenv("PANGOCAIRO_BACKEND=fontconfig");
 	_putenv("FONTCONFIG_PATH=fonts");
+	SetEnvironmentVariableA("PANGOCAIRO_BACKEND", "fontconfig");
+	SetEnvironmentVariableA("FONTCONFIG_PATH", "fonts");
 #endif
 #ifdef __APPLE__
 	// Using setenv with overwrite disabled so we can override this in the
 	// original process environment for research/testing purposes.
-	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
+	SDL_setenv_unsafe("PANGOCAIRO_BACKEND", "fontconfig", 0);
 #endif
 #ifdef __ANDROID__
-	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
-	setenv("SDL_HINT_AUDIODRIVER", "android", 0);
-	setenv("SDL_HINT_ANDROID_TRAP_BACK_BUTTON", "1", 0);
+	SDL_setenv_unsafe("PANGOCAIRO_BACKEND", "fontconfig", 0);
+	SDL_setenv_unsafe("SDL_HINT_AUDIODRIVER", "android", 0);
+	SDL_setenv_unsafe("SDL_HINT_ANDROID_TRAP_BACK_BUTTON", "1", 0);
 #endif
 
 	try {

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -992,18 +992,24 @@ int main(int argc, char** argv)
 	assert(!args.empty());
 
 #ifdef _WIN32
-	_putenv("PANGOCAIRO_BACKEND=fontconfig");
-	_putenv("FONTCONFIG_PATH=fonts");
+	// SDL_setenv_unsafe() is used instead of _putenv() because _putenv() only
+	// updates the C run-time's private environment copy on some Windows CRTs
+	// (eg the legacy msvcrt.dll linked by MSYS2 builds), not the process environment
+	// block that GetEnvironmentVariable (and thus GLib's g_getenv, which Pango
+	// uses to read PANGOCAIRO_BACKEND) reads. SDL_setenv_unsafe() calls
+	// SetEnvironmentVariableA() directly on Windows, avoiding that gap.
+	SDL_setenv_unsafe("PANGOCAIRO_BACKEND", "fontconfig", 0);
+	SDL_setenv_unsafe("FONTCONFIG_PATH", "fonts", 0);
 #endif
 #ifdef __APPLE__
 	// Using setenv with overwrite disabled so we can override this in the
 	// original process environment for research/testing purposes.
-	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
+	SDL_setenv_unsafe("PANGOCAIRO_BACKEND", "fontconfig", 0);
 #endif
 #ifdef __ANDROID__
-	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
-	setenv("SDL_HINT_AUDIODRIVER", "android", 0);
-	setenv("SDL_HINT_ANDROID_TRAP_BACK_BUTTON", "1", 0);
+	SDL_setenv_unsafe("PANGOCAIRO_BACKEND", "fontconfig", 0);
+	SDL_setenv_unsafe("SDL_HINT_AUDIODRIVER", "android", 0);
+	SDL_setenv_unsafe("SDL_HINT_ANDROID_TRAP_BACK_BUTTON", "1", 0);
 #endif
 
 	try {


### PR DESCRIPTION
Resolves #11447.

I can't test this since I use MSVC to build on Windows and its C run-time is unaffected. But I believe I confirmed the equivalent operation by manually setting the environment variable in a shell before running the official 1.19.25 and 1.19.26 releases, which then allowed the fonts to be configured properly.