### PR TITLE
Only initialize audio subsystem once, and other improvements

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -635,7 +635,6 @@ list_formatter sound_settings_report_internal(const std::string& heading = "")
 	fmt.insert("Number of channels", std::to_string(driver_status.channels));
 	fmt.insert("Output rate", std::to_string(driver_status.frequency) + " Hz");
 	fmt.insert("Sample format", fmt_name);
-	fmt.insert("Sample size", std::to_string(driver_status.chunk_size) + " bytes");
 
 	return fmt;
 }

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -254,9 +254,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts)
 	}
 
 	// disable sound in nosound mode, or when sound engine failed to initialize
-	if(no_sound || ((prefs::get().sound() || prefs::get().music_on() ||
-	                  prefs::get().turn_bell() || prefs::get().ui_sound_on()) &&
-	                 !sound::init_sound())) {
+	if(no_sound || !sound::init_sound()) {
 		prefs::get().set_sound(false);
 		prefs::get().set_music(false);
 		prefs::get().set_turn_bell(false);

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -794,23 +794,18 @@ bool prefs::turn_bell()
 	return preferences_[prefs_list::turn_bell].to_bool(true);
 }
 
-bool prefs::set_turn_bell(bool ison)
+bool prefs::set_turn_bell(bool is_on)
 {
-	if(!turn_bell() && ison) {
+	// TODO: the source of truth should be the sound system itself, not prefs
+	if(is_on && !turn_bell()) {
 		preferences_[prefs_list::turn_bell] = true;
-		if(!music_on() && !sound() && !ui_sound_on()) {
-			if(!sound::init_sound()) {
-				preferences_[prefs_list::turn_bell] = false;
-				return false;
-			}
-		}
-	} else if(turn_bell() && !ison) {
+		sound::restart_bell();
+	} else if(!is_on && turn_bell()) {
 		preferences_[prefs_list::turn_bell] = false;
 		sound::stop_bell();
-		if(!music_on() && !sound() && !ui_sound_on())
-			sound::close_sound();
 	}
-	return true;
+
+	return is_on;
 }
 
 // old pref name had uppercase UI
@@ -823,23 +818,18 @@ bool prefs::ui_sound_on()
 	}
 }
 
-bool prefs::set_ui_sound(bool ison)
+bool prefs::set_ui_sound(bool is_on)
 {
-	if(!ui_sound_on() && ison) {
+	// TODO: the source of truth should be the sound system itself, not prefs
+	if(is_on && !ui_sound_on()) {
 		preferences_[prefs_list::ui_sound] = true;
-		if(!music_on() && !sound() && !turn_bell()) {
-			if(!sound::init_sound()) {
-				preferences_[prefs_list::ui_sound] = false;
-				return false;
-			}
-		}
-	} else if(ui_sound_on() && !ison) {
+		sound::restart_UI_sound();
+	} else if(!is_on && ui_sound_on()) {
 		preferences_[prefs_list::ui_sound] = false;
 		sound::stop_UI_sound();
-		if(!music_on() && !sound() && !turn_bell())
-			sound::close_sound();
 	}
-	return true;
+
+	return is_on;
 }
 
 bool prefs::message_bell()
@@ -852,22 +842,18 @@ bool prefs::sound()
 	return preferences_[prefs_list::sound].to_bool(true);
 }
 
