### PR TITLE
Strengthen footprints as the map zooms out [LLM Assisted]

### DIFF
--- a/changelog_entries/footprint-zoom-strengthening.md
+++ b/changelog_entries/footprint-zoom-strengthening.md
@@ -1,0 +1,2 @@
+### UI
+   * Footprints are drawn at a stronger opacity as the map is zoomed out, so they stay readable when the hexes are small.

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -20,6 +20,7 @@
 
 #include "game_display.hpp"
 
+#include <cmath>
 #include <utility>
 
 
@@ -363,6 +364,36 @@ std::vector<texture> footsteps_images(const map_location& loc, const pathfind::m
 	return res;
 }
 
+/**
+ * Zoomed out, the prints are easily lost in the terrain.
+ * Boost visibility by blitting them repeatedly, fading the extra passes in as the map zooms out.
+ */
+struct zoom_boost_step_renderer
+{
+	std::vector<texture> images;
+
+	void operator()(const rect& dest) const {
+		// The zoom levels roughly double in size, so ramp in octaves to keep the steps even
+		constexpr double ramp_start = 216.0; // hex size where strengthening starts
+		constexpr double ramp_octaves = 3.7548; // log2(216/16), normalizes the ramp to 0-1
+
+		const double boost = std::clamp(std::log2(ramp_start / display::hex_size()) / ramp_octaves, 0.0, 1.0);
+
+		for(texture t : images) {
+			draw::blit(t, dest);
+
+			if(boost <= 0.0) {
+				continue;
+			}
+
+			t.set_alpha_mod(static_cast<uint8_t>(boost * 255));
+			draw::blit(t, dest);
+			draw::blit(t, dest);
+			t.set_alpha_mod(255);
+		}
+	}
+};
+
 struct flash_fade_step_renderer
 {
 	std::vector<texture> images;
@@ -481,11 +512,8 @@ void game_display::draw_hex(const map_location& loc)
 			// Draw standard footsteps for the current turn's route.
 			std::vector<texture> footstepImages = footsteps_images(loc, route_, dc_);
 			if(!footstepImages.empty()) {
-				drawing_buffer_add(drawing_layer::footsteps, loc, [images = std::move(footstepImages)](const rect& dest) {
-					for(const texture& t : images) {
-						draw::blit(t, dest);
-					}
-				});
+				drawing_buffer_add(drawing_layer::footsteps, loc,
+					zoom_boost_step_renderer{ std::move(footstepImages) });
 			}
 
 			// Draw the flash fade effect for queued (future turn) moves.


### PR DESCRIPTION
Footprints are drawn at a fixed 30%-ish opacity, which reads well at normal zoom but leaves them hard to follow once the hexes get small at high zoom levels. 

This PR will fade in extra blit passes of the footprints as the map zooms out so the path stays legible.

<img width="1039" height="556" alt="image" src="https://github.com/user-attachments/assets/9787be13-70ba-4f6d-a6aa-d80595c59fa6" />

Top image is when zoomed in (default opacity) Bottom part is when zoomed out more (max opacity)

@Hejnewar @Dalas121 @Vultraz 
