### PR TITLE
prevent boat in PaP-desolation from travelling over land (#11461)

### DIFF
--- a/data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/scenarios/03_Desolation.cfg
@@ -141,8 +141,8 @@
         #############################
         # FISHING BOATS
         #############################
-        {NAMED_UNIT 3 "Fishing Boat" 40 3 skiff1 _"Great White" facing=sw} {HITPOINTS 61}
-        {NAMED_UNIT 3 "Fishing Boat"  6 7 skiff2 _"The Garard"  facing=se} {HITPOINTS 37}
+        {NAMED_UNIT 3 "Fishing Boat Desolation" 40 3 skiff1 _"Great White" facing=sw} {HITPOINTS 61}
+        {NAMED_UNIT 3 "Fishing Boat Desolation"  6 7 skiff2 _"The Garard"  facing=se} {HITPOINTS 37}
         {GIVE_OBJECT_TO id=skiff1 ({EFFECT movement set=0})}
         {GIVE_OBJECT_TO id=skiff2 ({EFFECT movement set=0})}
 

--- a/data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg
+++ b/data/campaigns/Of_Pearls_and_Pirates/units/Variations.cfg
@@ -14,3 +14,26 @@
         __remove=yes
     [/attack]
 [/unit_type]
+
+# special case for Desolation scenario, make it able to path as necessary (combined hill/water tiles are in the way)
+[unit_type]
+    [base_unit]
+        id=Skiff
+    [/base_unit]
+    id=Fishing Boat Desolation
+    name=_"Fishing Boat"
+    [movement_costs]
+        deep_water=1
+        shallow_water=2
+        swamp_water=2
+        reef=3
+        village=1
+        hills=3
+    [/movement_costs]
+    [attack]
+        __remove=yes
+    [/attack]
+    [attack]
+        __remove=yes
+    [/attack]
+[/unit_type]


### PR DESCRIPTION
This is my attempt at fixing #11461. I'm not familiar with the codebase, so this may be an incorrect approach.

The problem appear to be that there are combined hills/shallow water tiles on the expected path, and apparently pathfinding requires a unit to be able to pass all the basic terrain types of a combined tile. This makes the boat pass also hills for that specific scenario.
