### PR TITLE
Allow GUI theme application wherever Preferences are accessible

### DIFF
--- a/src/chat_command_handler.cpp
+++ b/src/chat_command_handler.cpp
@@ -19,6 +19,9 @@
 #include "game_version.hpp"
 #include "gui/dialogs/multiplayer/mp_report.hpp"
 #include "gui/dialogs/preferences_dialog.hpp"
+#include "gui/dialogs/title_screen.hpp"
+#include "gui/gui.hpp"
+#include "gui/widgets/chatbox.hpp"
 #include "map_command_handler.hpp"
 #include "preferences/preferences.hpp"
 
@@ -119,7 +122,18 @@ void chat_command_handler::do_remove()
 
 void chat_command_handler::do_display()
 {
-	gui2::dialogs::preferences_dialog::display(pref_constants::VIEW_FRIENDS);
+	gui2::dialogs::preferences_dialog pref_dlg(pref_constants::VIEW_FRIENDS);
+	pref_dlg.show();
+	if(pref_dlg.get_retval() == gui2::dialogs::title_screen::RELOAD_UI) {
+		// Only the MP lobby chat needs special handling (closing and rebuilding
+		// its still-open owning window); everywhere else, applying the new theme
+		// in place is enough since there's no persistent GUI2 window to redraw.
+		if(auto* chat_box = dynamic_cast<gui2::chatbox*>(&chat_handler_)) {
+			chat_box->handle_gui2_theme_reload();
+		} else {
+			gui2::switch_theme(prefs::get().gui2_theme());
+		}
+	}
 }
 
 void chat_command_handler::do_version() {

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -36,8 +36,10 @@
 #include "gui/dialogs/file_dialog.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/preferences_dialog.hpp"
+#include "gui/dialogs/title_screen.hpp"
 #include "gui/dialogs/units_dialog.hpp"
 #include "gui/dialogs/transient_message.hpp"
+#include "gui/gui.hpp"
 
 #include "preferences/preferences.hpp"
 #include "resources.hpp"
@@ -1302,7 +1304,12 @@ void editor_controller::show_menu(const std::vector<config>& items_arg, const po
 void editor_controller::preferences()
 {
 	gui_->clear_help_string();
-	gui2::dialogs::preferences_dialog::display();
+
+	gui2::dialogs::preferences_dialog pref_dlg;
+	pref_dlg.show();
+	if(pref_dlg.get_retval() == gui2::dialogs::title_screen::RELOAD_UI) {
+		gui2::switch_theme(prefs::get().gui2_theme());
+	}
 
 	gui_->queue_rerender();
 }

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -26,6 +26,7 @@
 #include "gettext.hpp"
 #include "gui/dialogs/loading_screen.hpp"
 #include "gui/dialogs/message.hpp"
+#include "gui/gui.hpp"
 #include "gui/dialogs/multiplayer/lobby.hpp"
 #include "gui/dialogs/multiplayer/mp_create_game.hpp"
 #include "gui/dialogs/multiplayer/mp_join_game.hpp"
@@ -575,6 +576,10 @@ bool mp_manager::enter_lobby_mode()
 			case gui2::dialogs::mp_lobby::RELOAD_CONFIG:
 				// Let this function's caller reload the config and re-call.
 				return false;
+			case gui2::dialogs::mp_lobby::RELOAD_UI:
+				// Apply the new GUI2 theme, then rebuild the lobby window.
+				gui2::switch_theme(prefs::get().gui2_theme());
+				break;
 			default:
 				// Needed to handle the Quit signal and exit the loop
 				return true;

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -22,6 +22,7 @@
 #include "gui/dialogs/multiplayer/mp_join_game_password_prompt.hpp"
 #include "gui/dialogs/multiplayer/player_info.hpp"
 #include "gui/dialogs/preferences_dialog.hpp"
+#include "gui/dialogs/title_screen.hpp"
 
 #include "gui/core/timer.hpp"
 #include "gui/widgets/button.hpp"
@@ -1039,7 +1040,12 @@ void mp_lobby::refresh_lobby()
 
 void mp_lobby::show_preferences_button_callback()
 {
-	gui2::dialogs::preferences_dialog::display();
+	gui2::dialogs::preferences_dialog pref_dlg;
+	pref_dlg.show();
+	if(pref_dlg.get_retval() == gui2::dialogs::title_screen::RELOAD_UI) {
+		set_retval(RELOAD_UI);
+		return;
+	}
 
 	refresh_lobby();
 }

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -596,6 +596,7 @@ void mp_lobby::pre_show()
 	keyboard_capture(chatbox_);
 
 	chatbox_->set_active_window_changed_callback([this]() { player_list_dirty_ = true; });
+	chatbox_->set_theme_reload_callback([this]() { set_retval(RELOAD_UI); });
 	chatbox_->load_log(default_chat_log, true);
 
 	find_widget<button>("create").set_retval(CREATE);

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -63,7 +63,8 @@ public:
 		OBSERVE,
 		CREATE, /** player clicked the Create button */
 		RELOAD_CONFIG,
-		CREATE_PRESET
+		CREATE_PRESET,
+		RELOAD_UI /** GUI2 theme was changed via Preferences and needs to be applied */
 	};
 
 	const config queue_game_server_preset() const { return queue_game_server_preset_; }

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -56,9 +56,6 @@ class preferences_dialog : public modal_dialog
 public:
 	preferences_dialog(const pref_constants::PREFERENCE_VIEW initial_view = pref_constants::VIEW_DEFAULT);
 
-	/** The display function -- see @ref modal_dialog for more information. */
-	DEFINE_SIMPLE_DISPLAY_WRAPPER(preferences_dialog)
-
 private:
 	virtual const std::string& window_id() const override;
 

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -30,6 +30,7 @@
 #include "formula/string_utils.hpp"
 #include "game_initialization/multiplayer.hpp"
 #include "gettext.hpp"
+#include "gui/gui.hpp"
 #include "log.hpp"
 #include "preferences/preferences.hpp"
 #include "scripting/plugins/manager.hpp"
@@ -268,6 +269,15 @@ void chatbox::user_relation_changed(const std::string& /*name*/)
 {
 	if(active_window_changed_callback_) {
 		active_window_changed_callback_();
+	}
+}
+
+void chatbox::handle_gui2_theme_reload()
+{
+	if(theme_reload_callback_) {
+		theme_reload_callback_();
+	} else {
+		gui2::switch_theme(prefs::get().gui2_theme());
 	}
 }
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -83,6 +83,17 @@ public:
 		active_window_changed_callback_ = f;
 	}
 