-bool prefs::set_sound(bool ison) {
-	if(!sound() && ison) {
+bool prefs::set_sound(bool is_on)
+{
+	// TODO: the source of truth should be the sound system itself, not prefs
+	if(is_on && !sound()) {
 		preferences_[prefs_list::sound] = true;
-		if(!music_on() && !turn_bell() && !ui_sound_on()) {
-			if(!sound::init_sound()) {
-				preferences_[prefs_list::sound] = false;
-				return false;
-			}
-		}
-	} else if(sound() && !ison) {
+		sound::restart_sound();
+	} else if(!is_on && sound()) {
 		preferences_[prefs_list::sound] = false;
 		sound::stop_sound();
-		if(!music_on() && !turn_bell() && !ui_sound_on())
-			sound::close_sound();
 	}
-	return true;
+
+	return is_on;
 }
 
 bool prefs::music_on()
@@ -875,25 +861,18 @@ bool prefs::music_on()
 	return preferences_[prefs_list::music].to_bool(true);
 }
 
-bool prefs::set_music(bool ison) {
-	if(!music_on() && ison) {
+bool prefs::set_music(bool is_on)
+{
+	// TODO: the source of truth should be the sound system itself, not prefs
+	if(is_on && !music_on()) {
 		preferences_[prefs_list::music] = true;
-		if(!sound() && !turn_bell() && !ui_sound_on()) {
-			if(!sound::init_sound()) {
-				preferences_[prefs_list::music] = false;
-				return false;
-			}
-		}
-		else
-			sound::play_music();
-	} else if(music_on() && !ison) {
+		sound::restart_music();
+	} else if(!is_on && music_on()) {
 		preferences_[prefs_list::music] = false;
-		if(!sound() && !turn_bell() && !ui_sound_on())
-			sound::close_sound();
-		else
-			sound::stop_music();
+		sound::stop_music();
 	}
-	return true;
+
+	return is_on;
 }
 
 int prefs::scroll_speed()

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -909,22 +909,6 @@ optional_const_config prefs::get_alias()
 	return get_child(prefs_list::alias);
 }
 
-unsigned int prefs::sample_rate()
-{
-	return preferences_[prefs_list::sample_rate].to_int(44100);
-}
-
-void prefs::save_sample_rate(const unsigned int rate)
-{
-	if (sample_rate() == rate)
-		return;
-
-	preferences_[prefs_list::sample_rate] = rate;
-
-	// If audio is open, we have to re set sample rate
-	sound::reset_sound();
-}
-
 bool prefs::confirm_load_save_from_different_version()
 {
 	return preferences_[prefs_list::confirm_load_save_from_different_version].to_bool(true);

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -700,30 +700,6 @@ void prefs::keepalive_timeout(int seconds)
 	preferences_[prefs_list::keepalive_timeout] = std::abs(seconds);
 }
 
-std::size_t prefs::sound_buffer_size()
-{
-	// Sounds don't sound good on Windows unless the buffer size is 4k,
-	// but this seems to cause crashes on other systems...
-	#ifdef _WIN32
-		const std::size_t buf_size = 4096;
-	#else
-		const std::size_t buf_size = 1024;
-	#endif
-
-	return preferences_[prefs_list::sound_buffer_size].to_int(buf_size);
-}
-
-void prefs::save_sound_buffer_size(const std::size_t size)
-{
-	const std::string new_size = std::to_string(size);
-	if (preferences_[prefs_list::sound_buffer_size] == new_size)
-		return;
-
-	preferences_[prefs_list::sound_buffer_size] = new_size;
-
-	sound::reset_sound();
-}
-
 sound::volume prefs::music_volume()
 {
 	return sound::volume::from_percent(preferences_[prefs_list::music_volume].to_double(100.f));

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -274,9 +274,6 @@ public:
 	unsigned int sample_rate();
 	void save_sample_rate(const unsigned int rate);
 
-	std::size_t sound_buffer_size();
-	void save_sound_buffer_size(const std::size_t size);
-
 	sound::volume sound_volume();
 	void set_sound_volume(sound::volume vol);
 
@@ -867,7 +864,6 @@ private:
 		prefs_list::show_tips,
 		prefs_list::mp_server_program_name,
 		prefs_list::pixel_scale,
-		prefs_list::sound_buffer_size,
 		prefs_list::theme,
 		prefs_list::tile_size,
 		prefs_list::vsync,

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -271,9 +271,6 @@ public:
 	bool sound();
 	bool set_sound(bool ison);
 
-	unsigned int sample_rate();
-	void save_sample_rate(const unsigned int rate);
-
 	sound::volume sound_volume();
 	void set_sound_volume(sound::volume vol);
 
@@ -806,7 +803,6 @@ private:
 		prefs_list::skip_ai_moves,
 		prefs_list::skip_mp_replay,
 		prefs_list::sound,
-		prefs_list::sample_rate,
 		prefs_list::stop_music_in_background,
 		prefs_list::turbo,
 		prefs_list::turbo_speed,

--- a/src/preferences/preferences_list.hpp
+++ b/src/preferences/preferences_list.hpp
@@ -254,8 +254,6 @@ struct preferences_list_defines
 	ADDPREF(skip_mp_replay)
 	/** whether to play non-UI sounds */
 	ADDPREF(sound)
-	/** audio buffer size */
-	ADDPREF(sound_buffer_size)
 	/** the volume for playing sounds */
 	ADDPREF(sound_volume)
 	/** list of the last selected single player modifications */
@@ -516,7 +514,6 @@ struct preferences_list_defines
 		skip_ai_moves,
 		skip_mp_replay,
 		sound,
-		sound_buffer_size,
 		sound_volume,
 		sp_modifications,
 		stop_music_in_background,

--- a/src/preferences/preferences_list.hpp
+++ b/src/preferences/preferences_list.hpp
@@ -216,8 +216,6 @@ struct preferences_list_defines
 	ADDPREF(random_faction_mode)
 	/** whether to remember passwords typed into password fields */
 	ADDPREF(remember_password)
-	/** audio sample rate */
-	ADDPREF(sample_rate)
 	/** whether to save replays of games */
 	ADDPREF(save_replays)
 	/** the scroll speed */
@@ -495,7 +493,6 @@ struct preferences_list_defines
 		pixel_scale,
 		random_faction_mode,
 		remember_password,
-		sample_rate,
 		save_replays,
 		scroll,
 		scroll_threshold,

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -360,7 +360,7 @@ bool init_sound()
 
 	if(!mixer) {
 		SDL_AudioSpec spec;
-		spec.freq = prefs::get().sample_rate();
+		spec.freq = 44100;
 		spec.format = SDL_AUDIO_S16;
 		spec.channels = 2;
 		mixer = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec);

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -437,35 +437,6 @@ void close_sound()
 	LOG_AUDIO << "Audio device released.";
 }
 
-void reset_sound()
-{
-	bool music = prefs::get().music_on();
-	bool sound = prefs::get().sound();
-	bool UI_sound = prefs::get().ui_sound_on();
-	bool bell = prefs::get().turn_bell();
-
-	if(music || sound || bell || UI_sound) {
-		sound::close_sound();
-		sound::init_sound();
-
-		if(!music) {
-			sound::stop_music();
-		}
-
-		if(!sound) {
-			sound::stop_sound();
-		}
-
-		if(!UI_sound) {
-			sound::stop_UI_sound();
-		}
-
-		if(!bell) {
-			sound::stop_bell();
-		}
-	}
-}
-
 void stop_music()
 {
 	if(mixer) {

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -986,7 +986,7 @@ volume get_music_volume()
 void set_music_volume(volume vol)
 {
 	if(mixer) {
-		MIX_SetTrackGain(sound::music_channels[0], clamp_gain(vol));
+		MIX_SetTagGain(mixer, sound_tracks::music, clamp_gain(vol));
 	}
 }
 
@@ -1005,14 +1005,8 @@ void set_sound_volume(volume vol)
 	if(mixer) {
 		vol = clamp_gain(vol);
 
-		// Bell, timer and UI have separate tracks which we can't set up from this
-		for(channel& c : positional_channels) {
-			MIX_SetTrackGain(c, vol);
-		}
-
-		for(channel& c : SFX_channels) {
-			MIX_SetTrackGain(c, vol);
-		}
+		MIX_SetTagGain(mixer, sound_tracks::sound_source, vol);
+		MIX_SetTagGain(mixer, sound_tracks::sound_fx, vol);
 	}
 }
 
@@ -1024,19 +1018,15 @@ void set_bell_volume(volume vol)
 	if(mixer) {
 		vol = clamp_gain(vol);
 
-		MIX_SetTrackGain(sound::bell_channels[0], vol);
-		MIX_SetTrackGain(sound::timer_channels[0], vol);
+		MIX_SetTagGain(mixer, sound_tracks::sound_bell, vol);
+		MIX_SetTagGain(mixer, sound_tracks::sound_timer, vol);
 	}
 }
 
 void set_UI_volume(volume vol)
 {
 	if(mixer) {
-		vol = clamp_gain(vol);
-
-		for(channel& c : UI_channels) {
-			MIX_SetTrackGain(c, vol);
-		}
+		MIX_SetTagGain(mixer, sound_tracks::sound_ui, clamp_gain(vol));
 	}
 }
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -409,14 +409,9 @@ bool init_sound()
 void close_sound()
 {
 	if(mixer) {
-		stop_bell();
-		stop_UI_sound();
-		stop_sound();
-		stop_music();
-	}
+		MIX_StopAllTracks(mixer, 0);
+		channel_pool = {};
 
-	channel_pool = {};
-	if(mixer) {
 		MIX_DestroyMixer(mixer);
 		mixer = nullptr;
 	}
@@ -426,10 +421,9 @@ void close_sound()
 	// as per documentation, calling MIX_Init multiple times won't result in a failure
 	// MIX_Quit then needs to be called the same number of times to make it de-initialize
 	// so, make sure that always happens
-	for(std::size_t i = 0; i < mixer_init_counter; i++) {
+	while(mixer_init_counter-- > 0) {
 		MIX_Quit();
 	}
-	mixer_init_counter = 0;
 
 	if(SDL_WasInit(SDL_INIT_AUDIO) != 0) {
 		SDL_QuitSubSystem(SDL_INIT_AUDIO);

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -421,6 +421,8 @@ void close_sound()
 		mixer = nullptr;
 	}
 
+	flush_cache();
+
 	// as per documentation, calling MIX_Init multiple times won't result in a failure
 	// MIX_Quit then needs to be called the same number of times to make it de-initialize
 	// so, make sure that always happens

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -82,12 +82,11 @@ std::vector<std::string> music_cache_insertion_order;
 std::map<std::string, std::shared_ptr<MIX_Audio>> sound_cache;
 std::vector<std::string> sound_cache_insertion_order;
 
-MIX_Mixer* mixer;
+MIX_Mixer* mixer = nullptr;
 std::size_t mixer_init_counter = 0;
 
 using namespace std::chrono_literals;
 
-bool mix_ok = false;
 utils::optional<std::chrono::steady_clock::time_point> music_start_time;
 utils::rate_counter music_refresh_rate{20};
 bool want_new_music = false;
@@ -328,9 +327,9 @@ std::vector<std::string> enumerate_drivers()
 
 driver_status driver_status::query()
 {
-	driver_status res{mix_ok, 0, SDL_AUDIO_UNKNOWN, 0, 0};
+	driver_status res{mixer != nullptr, 0, SDL_AUDIO_UNKNOWN, 0, 0};
 
-	if(mix_ok) {
+	if(mixer) {
 		SDL_AudioSpec spec;
 		if(MIX_GetMixerFormat(mixer, &spec)) {
 			res.chunk_size = prefs::get().sound_buffer_size();
@@ -360,19 +359,16 @@ bool init_sound()
 		return false;
 	}
 
-	if(!mix_ok) {
+	if(!mixer) {
 		SDL_AudioSpec spec;
 		spec.freq = prefs::get().sample_rate();
 		spec.format = SDL_AUDIO_S16;
 		spec.channels = 2;
 		mixer = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec);
 		if(!mixer) {
-			mix_ok = false;
 			ERR_AUDIO << "Could not initialize audio: " << SDL_GetError();
 			return false;
 		}
-
-		mix_ok = true;
 
 		for(channel& c : music_channels) {
 			c.allocate_channel(mixer, sound_tracks::music);
@@ -412,17 +408,17 @@ bool init_sound()
 
 void close_sound()
 {
-	if(mix_ok) {
+	if(mixer) {
 		stop_bell();
 		stop_UI_sound();
 		stop_sound();
 		stop_music();
-		mix_ok = false;
 	}
 
 	channel_pool = {};
 	if(mixer) {
 		MIX_DestroyMixer(mixer);
+		mixer = nullptr;
 	}
 
 	// as per documentation, calling MIX_Init multiple times won't result in a failure
@@ -471,14 +467,14 @@ void reset_sound()
 
 void stop_music()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_StopTag(mixer, sound_tracks::music, 500);
 	}
 }
 
 void stop_sound()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_StopTag(mixer, sound_tracks::sound_source, 0);
 		MIX_StopTag(mixer, sound_tracks::sound_fx, 0);
 	}
@@ -489,7 +485,7 @@ void stop_sound()
  */
 void stop_bell()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_StopTag(mixer, sound_tracks::sound_bell, 0);
 		MIX_StopTag(mixer, sound_tracks::sound_timer, 0);
 	}
@@ -497,21 +493,21 @@ void stop_bell()
 
 void stop_UI_sound()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_StopTag(mixer, sound_tracks::sound_ui, 0);
 	}
 }
 
 void restart_music()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_ResumeTag(mixer, sound_tracks::music);
 	}
 }
 
 void restart_sound()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_ResumeTag(mixer, sound_tracks::sound_source);
 		MIX_ResumeTag(mixer, sound_tracks::sound_fx);
 	}
@@ -519,7 +515,7 @@ void restart_sound()
 
 void restart_bell()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_ResumeTag(mixer, sound_tracks::sound_bell);
 		MIX_ResumeTag(mixer, sound_tracks::sound_timer);
 	}
@@ -527,7 +523,7 @@ void restart_bell()
 
 void restart_UI_sound()
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_ResumeTag(mixer, sound_tracks::sound_ui);
 	}
 }
