### PR TITLE
DW S11: Add loyal marker to Tyegea

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -37,6 +37,7 @@
         name= _ "Tyegëa"
         canrecruit=yes
         type=Mermaid Diviner
+        facing=ne
         [ai]
             ai_algorithm=idle_ai
         [/ai]

--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -37,10 +37,6 @@
         name= _ "Tyegëa"
         canrecruit=yes
         type=Mermaid Diviner
-        [modifications]
-            {TRAIT_LOYAL OVERLAY=""}
-            {TRAIT_DEXTROUS}
-        [/modifications]
         [ai]
             ai_algorithm=idle_ai
         [/ai]
@@ -116,13 +112,11 @@
             [/filter]
             side=1
             canrecruit=no
+			[modifications]
+				{TRAIT_LOYAL}
+				{TRAIT_DEXTROUS}
+			[/modifications]
         [/modify_unit]
-        ## TODO: im not sure what happens here, why is he getting the loyal overlay but not the real trait?
-        [unit_overlay]
-            x=$Tyegea_stored.x
-            y=$Tyegea_stored.y
-            image=misc/loyal-icon.png
-        [/unit_overlay]
 
         [allow_recruit]
             type=Mermaid Priestess

--- a/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
+++ b/data/campaigns/Dead_Water/scenarios/11_Getting_Help.cfg
@@ -112,10 +112,10 @@
             [/filter]
             side=1
             canrecruit=no
-			[modifications]
-				{TRAIT_LOYAL}
-				{TRAIT_DEXTROUS}
-			[/modifications]
+            [modifications]
+                {TRAIT_LOYAL}
+                {TRAIT_DEXTROUS}
+            [/modifications]
         [/modify_unit]
 
         [allow_recruit]


### PR DESCRIPTION
Tyegëa is missing the loyal overlay in the 1.19 version:Removed the loyal overlay modification and updated the trait modifications for Tyegea.

<img width="719" height="498" alt="image" src="https://github.com/user-attachments/assets/9c82fb0f-b65b-454f-b92a-a55193b8caee" />

Removed the modifications in [side] by 11_Getting_Help.cfg and updated the modify_unit part Tyegëa at the end of the scenario.
<img width="701" height="511" alt="image" src="https://github.com/user-attachments/assets/5e6c668e-5924-4f00-833e-7795d3098581" />