+	void set_theme_reload_callback(const std::function<void(void)>& f)
+	{
+		theme_reload_callback_ = f;
+	}
+
+	/**
+	 * Called by chat_command_handler::do_display() after Preferences opened
+	 * via a chat command (eg /friends) closes having changed the GUI2 theme.
+	 */
+	void handle_gui2_theme_reload();
+
 	void load_log(std::map<std::string, chatroom_log>& log, bool show_lobby);
 
 protected:
@@ -132,6 +143,8 @@ private:
 	std::size_t active_window_;
 
 	std::function<void(void)> active_window_changed_callback_;
+
+	std::function<void(void)> theme_reload_callback_;
 
 	std::map<std::string, chatroom_log>* log_;
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -50,8 +50,10 @@
 #include "gui/dialogs/simple_item_selector.hpp"
 #include "gui/dialogs/statistics_dialog.hpp"
 #include "gui/dialogs/terrain_layers.hpp"
+#include "gui/dialogs/title_screen.hpp"
 #include "gui/dialogs/transient_message.hpp"
 #include "gui/dialogs/units_dialog.hpp"
+#include "gui/gui.hpp"
 #include "gui/widgets/retval.hpp"
 #include "help/help.hpp"
 #include "log.hpp"
@@ -204,8 +206,12 @@ void menu_handler::save_map()
 
 void menu_handler::preferences()
 {
-	// Causes MSVC ambiguity
-	gui2::dialogs::preferences_dialog::display();
+	gui2::dialogs::preferences_dialog pref_dlg;
+	pref_dlg.show();
+	if(pref_dlg.get_retval() == gui2::dialogs::title_screen::RELOAD_UI) {
+		gui2::switch_theme(prefs::get().gui2_theme());
+	}
+
 	// Needed after changing fullscreen/windowed mode or display resolution
 	gui_->queue_rerender();
 }


### PR DESCRIPTION
Resolves #11458.

I admit I'm not too comfortable with the GUI code, but the changes the LLM made make sense to me - the Lobby needs to be rebuilt after changing the theme selection.

The LLM claimed Preferences could be accessed through a chat command, but I don't know how to do that. So there may be one other place that needs updating, but I thought chat was part of the normal game interface anyway.