@@ -579,7 +575,7 @@ void play_new_music()
 	music_start_time.reset(); // reset status: no start time
 	want_new_music = true;
 
-	if(!prefs::get().music_on() || !mix_ok || !current_track) {
+	if(!prefs::get().music_on() || !mixer || !current_track) {
 		return;
 	}
 
@@ -868,7 +864,7 @@ void play_sound_internal(const std::string& files,
 		const std::chrono::milliseconds& loop_ticks = 0ms,
 		const std::chrono::milliseconds& fadein_ticks = 0ms)
 {
-	if(files.empty() || !mix_ok) {
+	if(files.empty() || !mixer) {
 		return;
 	}
 
@@ -1013,7 +1009,7 @@ void play_UI_sound(const std::string& files)
 
 volume get_music_volume()
 {
-	if(mix_ok) {
+	if(mixer) {
 		return volume{MIX_GetTrackGain(sound::music_channels[0])};
 	}
 
@@ -1022,14 +1018,14 @@ volume get_music_volume()
 
 void set_music_volume(volume vol)
 {
-	if(mix_ok) {
+	if(mixer) {
 		MIX_SetTrackGain(sound::music_channels[0], clamp_gain(vol));
 	}
 }
 
 volume get_sound_volume()
 {
-	if(mix_ok) {
+	if(mixer) {
 		// Since set_sound_volume sets all main tracks to the same, just return the volume of any main track
 		return volume{MIX_GetTrackGain(sound::positional_channels[0])};
 	}
@@ -1039,7 +1035,7 @@ volume get_sound_volume()
 
 void set_sound_volume(volume vol)
 {
-	if(mix_ok) {
+	if(mixer) {
 		vol = clamp_gain(vol);
 
 		// Bell, timer and UI have separate tracks which we can't set up from this
@@ -1058,7 +1054,7 @@ void set_sound_volume(volume vol)
  */
 void set_bell_volume(volume vol)
 {
-	if(mix_ok) {
+	if(mixer) {
 		vol = clamp_gain(vol);
 
 		MIX_SetTrackGain(sound::bell_channels[0], vol);
@@ -1068,7 +1064,7 @@ void set_bell_volume(volume vol)
 
 void set_UI_volume(volume vol)
 {
-	if(mix_ok) {
+	if(mixer) {
 		vol = clamp_gain(vol);
 
 		for(channel& c : UI_channels) {

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -327,12 +327,11 @@ std::vector<std::string> enumerate_drivers()
 
 driver_status driver_status::query()
 {
-	driver_status res{mixer != nullptr, 0, SDL_AUDIO_UNKNOWN, 0, 0};
+	driver_status res{mixer != nullptr, 0, SDL_AUDIO_UNKNOWN, 0};
 
 	if(mixer) {
 		SDL_AudioSpec spec;
 		if(MIX_GetMixerFormat(mixer, &spec)) {
-			res.chunk_size = prefs::get().sound_buffer_size();
 			res.frequency = spec.freq;
 			res.format = spec.format;
 			res.channels = spec.channels;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -327,18 +327,19 @@ std::vector<std::string> enumerate_drivers()
 
 driver_status driver_status::query()
 {
-	driver_status res{mixer != nullptr, 0, SDL_AUDIO_UNKNOWN, 0};
-
 	if(mixer) {
 		SDL_AudioSpec spec;
 		if(MIX_GetMixerFormat(mixer, &spec)) {
-			res.frequency = spec.freq;
-			res.format = spec.format;
-			res.channels = spec.channels;
+			return {
+				true,
+				spec.freq,
+				spec.format,
+				spec.channels
+			};
 		}
 	}
 
-	return res;
+	return {};
 }
 
 bool init_sound()

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -472,9 +472,7 @@ void reset_sound()
 void stop_music()
 {
 	if(mix_ok) {
-		for(channel& c : music_channels) {
-			MIX_StopTrack(c, MIX_TrackMSToFrames(c, 500));
-		}
+		MIX_StopTag(mixer, sound_tracks::music, 500);
 	}
 }
 
@@ -501,6 +499,36 @@ void stop_UI_sound()
 {
 	if(mix_ok) {
 		MIX_StopTag(mixer, sound_tracks::sound_ui, 0);
+	}
+}
+
+void restart_music()
+{
+	if(mix_ok) {
+		MIX_ResumeTag(mixer, sound_tracks::music);
+	}
+}
+
+void restart_sound()
+{
+	if(mix_ok) {
+		MIX_ResumeTag(mixer, sound_tracks::sound_source);
+		MIX_ResumeTag(mixer, sound_tracks::sound_fx);
+	}
+}
+
+void restart_bell()
+{
+	if(mix_ok) {
+		MIX_ResumeTag(mixer, sound_tracks::sound_bell);
+		MIX_ResumeTag(mixer, sound_tracks::sound_timer);
+	}
+}
+
+void restart_UI_sound()
+{
+	if(mix_ok) {
+		MIX_ResumeTag(mixer, sound_tracks::sound_ui);
 	}
 }
 

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -37,7 +37,6 @@ struct driver_status
 	int frequency;
 	SDL_AudioFormat format;
 	int channels;
-	int chunk_size;
 
 	static driver_status query();
 };

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -33,10 +33,10 @@ std::vector<std::string> enumerate_drivers();
 
 struct driver_status
 {
-	bool initialized;
-	int frequency;
-	SDL_AudioFormat format;
-	int channels;
+	bool initialized{false};
+	int frequency{0};
+	SDL_AudioFormat format{SDL_AUDIO_UNKNOWN};
+	int channels{0};
 
 	static driver_status query();
 };

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -43,7 +43,6 @@ struct driver_status
 
 bool init_sound();
 void close_sound();
-void reset_sound();
 
 void stop_music();
 void stop_sound();

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -51,6 +51,11 @@ void stop_sound();
 void stop_UI_sound();
 void stop_bell();
 
+void restart_music();
+void restart_sound();
+void restart_bell();
+void restart_UI_sound();
+
 // Read config entry, alter track list accordingly.
 void play_music_config(const config &music_node, bool allow_interrupt_current_track = false, int i = -1);
 // Act on any track list changes from above.


### PR DESCRIPTION
We don't need to completely disable the entire audio subsystem just because all sound is turned off in preferences. This change ensures that the track/channel pool, as well as the mixer device, are initialized once and remain valid for the lifetime of the program.

This change also seems to fix several non-deterministic crashes that could arise when toggling sound on and off quickly.