### PR TITLE
Server: add Tournament Manager authorization and metadata

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -11,7 +11,7 @@ EnsureSConsVersion(0,98,3)
 
 lua_ver = "5.4"
 
-import os, sys, shutil, re, subprocess
+import os, sys, shutil, re, shlex, subprocess
 from glob import glob
 from subprocess import Popen, PIPE, call, check_output
 from os import access, F_OK
@@ -689,9 +689,12 @@ for env in [test_env, client_env, env]:
 if not env['static_test']:
     test_env.Append(CPPDEFINES = "BOOST_TEST_DYN_LINK")
 
-if env['autorevision']:
+autorevision = File("#/utils/autorevision.sh").srcnode().abspath
+if env['autorevision'] and os.path.isfile(autorevision):
     try:
-        if call(env.subst("utils/autorevision.sh -t h > $build_dir/revision.h"), shell=True) == 0:
+        revision_header = env.subst("$build_dir/revision.h")
+        command = "{} -t h > {}".format(shlex.quote(autorevision), shlex.quote(revision_header))
+        if call(command, shell=True) == 0:
             env["have_autorevision"] = True
             if not call(env.subst("cmp -s $build_dir/revision.h src/revision.h"), shell=True) == 0:
                 call(env.subst("cp $build_dir/revision.h src/revision.h"), shell=True)

--- a/doc/man/es/wesnothd.6
+++ b/doc/man/es/wesnothd.6
@@ -228,6 +228,25 @@ El nombre del usuario con el cual iniciar sesión en la base de datos
 \fBdb_password\fP
 La contraseña de este usuario
 .TP 
+\fBtournament_db_host\fP
+El nombre del host del servidor de base de datos de Tournament Manager.
+.TP
+\fBtournament_db_user\fP
+El usuario con el que wesnothd se conecta a la base de datos de Tournament
+Manager.
+.TP
+\fBtournament_db_password\fP
+La contraseña del usuario de la base de datos de Tournament Manager.
+.TP
+\fBtournament_db_name\fP
+El nombre de la base de datos de Tournament Manager. Las consultas
+competitivas se ejecutan en este esquema y deben usar nombres de tabla sin
+prefijo de base de datos.
+.TP
+\fBtournament_db_port\fP
+El puerto TCP del servidor de base de datos de Tournament Manager. El valor
+predeterminado es 3306.
+.TP
 \fBdb_users_table\fP
 El nombre de la tabla en la que sus foros phpBB almacenan los datos de sus
 usuarios. Generalmente éste será <table\-prefix>_users (por ej.:
@@ -258,6 +277,25 @@ grupos de usuarios. Generalmente éste será <table\-prefix>_user_group
 La consulta SQL para encontrar torneos que se anunciarán al iniciar
 sesión. Debe devolver el torneo \fBtitle\fP, \fBstatus\fP y \fBurl\fP.
 .TP 
+\fBdb_player_tournaments_query\fP
+Consulta SQL parametrizada para las partidas de torneo pendientes en las que
+el jugador conectado tiene una entrada activa. Recibe el apodo como primer
+parámetro y debe devolver columnas llamadas \fBID\fP (identificador del torneo),
+\fBNAME\fP (nombre del torneo), \fBGAME_ID\fP (identificador de la partida de
+torneo), \fBPHASE_NAME\fP, \fBGROUP_NAME\fP, \fBROUND_NUMBER\fP,
+\fBGAME_NUMBER\fP y \fBMODE\fP (modo del torneo). Los nombres de fase y
+grupo se muestran literalmente; el cliente solo traduce las etiquetas fijas.
+.TP
+\fBdb_ranked_user_query\fP
+Consulta SQL parametrizada que recibe un apodo y devuelve \fB1\fP si el
+usuario puede jugar partidas clasificatorias, o \fB0\fP en caso contrario.
+.TP
+\fBdb_tournament_join_query\fP
+Consulta SQL parametrizada para autorizar unirse a partidas de torneo.
+Recibe el identificador del torneo, el identificador de la partida de torneo y
+dos veces el apodo que se une; debe devolver \fB1\fP solo si ese jugador
+pertenece a una de las entradas activas de esa partida de torneo pendiente.
+.TP
 \fBdb_connection_history_table\fP
 El nombre de la tabla en la que almacenar los tiempos de inicio/cierre de
 sesión. También se utiliza para hacer coincidir las direcciones IP con los
@@ -314,4 +352,3 @@ PROPÓSITO PARTICULAR.
 .SH "VÉASE TAMBIÉN"
 .
 \fBwesnoth\fP(6)
-

--- a/doc/man/wesnothd.6
+++ b/doc/man/wesnothd.6
@@ -228,6 +228,22 @@ The name of the user under which to log into the database
 .B db_password
 This user's password
 .TP
+.B tournament_db_host
+The hostname of the database server hosting the Tournament Manager database.
+.TP
+.B tournament_db_user
+The user under which wesnothd connects to the Tournament Manager database.
+.TP
+.B tournament_db_password
+The password for the Tournament Manager database user.
+.TP
+.B tournament_db_name
+The name of the Tournament Manager database. Competitive SQL queries are
+executed in this schema and should use unqualified table names.
+.TP
+.B tournament_db_port
+The TCP port of the Tournament Manager database server. Defaults to 3306.
+.TP
 .B db_users_table
 The name of the table in which your phpbb forum saves its user data. Most likely this will be <table-prefix>_users (e.g. phpbb3_users).
 .TP
@@ -248,6 +264,15 @@ The name of the table in which your phpbb forum saves its user group data. Most 
 .TP
 .B db_tournament_query
 The SQL query to find tournaments to announce on login. Should return tournament \fBtitle\fR, \fBstatus\fR and \fBurl\fR.
+.TP
+.B db_player_tournaments_query
+Parameterized SQL query for pending tournament games in which the logged-in player has an active entry. The query receives the nickname as its first parameter and must return columns named \fBID\fR (tournament ID), \fBNAME\fR (tournament name), \fBGAME_ID\fR (tournament-game ID), \fBPHASE_NAME\fR, \fBGROUP_NAME\fR, \fBROUND_NUMBER\fR, \fBGAME_NUMBER\fR, and \fBMODE\fR (the tournament mode). Phase and group names are displayed verbatim; the client localizes only fixed labels.
+.TP
+.B db_ranked_user_query
+Parameterized SQL query receiving a nickname and returning \fB1\fR when ranked access is enabled, otherwise \fB0\fR.
+.TP
+.B db_tournament_join_query
+Parameterized SQL query used to authorize tournament joins. It receives the tournament ID, tournament-game ID, joining nickname, and joining nickname, and must return \fB1\fR only when that player belongs to either active entry of that exact pending tournament game.
 .TP
 .B db_connection_history_table
 The name of the table in which to store login/logout times. Also used for matching IPs to users and vice versa.
@@ -290,4 +315,3 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 .SH SEE ALSO
 .
 .BR wesnoth (6)
-

--- a/projectfiles/CodeBlocks/wesnothd.cbp
+++ b/projectfiles/CodeBlocks/wesnothd.cbp
@@ -136,6 +136,8 @@
 		<Unit filename="../../src/serialization/tokenizer.hpp" />
 		<Unit filename="../../src/serialization/unicode.cpp" />
 		<Unit filename="../../src/serialization/unicode.hpp" />
+		<Unit filename="../../src/server/common/competitive_game_security.cpp" />
+		<Unit filename="../../src/server/common/competitive_game_security.hpp" />
 		<Unit filename="../../src/server/common/dbconn.cpp" />
 		<Unit filename="../../src/server/common/dbconn.hpp" />
 		<Unit filename="../../src/server/common/forum_user_handler.cpp" />

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1C3D48879EAC414AE3DB122E /* combobox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 875E45698F8A8D5B750E7317 /* combobox.cpp */; };
 		262647058B8E718FB1D8264C /* tracked_drawable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 832143969FA807F7E6072A0E /* tracked_drawable.hpp */; };
 		285C4E7A9E891E1DCB215683 /* back_edge_detector.hpp in Headers */ = {isa = PBXBuildFile; fileRef = DA034C90BB2E6C060B0A0B93 /* back_edge_detector.hpp */; };
+		29AB4976BC4895899269E082 /* competitive_game_security.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5E7140518DC5C72BA2D8550F /* competitive_game_security.hpp */; };
 		355942A786D57DD0A6A93E2A /* units_dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CAF74C3AB8D456EA3E756396 /* units_dialog.cpp */; };
 		362245818DDA4C7E4CC8165A /* charconv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CDC443798CB3254283483D0 /* charconv.cpp */; };
 		365D4F89BD511BC074E639D7 /* migrate_version_selection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B3DE4F95AF72C6F6BC37E695 /* migrate_version_selection.hpp */; };
@@ -91,18 +92,6 @@
 		46406DEE230DA7180069492E /* libSDL3.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 464C0367228361B6007D2741 /* libSDL3.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		46406DEF230DA7190069492E /* libvorbis.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 464C0364228361B6007D2741 /* libvorbis.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		46406DF0230DA7190069492E /* libvorbisfile.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 464C0369228361B7007D2741 /* libvorbisfile.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A200001B5C0000100000001 /* libbz2.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C242218EF07B4001FA499 /* libbz2.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A200002B5C0000100000001 /* libexpat.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C242318EF07B4001FA499 /* libexpat.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A200003B5C0000100000001 /* libz.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C243A18EF07B4001FA499 /* libz.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300001B6C0000100000001 /* libbrotlicommon.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300101B6C0000100000001 /* libbrotlicommon.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300002B6C0000100000001 /* libbrotlidec.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300102B6C0000100000001 /* libbrotlidec.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300003B6C0000100000001 /* libicudata.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300103B6C0000100000001 /* libicudata.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300004B6C0000100000001 /* libicui18n.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300104B6C0000100000001 /* libicui18n.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300005B6C0000100000001 /* libicuuc.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300105B6C0000100000001 /* libicuuc.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300006B6C0000100000001 /* libjpeg.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300106B6C0000100000001 /* libjpeg.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300007B6C0000100000001 /* liblzma.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300107B6C0000100000001 /* liblzma.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300008B6C0000100000001 /* libwavpack.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300108B6C0000100000001 /* libwavpack.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A300009B6C0000100000001 /* libzstd.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300109B6C0000100000001 /* libzstd.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		46406DF1230DA73E0069492E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C58BBDF21822A930078D25A /* Security.framework */; platformFilters = (macos, ); };
 		4649B87A202886F000827CFB /* test_irdya_date.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4649B879202886F000827CFB /* test_irdya_date.cpp */; };
 		4649B87B20288CBB00827CFB /* manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECA556251E7B5DA5006E907D /* manager.cpp */; };
@@ -223,13 +212,6 @@
 		468A5BC6258CD8D3004A80EF /* libboost_thread.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 468A5B8E258CD3B4004A80EF /* libboost_thread.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		468A5BCB258CDBE4004A80EF /* libboost_chrono.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 468A5B85258CD3B4004A80EF /* libboost_chrono.dylib */; platformFilters = (macos, ); };
 		468A5BCC258CDBEA004A80EF /* libboost_chrono.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 468A5B85258CD3B4004A80EF /* libboost_chrono.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A100001B4C0000100000001 /* libboost_process.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; platformFilters = (macos, ); };
-		7A100002B4C0000100000001 /* libboost_process.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A10000AB4C0000100000001 /* libboost_process.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; };
-		7A100003B4C0000100000001 /* libboost_container.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100008B4C0000100000001 /* libboost_container.dylib */; platformFilters = (macos, ); };
-		7A100004B4C0000100000001 /* libboost_container.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100008B4C0000100000001 /* libboost_container.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		7A100005B4C0000100000001 /* libboost_date_time.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100009B4C0000100000001 /* libboost_date_time.dylib */; platformFilters = (macos, ); };
-		7A100006B4C0000100000001 /* libboost_date_time.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100009B4C0000100000001 /* libboost_date_time.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		468C1B971F09245F002DF652 /* function_gamestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 468C1B951F09245E002DF652 /* function_gamestate.cpp */; };
 		4690FBC52884726900986A47 /* libboost_atomic.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4690FBC42884726900986A47 /* libboost_atomic.dylib */; platformFilters = (macos, ); };
 		4690FBC62884726900986A47 /* libboost_atomic.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4690FBC42884726900986A47 /* libboost_atomic.dylib */; };
@@ -271,6 +253,7 @@
 		46D60159255AFA7E00E072F0 /* commandline_argv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46D60156255AFA7E00E072F0 /* commandline_argv.cpp */; };
 		46D60162255AFDE100E072F0 /* commandline_argv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46D60156255AFA7E00E072F0 /* commandline_argv.cpp */; };
 		46DE42A486EEA7BD55757690 /* fps_report.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03A840C5A9D9062764009C89 /* fps_report.cpp */; };
+		46E09C242C79D60700B247E2 /* cacert.pem in Copy iOS CA Bundle */ = {isa = PBXBuildFile; fileRef = 46E09C252C79D60700B247E2 /* cacert.pem */; platformFilters = (ios, ); };
 		46E2D98F25022BF5003D99F3 /* lua_widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E2D98B25022BF5003D99F3 /* lua_widget.cpp */; };
 		46E2D99025022BF5003D99F3 /* lua_widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E2D98B25022BF5003D99F3 /* lua_widget.cpp */; };
 		46E2D99125022BF6003D99F3 /* lua_widget_attributes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E2D98D25022BF5003D99F3 /* lua_widget_attributes.cpp */; };
@@ -286,10 +269,8 @@
 		46EB546227DD2FC800D5CDE8 /* libwebp.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 46EB545F27DD2FAD00D5CDE8 /* libwebp.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		46EEFB762087434300E1E75A /* chat_log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46EEFB742087434200E1E75A /* chat_log.cpp */; };
 		46EEFB772087434300E1E75A /* chat_log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46EEFB742087434200E1E75A /* chat_log.cpp */; };
-		46E09C242C79D60700B247E2 /* cacert.pem in Copy iOS CA Bundle */ = {isa = PBXBuildFile; fileRef = 46E09C252C79D60700B247E2 /* cacert.pem */; platformFilters = (ios, ); };
+		46F1280130AF6D4F00B5AC11 /* liblua.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9107AE141DB32862001927B0 /* liblua.a */; platformFilters = (ios, ); };
 		46F302EE220327FE0028938F /* container-migration.plist in Resources */ = {isa = PBXBuildFile; fileRef = 46F302EC220327FD0028938F /* container-migration.plist */; };
-		EB3A53F5AF0D4883A38A9CB9 /* Resources/Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2294281A8FB742D3A49A7FBA /* Resources/Assets.xcassets */; platformFilters = (ios, ); };
-		F57BE6B24F76DB47B2231B2F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EC324240DB23D8921BB0FFE /* LaunchScreen.storyboard */; platformFilters = (ios, ); };
 		46F54C27211DFB7200374A1C /* apple_version.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46F54C26211DFB7200374A1C /* apple_version.mm */; };
 		46F57084205FCE34007031BF /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 469BDB53205C357400DBF748 /* base64.cpp */; };
 		46F57085205FCE48007031BF /* crypt_blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 46BED4D1205060EA00842FA5 /* crypt_blowfish.c */; };
@@ -620,6 +601,10 @@
 		4A1D4916A16C7C6E07D0BAB2 /* spritesheet_generator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 492144E3AE22C0C7A2D5F27C /* spritesheet_generator.cpp */; };
 		4E19429E82899A42A73BBE91 /* choose_addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E644DC98F26C756364EC2C /* choose_addon.cpp */; };
 		4E4A4DBC9F44444A5867EC2B /* migrate_version_selection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7B1444E9B79504502208B82 /* migrate_version_selection.cpp */; };
+		4F8A5D1130B1A10000A1D001 /* libbz2.1.0.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1230B1A10000A1D001 /* libexpat.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1330B1A10000A1D001 /* libiconv.2.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4F8A5D1430B1A10000A1D001 /* libz.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4FD94DA284B825C931FF52C7 /* utils_simd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86A64A4ABB2987095E97AAF4 /* utils_simd.cpp */; };
 		508C40A885166B2E3F4245F4 /* general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84234C54BB84519421FD4136 /* general.cpp */; };
 		52074B55B6C7AC8A1AE8BEA8 /* addon_server_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 39A1469A99EFCB311DF640CB /* addon_server_info.cpp */; };
@@ -672,6 +657,25 @@
 		70284C5A94BEC79FC449D9E5 /* tracked_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5744948AA0B9637D5203B90 /* tracked_drawable.cpp */; };
 		77D94146A5FA29849D1A9BD8 /* multiline_text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0B0F48CE9CF65D9813BE6CDC /* multiline_text.cpp */; };
 		7A0347D48BDB52B1430D9E79 /* migrate_version_selection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B3DE4F95AF72C6F6BC37E695 /* migrate_version_selection.hpp */; };
+		7A100001B4C0000100000001 /* libboost_process.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; platformFilters = (macos, ); };
+		7A100002B4C0000100000001 /* libboost_process.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A100003B4C0000100000001 /* libboost_container.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100008B4C0000100000001 /* libboost_container.dylib */; platformFilters = (macos, ); };
+		7A100004B4C0000100000001 /* libboost_container.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100008B4C0000100000001 /* libboost_container.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A100005B4C0000100000001 /* libboost_date_time.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100009B4C0000100000001 /* libboost_date_time.dylib */; platformFilters = (macos, ); };
+		7A100006B4C0000100000001 /* libboost_date_time.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100009B4C0000100000001 /* libboost_date_time.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A10000AB4C0000100000001 /* libboost_process.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A100007B4C0000100000001 /* libboost_process.dylib */; };
+		7A200001B5C0000100000001 /* libbz2.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C242218EF07B4001FA499 /* libbz2.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A200002B5C0000100000001 /* libexpat.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C242318EF07B4001FA499 /* libexpat.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A200003B5C0000100000001 /* libz.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = EC5C243A18EF07B4001FA499 /* libz.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300001B6C0000100000001 /* libbrotlicommon.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300101B6C0000100000001 /* libbrotlicommon.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300002B6C0000100000001 /* libbrotlidec.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300102B6C0000100000001 /* libbrotlidec.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300003B6C0000100000001 /* libicudata.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300103B6C0000100000001 /* libicudata.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300004B6C0000100000001 /* libicui18n.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300104B6C0000100000001 /* libicui18n.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300005B6C0000100000001 /* libicuuc.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300105B6C0000100000001 /* libicuuc.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300006B6C0000100000001 /* libjpeg.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300106B6C0000100000001 /* libjpeg.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300007B6C0000100000001 /* liblzma.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300107B6C0000100000001 /* liblzma.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300008B6C0000100000001 /* libwavpack.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300108B6C0000100000001 /* libwavpack.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		7A300009B6C0000100000001 /* libzstd.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7A300109B6C0000100000001 /* libzstd.dylib */; platformFilters = (macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		7A7146D7893AA09891352019 /* test_schema_validator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF14AB694764953E2CB3AF7 /* test_schema_validator.cpp */; };
 		7BED48C1A5A814946FADBE6B /* utils_simd.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 81144D69A447D9A8DF6D04CF /* utils_simd.hpp */; };
 		7BFC4DF5BFF8CF75855BA662 /* prompt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67044415B63F5888193BD7A6 /* prompt.cpp */; };
@@ -1305,6 +1309,7 @@
 		C9D14DC39B87182A00397A3D /* choose_addon.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D9A141EAAE90E98B6F6171D6 /* choose_addon.hpp */; };
 		D09A4D40A36568E32D8723F7 /* combobox.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B3534BCB9BB2673B5E513D67 /* combobox.hpp */; };
 		D1254FCA82471825B83AA786 /* multiline_text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0B0F48CE9CF65D9813BE6CDC /* multiline_text.cpp */; };
+		D1D947CE8015F31ED5EDA8F8 /* competitive_game_security.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6CB04F7AB718B470E5BD720A /* competitive_game_security.cpp */; };
 		D2E9440BBCDCE2A75C93F85D /* migrate_version_selection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7B1444E9B79504502208B82 /* migrate_version_selection.cpp */; };
 		D6EC45B189E997A1DB5F6868 /* utils_simd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86A64A4ABB2987095E97AAF4 /* utils_simd.cpp */; };
 		D9E94D2083155213BFA6EDD6 /* preferences.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2CFD4922B64EA6C9F71F71A2 /* preferences.hpp */; };
@@ -1321,6 +1326,7 @@
 		E6CF415F9FD04C35A55FB24D /* scroll_text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 755D4555A1DEA29125E7F338 /* scroll_text.cpp */; };
 		E79249078ACE777D1E219DED /* choose_addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20E644DC98F26C756364EC2C /* choose_addon.cpp */; };
 		E875402885AA34096C34E3B0 /* reachmap_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85514A7D81C52A912FF68AEB /* reachmap_options.cpp */; };
+		EB3A53F5AF0D4883A38A9CB9 /* Resources/Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2294281A8FB742D3A49A7FBA /* Resources/Assets.xcassets */; platformFilters = (ios, ); };
 		EBB44A70837B84A928CB6424 /* edit_pbl_translation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00574699A982AA23F12B39E0 /* edit_pbl_translation.cpp */; };
 		EC0341E11ECF46FE000F2E2B /* config_attribute_value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0341DF1ECF46FE000F2E2B /* config_attribute_value.cpp */; };
 		EC0341E21ECF4712000F2E2B /* config_attribute_value.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0341DF1ECF46FE000F2E2B /* config_attribute_value.cpp */; };
@@ -1400,10 +1406,6 @@
 		EC64D7661A085F120092EF75 /* mt_rng.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC64D7641A085F120092EF75 /* mt_rng.cpp */; };
 		EC64D7671A085F2F0092EF75 /* seed_rng.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC64D75F1A085CE60092EF75 /* seed_rng.cpp */; };
 		EC669C261DFC95AF00172EED /* surface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC669C251DFC95AF00172EED /* surface.cpp */; };
-		4F8A5D1130B1A10000A1D001 /* libbz2.1.0.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4F8A5D1230B1A10000A1D001 /* libexpat.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4F8A5D1330B1A10000A1D001 /* libiconv.2.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4F8A5D1430B1A10000A1D001 /* libz.1.ios.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		EC74C11F197576F500B85A1A /* notifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC74C119197576F500B85A1A /* notifications.cpp */; };
 		EC74C120197576F500B85A1A /* open.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC74C11B197576F500B85A1A /* open.cpp */; };
 		EC8174671FB4284E00A8ED00 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC0680271EA920A300EEE03B /* random.cpp */; };
@@ -1476,13 +1478,13 @@
 		F46C5DCF13A5074C00DD0816 /* commandline_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F46C5DCB13A5074C00DD0816 /* commandline_options.cpp */; };
 		F46C5DD413A5089100DD0816 /* lua_object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F46C5DD313A5089100DD0816 /* lua_object.cpp */; };
 		F480CD1F14034E6D007175D6 /* mapbuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F480CD1D14034E6D007175D6 /* mapbuilder.cpp */; };
-		46F1280130AF6D4F00B5AC11 /* liblua.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9107AE141DB32862001927B0 /* liblua.a */; platformFilters = (ios, ); };
 		F4D2A99614DAED0E00CAFF31 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D2A99514DAED0E00CAFF31 /* CoreFoundation.framework */; platformFilters = (macos, ); };
 		F4D2A9D514DAED4200CAFF31 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D2A99514DAED0E00CAFF31 /* CoreFoundation.framework */; };
 		F4D2DECB14DCA1D000CAFF31 /* client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4D2DECA14DCA1D000CAFF31 /* client.cpp */; };
 		F4D5483E15198D060058C8A7 /* lua_jailbreak_exception.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F419E44413354E620031448A /* lua_jailbreak_exception.cpp */; };
 		F4E4E0B11367241E001C7528 /* suppose_dead.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4E4E0AF1367241E001C7528 /* suppose_dead.cpp */; };
 		F4E4E0B41367244F001C7528 /* image_modifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4E4E0B21367244F001C7528 /* image_modifications.cpp */; };
+		F57BE6B24F76DB47B2231B2F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EC324240DB23D8921BB0FFE /* LaunchScreen.storyboard */; platformFilters = (ios, ); };
 		F6E34C7CBC418F214B43BC39 /* general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84234C54BB84519421FD4136 /* general.cpp */; };
 		F7524948ADF9BC097E6D8DBC /* charconv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A03A423AB502FE015C91F1C9 /* charconv.hpp */; };
 		F8974F919B014C9E7103A6B9 /* markup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5EE4DE4B73C204AC0666900 /* markup.cpp */; };
@@ -1650,6 +1652,7 @@
 		1C58BBDF21822A930078D25A /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		1E364CB2B7C9E22650753C72 /* addon_server_info.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = addon_server_info.hpp; sourceTree = "<group>"; };
 		20E644DC98F26C756364EC2C /* choose_addon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = choose_addon.cpp; sourceTree = "<group>"; };
+		2294281A8FB742D3A49A7FBA /* Resources/Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Resources/Assets.xcassets; sourceTree = "<group>"; };
 		231C4A6BB2F1A717F0D6E2E2 /* reachmap_options.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = reachmap_options.hpp; sourceTree = "<group>"; };
 		26A04033A9545CFE8A226FBD /* test_schema_self_validator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = test_schema_self_validator.cpp; sourceTree = "<group>"; };
 		27764FB68F02032F1C0B6748 /* statistics_record.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = statistics_record.cpp; sourceTree = "<group>"; };
@@ -1700,25 +1703,16 @@
 		46181DD12119F74C00908BC2 /* battery_info.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = battery_info.cpp; sourceTree = "<group>"; };
 		461DC52B241F836200B9DD10 /* lua_color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lua_color.cpp; sourceTree = "<group>"; };
 		461DC52C241F836200B9DD10 /* lua_color.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua_color.hpp; sourceTree = "<group>"; };
-		462311A92D047BF400DAE465 /* libboost_charconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_charconv.dylib"; path = "lib/libboost_charconv.dylib"; sourceTree = "<group>"; };
+		462311A92D047BF400DAE465 /* libboost_charconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_charconv.dylib; path = lib/libboost_charconv.dylib; sourceTree = "<group>"; };
 		4638966F2034180800075E54 /* deprecation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = deprecation.hpp; sourceTree = "<group>"; };
 		463896702034180900075E54 /* deprecation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = deprecation.cpp; sourceTree = "<group>"; };
 		4649B879202886F000827CFB /* test_irdya_date.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_irdya_date.cpp; sourceTree = "<group>"; };
-		464C0362228361B5007D2741 /* libSDL3_image.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL3_image.dylib"; path = "lib/libSDL3_image.dylib"; sourceTree = "<group>"; };
+		464C0362228361B5007D2741 /* libSDL3_image.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSDL3_image.dylib; path = lib/libSDL3_image.dylib; sourceTree = "<group>"; };
 		464C0363228361B6007D2741 /* libogg.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libogg.dylib; path = lib/libogg.dylib; sourceTree = "<group>"; };
 		464C0364228361B6007D2741 /* libvorbis.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbis.dylib; path = lib/libvorbis.dylib; sourceTree = "<group>"; };
-		464C0367228361B6007D2741 /* libSDL3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL3.dylib"; path = "lib/libSDL3.dylib"; sourceTree = "<group>"; };
-		464C0368228361B7007D2741 /* libSDL3_mixer.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL3_mixer.dylib"; path = "lib/libSDL3_mixer.dylib"; sourceTree = "<group>"; };
+		464C0367228361B6007D2741 /* libSDL3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSDL3.dylib; path = lib/libSDL3.dylib; sourceTree = "<group>"; };
+		464C0368228361B7007D2741 /* libSDL3_mixer.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSDL3_mixer.dylib; path = lib/libSDL3_mixer.dylib; sourceTree = "<group>"; };
 		464C0369228361B7007D2741 /* libvorbisfile.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbisfile.dylib; path = lib/libvorbisfile.dylib; sourceTree = "<group>"; };
-		7A300101B6C0000100000001 /* libbrotlicommon.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libbrotlicommon.dylib"; path = "lib/libbrotlicommon.dylib"; sourceTree = "<group>"; };
-		7A300102B6C0000100000001 /* libbrotlidec.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libbrotlidec.dylib"; path = "lib/libbrotlidec.dylib"; sourceTree = "<group>"; };
-		7A300103B6C0000100000001 /* libicudata.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libicudata.dylib"; path = "lib/libicudata.dylib"; sourceTree = "<group>"; };
-		7A300104B6C0000100000001 /* libicui18n.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libicui18n.dylib"; path = "lib/libicui18n.dylib"; sourceTree = "<group>"; };
-		7A300105B6C0000100000001 /* libicuuc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libicuuc.dylib"; path = "lib/libicuuc.dylib"; sourceTree = "<group>"; };
-		7A300106B6C0000100000001 /* libjpeg.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libjpeg.dylib"; path = "lib/libjpeg.dylib"; sourceTree = "<group>"; };
-		7A300107B6C0000100000001 /* liblzma.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "liblzma.dylib"; path = "lib/liblzma.dylib"; sourceTree = "<group>"; };
-		7A300108B6C0000100000001 /* libwavpack.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libwavpack.dylib"; path = "lib/libwavpack.dylib"; sourceTree = "<group>"; };
-		7A300109B6C0000100000001 /* libzstd.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libzstd.dylib"; path = "lib/libzstd.dylib"; sourceTree = "<group>"; };
 		46515C2E2569CE0B00084CE2 /* libssl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libssl.dylib; path = lib/libssl.dylib; sourceTree = "<group>"; };
 		46515C2F2569CE0B00084CE2 /* libcrypto.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcrypto.dylib; path = lib/libcrypto.dylib; sourceTree = "<group>"; };
 		46685C6B219D51870009CFFE /* utf8_exception.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = utf8_exception.hpp; sourceTree = "<group>"; };
@@ -1762,22 +1756,19 @@
 		4685A5F925B4501E006FD3A1 /* match_history.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = match_history.cpp; sourceTree = "<group>"; };
 		4685A5FA25B4501E006FD3A1 /* match_history.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = match_history.hpp; sourceTree = "<group>"; };
 		4685E3702417F9BF00CB1ED8 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../../data; sourceTree = "<group>"; };
-		468A5B85258CD3B4004A80EF /* libboost_chrono.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_chrono.dylib"; path = "lib/libboost_chrono.dylib"; sourceTree = "<group>"; };
-		468A5B86258CD3B4004A80EF /* libboost_context.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_context.dylib"; path = "lib/libboost_context.dylib"; sourceTree = "<group>"; };
-		468A5B88258CD3B4004A80EF /* libboost_unit_test_framework.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_unit_test_framework.dylib"; path = "lib/libboost_unit_test_framework.dylib"; sourceTree = "<group>"; };
-		468A5B89258CD3B4004A80EF /* libboost_iostreams.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_iostreams.dylib"; path = "lib/libboost_iostreams.dylib"; sourceTree = "<group>"; };
-		468A5B8C258CD3B4004A80EF /* libboost_filesystem.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_filesystem.dylib"; path = "lib/libboost_filesystem.dylib"; sourceTree = "<group>"; };
-		468A5B8D258CD3B4004A80EF /* libboost_coroutine.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_coroutine.dylib"; path = "lib/libboost_coroutine.dylib"; sourceTree = "<group>"; };
-		468A5B8E258CD3B4004A80EF /* libboost_thread.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_thread.dylib"; path = "lib/libboost_thread.dylib"; sourceTree = "<group>"; };
-		468A5B8F258CD3B4004A80EF /* libboost_program_options.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_program_options.dylib"; path = "lib/libboost_program_options.dylib"; sourceTree = "<group>"; };
-		468A5B91258CD3B4004A80EF /* libboost_locale.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_locale.dylib"; path = "lib/libboost_locale.dylib"; sourceTree = "<group>"; };
-		468A5B92258CD3B4004A80EF /* libboost_random.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_random.dylib"; path = "lib/libboost_random.dylib"; sourceTree = "<group>"; };
-		7A100007B4C0000100000001 /* libboost_process.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_process.dylib"; path = "lib/libboost_process.dylib"; sourceTree = "<group>"; };
-		7A100008B4C0000100000001 /* libboost_container.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_container.dylib"; path = "lib/libboost_container.dylib"; sourceTree = "<group>"; };
-		7A100009B4C0000100000001 /* libboost_date_time.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_date_time.dylib"; path = "lib/libboost_date_time.dylib"; sourceTree = "<group>"; };
+		468A5B85258CD3B4004A80EF /* libboost_chrono.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_chrono.dylib; path = lib/libboost_chrono.dylib; sourceTree = "<group>"; };
+		468A5B86258CD3B4004A80EF /* libboost_context.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_context.dylib; path = lib/libboost_context.dylib; sourceTree = "<group>"; };
+		468A5B88258CD3B4004A80EF /* libboost_unit_test_framework.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_unit_test_framework.dylib; path = lib/libboost_unit_test_framework.dylib; sourceTree = "<group>"; };
+		468A5B89258CD3B4004A80EF /* libboost_iostreams.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_iostreams.dylib; path = lib/libboost_iostreams.dylib; sourceTree = "<group>"; };
+		468A5B8C258CD3B4004A80EF /* libboost_filesystem.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_filesystem.dylib; path = lib/libboost_filesystem.dylib; sourceTree = "<group>"; };
+		468A5B8D258CD3B4004A80EF /* libboost_coroutine.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_coroutine.dylib; path = lib/libboost_coroutine.dylib; sourceTree = "<group>"; };
+		468A5B8E258CD3B4004A80EF /* libboost_thread.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_thread.dylib; path = lib/libboost_thread.dylib; sourceTree = "<group>"; };
+		468A5B8F258CD3B4004A80EF /* libboost_program_options.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_program_options.dylib; path = lib/libboost_program_options.dylib; sourceTree = "<group>"; };
+		468A5B91258CD3B4004A80EF /* libboost_locale.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_locale.dylib; path = lib/libboost_locale.dylib; sourceTree = "<group>"; };
+		468A5B92258CD3B4004A80EF /* libboost_random.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_random.dylib; path = lib/libboost_random.dylib; sourceTree = "<group>"; };
 		468C1B951F09245E002DF652 /* function_gamestate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = function_gamestate.cpp; sourceTree = "<group>"; };
 		468C1B961F09245E002DF652 /* function_gamestate.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = function_gamestate.hpp; sourceTree = "<group>"; };
-		4690FBC42884726900986A47 /* libboost_atomic.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libboost_atomic.dylib"; path = "lib/libboost_atomic.dylib"; sourceTree = "<group>"; };
+		4690FBC42884726900986A47 /* libboost_atomic.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_atomic.dylib; path = lib/libboost_atomic.dylib; sourceTree = "<group>"; };
 		469853CD24D3560800B0E93B /* server_info_dialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = server_info_dialog.cpp; sourceTree = "<group>"; };
 		469853CE24D3560800B0E93B /* server_info_dialog.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = server_info_dialog.hpp; sourceTree = "<group>"; };
 		469BDB53205C357400DBF748 /* base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = base64.cpp; sourceTree = "<group>"; };
@@ -1798,6 +1789,8 @@
 		46BED4D1205060EA00842FA5 /* crypt_blowfish.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypt_blowfish.c; sourceTree = "<group>"; };
 		46BFFC77258256C700643800 /* license_prompt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = license_prompt.cpp; sourceTree = "<group>"; };
 		46BFFC78258256C700643800 /* license_prompt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = license_prompt.hpp; sourceTree = "<group>"; };
+		46C0FFEE0000000000000001 /* wesnothd-mas.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = "wesnothd-mas.entitlements"; path = "Resources/wesnothd-mas.entitlements"; sourceTree = "<group>"; };
+		46C0FFEE0000000000000002 /* wesnothd-nosandbox.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = "wesnothd-nosandbox.entitlements"; path = "Resources/wesnothd-nosandbox.entitlements"; sourceTree = "<group>"; };
 		46CAC4CB29BD07C0004763BE /* libcurl.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libcurl.tbd; path = usr/lib/libcurl.tbd; sourceTree = SDKROOT; };
 		46D6014A255AFA5F00E072F0 /* auth.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = auth.hpp; sourceTree = "<group>"; };
 		46D6014B255AFA5F00E072F0 /* options.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = options.hpp; sourceTree = "<group>"; };
@@ -1807,6 +1800,7 @@
 		46D60157255AFA7E00E072F0 /* commandline_argv.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = commandline_argv.hpp; sourceTree = "<group>"; };
 		46DF5BCB1F46173700BE6D24 /* irdya_datetime.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = irdya_datetime.hpp; sourceTree = "<group>"; };
 		46DF5BCC1F46173700BE6D24 /* irdya_datetime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = irdya_datetime.cpp; sourceTree = "<group>"; };
+		46E09C252C79D60700B247E2 /* cacert.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = cacert.pem; path = ../../packaging/android/app/src/main/res/raw/cacert.pem; sourceTree = SOURCE_ROOT; };
 		46E2D98925022BF4003D99F3 /* lua_widget_methods.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua_widget_methods.hpp; sourceTree = "<group>"; };
 		46E2D98A25022BF4003D99F3 /* lua_widget_attributes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua_widget_attributes.hpp; sourceTree = "<group>"; };
 		46E2D98B25022BF5003D99F3 /* lua_widget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lua_widget.cpp; sourceTree = "<group>"; };
@@ -1817,11 +1811,8 @@
 		46EB545F27DD2FAD00D5CDE8 /* libwebp.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libwebp.dylib; path = lib/libwebp.dylib; sourceTree = "<group>"; };
 		46EEFB742087434200E1E75A /* chat_log.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chat_log.cpp; sourceTree = "<group>"; };
 		46EEFB752087434200E1E75A /* chat_log.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = chat_log.hpp; sourceTree = "<group>"; };
-		46E09C252C79D60700B247E2 /* cacert.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = cacert.pem; path = ../../packaging/android/app/src/main/res/raw/cacert.pem; sourceTree = SOURCE_ROOT; };
 		46F302EC220327FD0028938F /* container-migration.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "container-migration.plist"; path = "Resources/container-migration.plist"; sourceTree = "<group>"; };
 		46F302ED220327FE0028938F /* Wesnoth.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = Wesnoth.entitlements; path = Resources/Wesnoth.entitlements; sourceTree = "<group>"; };
-		46C0FFEE0000000000000001 /* wesnothd-mas.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = "wesnothd-mas.entitlements"; path = "Resources/wesnothd-mas.entitlements"; sourceTree = "<group>"; };
-		46C0FFEE0000000000000002 /* wesnothd-nosandbox.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = "wesnothd-nosandbox.entitlements"; path = "Resources/wesnothd-nosandbox.entitlements"; sourceTree = "<group>"; };
 		46F54C26211DFB7200374A1C /* apple_version.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = apple_version.mm; path = ../../src/desktop/apple_version.mm; sourceTree = "<group>"; };
 		46F54C28211DFB9100374A1C /* apple_version.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = apple_version.hpp; path = ../../src/desktop/apple_version.hpp; sourceTree = "<group>"; };
 		46F92C082174F5D600602C1C /* help.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = help.hpp; sourceTree = "<group>"; };
@@ -2177,9 +2168,14 @@
 		4944F41A1354FBFF0027E614 /* teleport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = teleport.cpp; sourceTree = "<group>"; };
 		49478712172FF6F8002B7ABA /* tristate_button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tristate_button.cpp; sourceTree = "<group>"; };
 		49478713172FF6F8002B7ABA /* tristate_button.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tristate_button.hpp; sourceTree = "<group>"; };
+		4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.ios.dylib; path = lib/libbz2.1.0.dylib; sourceTree = "<group>"; };
+		4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libexpat.1.ios.dylib; path = lib/libexpat.1.dylib; sourceTree = "<group>"; };
+		4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.2.ios.dylib; path = lib/libiconv.2.dylib; sourceTree = "<group>"; };
+		4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.ios.dylib; path = lib/libz.1.dylib; sourceTree = "<group>"; };
 		57724A59B2F7D072D91DD787 /* attributes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = attributes.cpp; path = font/attributes.cpp; sourceTree = "<group>"; };
 		58C649488B3014E6F7254B62 /* mp_report.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mp_report.cpp; sourceTree = "<group>"; };
 		5D46466DBCD81B13621C7342 /* tod_new_schedule.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tod_new_schedule.hpp; sourceTree = "<group>"; };
+		5E7140518DC5C72BA2D8550F /* competitive_game_security.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = competitive_game_security.hpp; path = competitive_game_security.hpp; sourceTree = "<group>"; };
 		620A386215E9364E00A4F513 /* attack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = attack.cpp; sourceTree = "<group>"; };
 		620A386315E9364E00A4F513 /* attack.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = attack.hpp; sourceTree = "<group>"; };
 		620A386415E9364E00A4F513 /* create.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = create.cpp; sourceTree = "<group>"; };
@@ -2262,8 +2258,21 @@
 		62D24F331519994300350848 /* palette_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = palette_manager.hpp; sourceTree = "<group>"; };
 		62D24F341519995200350848 /* palette_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = palette_manager.cpp; sourceTree = "<group>"; };
 		67044415B63F5888193BD7A6 /* prompt.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = prompt.cpp; sourceTree = "<group>"; };
+		6CB04F7AB718B470E5BD720A /* competitive_game_security.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = competitive_game_security.cpp; path = competitive_game_security.cpp; sourceTree = "<group>"; };
 		6FA542D78393E8FF067775DA /* edit_pbl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = edit_pbl.cpp; sourceTree = "<group>"; };
 		755D4555A1DEA29125E7F338 /* scroll_text.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = scroll_text.cpp; sourceTree = "<group>"; };
+		7A100007B4C0000100000001 /* libboost_process.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_process.dylib; path = lib/libboost_process.dylib; sourceTree = "<group>"; };
+		7A100008B4C0000100000001 /* libboost_container.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_container.dylib; path = lib/libboost_container.dylib; sourceTree = "<group>"; };
+		7A100009B4C0000100000001 /* libboost_date_time.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_date_time.dylib; path = lib/libboost_date_time.dylib; sourceTree = "<group>"; };
+		7A300101B6C0000100000001 /* libbrotlicommon.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbrotlicommon.dylib; path = lib/libbrotlicommon.dylib; sourceTree = "<group>"; };
+		7A300102B6C0000100000001 /* libbrotlidec.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbrotlidec.dylib; path = lib/libbrotlidec.dylib; sourceTree = "<group>"; };
+		7A300103B6C0000100000001 /* libicudata.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicudata.dylib; path = lib/libicudata.dylib; sourceTree = "<group>"; };
+		7A300104B6C0000100000001 /* libicui18n.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicui18n.dylib; path = lib/libicui18n.dylib; sourceTree = "<group>"; };
+		7A300105B6C0000100000001 /* libicuuc.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicuuc.dylib; path = lib/libicuuc.dylib; sourceTree = "<group>"; };
+		7A300106B6C0000100000001 /* libjpeg.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.dylib; path = lib/libjpeg.dylib; sourceTree = "<group>"; };
+		7A300107B6C0000100000001 /* liblzma.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblzma.dylib; path = lib/liblzma.dylib; sourceTree = "<group>"; };
+		7A300108B6C0000100000001 /* libwavpack.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libwavpack.dylib; path = lib/libwavpack.dylib; sourceTree = "<group>"; };
+		7A300109B6C0000100000001 /* libzstd.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libzstd.dylib; path = lib/libzstd.dylib; sourceTree = "<group>"; };
 		7CF14AB694764953E2CB3AF7 /* test_schema_validator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = test_schema_validator.cpp; sourceTree = "<group>"; };
 		7FBD4033B4B52E9424819B5F /* gui_test_dialog.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gui_test_dialog.cpp; sourceTree = "<group>"; };
 		81144D69A447D9A8DF6D04CF /* utils_simd.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = utils_simd.hpp; sourceTree = "<group>"; };
@@ -2272,9 +2281,7 @@
 		85514A7D81C52A912FF68AEB /* reachmap_options.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = reachmap_options.cpp; sourceTree = "<group>"; };
 		86A64A4ABB2987095E97AAF4 /* utils_simd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = utils_simd.cpp; sourceTree = "<group>"; };
 		875E45698F8A8D5B750E7317 /* combobox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = combobox.cpp; sourceTree = "<group>"; };
-		2294281A8FB742D3A49A7FBA /* Resources/Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Resources/Assets.xcassets"; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9EC324240DB23D8921BB0FFE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* The Battle for Wesnoth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "The Battle for Wesnoth.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DAD49C8B52CC4E4FD686A60 /* units_dialog.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = units_dialog.hpp; sourceTree = "<group>"; };
 		9107AE141DB32862001927B0 /* liblua.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblua.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2497,6 +2504,7 @@
 		95EB8A51287A02B800B09F95 /* draw_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_manager.hpp; sourceTree = "<group>"; };
 		95EB8A53287A02EC00B09F95 /* top_level_drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = top_level_drawable.hpp; path = gui/core/top_level_drawable.hpp; sourceTree = "<group>"; };
 		95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = top_level_drawable.cpp; path = gui/core/top_level_drawable.cpp; sourceTree = "<group>"; };
+		9EC324240DB23D8921BB0FFE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A03A423AB502FE015C91F1C9 /* charconv.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = charconv.hpp; sourceTree = "<group>"; };
 		A05D48F0A2C022FC128C8B3E /* edit_unit.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = edit_unit.cpp; sourceTree = "<group>"; };
 		B2CC45FEA71445AE817CAA6B /* edit_pbl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = edit_pbl.hpp; sourceTree = "<group>"; };
@@ -2915,10 +2923,6 @@
 		EC5C243018EF07B4001FA499 /* libpangoft2-1.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpangoft2-1.0.dylib"; path = "lib/libpangoft2-1.0.dylib"; sourceTree = "<group>"; };
 		EC5C243118EF07B4001FA499 /* libpng16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.dylib; path = lib/libpng16.dylib; sourceTree = "<group>"; };
 		EC5C243A18EF07B4001FA499 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = lib/libz.dylib; sourceTree = "<group>"; };
-		4F8A5D0130B1A10000A1D001 /* libbz2.1.0.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.ios.dylib; path = lib/libbz2.1.0.dylib; sourceTree = "<group>"; };
-		4F8A5D0230B1A10000A1D001 /* libexpat.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libexpat.1.ios.dylib; path = lib/libexpat.1.dylib; sourceTree = "<group>"; };
-		4F8A5D0330B1A10000A1D001 /* libiconv.2.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.2.ios.dylib; path = lib/libiconv.2.dylib; sourceTree = "<group>"; };
-		4F8A5D0430B1A10000A1D001 /* libz.1.ios.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.ios.dylib; path = lib/libz.1.dylib; sourceTree = "<group>"; };
 		EC5C70BB19EEB54900432CF4 /* filesystem_common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filesystem_common.cpp; sourceTree = "<group>"; };
 		EC5C70C019EEB58300432CF4 /* mp_ui_alerts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mp_ui_alerts.cpp; sourceTree = "<group>"; };
 		EC64D75F1A085CE60092EF75 /* seed_rng.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = seed_rng.cpp; sourceTree = "<group>"; };
@@ -3700,6 +3704,8 @@
 				460D899524DC7842000B1ABC /* simple_wml.cpp */,
 				460D898F24DC7841000B1ABC /* simple_wml.hpp */,
 				460D899124DC7842000B1ABC /* user_handler.hpp */,
+				6CB04F7AB718B470E5BD720A /* competitive_game_security.cpp */,
+				5E7140518DC5C72BA2D8550F /* competitive_game_security.hpp */,
 			);
 			path = common;
 			sourceTree = "<group>";
@@ -5284,6 +5290,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BEDD492999CDB53637FA1530 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				29AB4976BC4895899269E082 /* competitive_game_security.hpp in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -5369,6 +5383,7 @@
 			buildPhases = (
 				B5BB6B480F890FBA00444FBF /* Sources */,
 				B5BB6B490F890FBA00444FBF /* Frameworks */,
+				BEDD492999CDB53637FA1530 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -6728,6 +6743,7 @@
 				B5BB6C790F89426400444FBF /* game_version.cpp in Sources */,
 				915C68EB1DF1DCB000594B07 /* color.cpp in Sources */,
 				F6E34C7CBC418F214B43BC39 /* general.cpp in Sources */,
+				D1D947CE8015F31ED5EDA8F8 /* competitive_game_security.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6843,9 +6859,15 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = P7YF26GARW;
 				ENABLE_HARDENED_RUNTIME = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
+					SDLMain.mm,
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"LOCALEDIR=\\\"translations\\\"",
@@ -6887,8 +6909,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Wesnoth;
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
-				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -6897,10 +6917,6 @@
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(BUILT_PRODUCTS_DIR)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
-				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
@@ -7014,14 +7030,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.Wesnoth;
 				PRODUCT_NAME = "The Battle for Wesnoth";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
-					SDLMain.mm,
-				);
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WARNING_CFLAGS = "";
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				WRAPPER_EXTENSION = app;
 			};
 			name = SignedRelease;
@@ -7404,9 +7419,15 @@
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
+					SDLMain.mm,
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -7451,8 +7472,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Wesnoth;
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
-				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -7461,10 +7480,6 @@
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(BUILT_PRODUCTS_DIR)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
-				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
@@ -7577,13 +7592,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.Wesnoth;
 				PRODUCT_NAME = "The Battle for Wesnoth";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
-					SDLMain.mm,
-				);
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -7611,9 +7625,15 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = SDLMain.mm;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
+					SDLMain.mm,
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
+					"$(BUILT_PRODUCTS_DIR)",
+					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"LOCALEDIR=\\\"translations\\\"",
@@ -7656,8 +7676,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Wesnoth;
 				INSTALL_PATH = /Applications;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
-				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				LD_CLASSIC_1000 = "";
 				LD_CLASSIC_1100 = "";
 				LD_CLASSIC_1200 = "";
@@ -7666,10 +7684,6 @@
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				"FRAMEWORK_SEARCH_PATHS[sdk=iphone*]" = (
-					"$(BUILT_PRODUCTS_DIR)",
-					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
-				);
 				"LIBRARY_SEARCH_PATHS[sdk=iphone*]" = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"$(PROJECT_DIR)/temp/iOSCompileStuff-v0.0.1/$(WESNOTH_IOS_TRIPLET)/lib",
@@ -7783,14 +7797,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.Wesnoth;
 				PRODUCT_NAME = "The Battle for Wesnoth";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*]" = (
-					SDLMain.mm,
-				);
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WARNING_CFLAGS = "";
+				"WESNOTH_IOS_TRIPLET[sdk=iphoneos*]" = "arm64-ios-wesnoth";
+				"WESNOTH_IOS_TRIPLET[sdk=iphonesimulator*]" = "arm64-ios-simulator-wesnoth";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/source_lists/boost_unit_tests
+++ b/source_lists/boost_unit_tests
@@ -35,4 +35,4 @@ tests/utils/wml_equivalence.cpp
 tests/wml/schema/test_schema_self_validator.cpp
 tests/wml/schema/test_schema_validator.cpp
 tests/wml/test_macro_define.cpp
-	tests/test_tournament_ranked_server.cpp
+tests/test_tournament_ranked_server.cpp

--- a/source_lists/boost_unit_tests
+++ b/source_lists/boost_unit_tests
@@ -35,3 +35,4 @@ tests/utils/wml_equivalence.cpp
 tests/wml/schema/test_schema_self_validator.cpp
 tests/wml/schema/test_schema_validator.cpp
 tests/wml/test_macro_define.cpp
+	tests/test_tournament_ranked_server.cpp

--- a/source_lists/boost_unit_tests
+++ b/source_lists/boost_unit_tests
@@ -36,3 +36,4 @@ tests/wml/schema/test_schema_self_validator.cpp
 tests/wml/schema/test_schema_validator.cpp
 tests/wml/test_macro_define.cpp
 tests/test_tournament_ranked_server.cpp
+server/common/competitive_game_security.cpp

--- a/source_lists/wesnothd
+++ b/source_lists/wesnothd
@@ -1,4 +1,5 @@
 server/common/dbconn.cpp
+server/common/competitive_game_security.cpp
 server/common/forum_user_handler.cpp
 server/common/server_base.cpp
 server/wesnothd/ban.cpp

--- a/src/SConscript
+++ b/src/SConscript
@@ -206,13 +206,13 @@ else:
 #---boost_unit_tests---
 test_sources = GetSources("boost_unit_tests")
 if env["PLATFORM"] == 'darwin':
-    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs)
+    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs, OBJPREFIX = "tests_")
     test_env.Append(LINKFLAGS=['-Wl,-force_load', libwesnoth_widgets])
 elif env["PLATFORM"] == 'win32':
-    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs)
+    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs, OBJPREFIX = "tests_")
     test_env.Append(LINKFLAGS=['-Wl,--whole-archive', libwesnoth_widgets, '-Wl,--no-whole-archive'])
 else:
-    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs)
+    boost_unit_tests = test_env.WesnothProgram("boost_unit_tests", test_sources + libwesnoth_objects, have_client_prereqs, OBJPREFIX = "tests_")
     test_env.Append(LINKFLAGS=['-Wl,--whole-archive', libwesnoth_widgets, '-Wl,--no-whole-archive'])
 Depends(boost_unit_tests, libwesnoth_widgets)
 #---end of getting sources---

--- a/src/server/common/competitive_game_security.cpp
+++ b/src/server/common/competitive_game_security.cpp
@@ -1,0 +1,91 @@
+/*
+	Part of the Battle for Wesnoth Project
+*/
+
+#include "server/common/competitive_game_security.hpp"
+
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+
+#include <array>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+namespace
+{
+	// Encode binary cryptographic output without exposing the raw bytes in WML
+	// or database fields.
+	std::string hex_encode(const unsigned char* data, const std::size_t size)
+	{
+		std::ostringstream result;
+		result << std::hex << std::setfill('0');
+		for(std::size_t index = 0; index < size; ++index) {
+			result << std::setw(2) << static_cast<unsigned int>(data[index]);
+		}
+		return result.str();
+	}
+
+	std::string random_hex(const std::size_t byte_count)
+	{
+		std::vector<unsigned char> bytes(byte_count);
+		// OpenSSL's CSPRNG is required here; a fallback pseudo-random generator
+		// would make identifiers and resume credentials predictable.
+		if(RAND_bytes(bytes.data(), static_cast<int>(bytes.size())) != 1) {
+			return {};
+		}
+		return hex_encode(bytes.data(), bytes.size());
+	}
+}
+
+namespace competitive_game_security
+{
+	std::string generate_identifier()
+	{
+		// Keep the familiar UUID representation while using cryptographically
+		// random bytes; this identifier is not used as an authentication secret.
+		const std::string raw = random_hex(16);
+		if(raw.size() != 32) {
+			return {};
+		}
+		return raw.substr(0, 8) + "-" + raw.substr(8, 4) + "-" + raw.substr(12, 4) + "-"
+			+ raw.substr(16, 4) + "-" + raw.substr(20);
+	}
+
+	std::string generate_resume_token()
+	{
+		// The token is returned to the authorized client but only its digest is
+		// persisted, limiting the impact of a database disclosure.
+		return random_hex(32);
+	}
+
+	std::string sha256(const std::string& value)
+	{
+		// SHA-256 is used for one-way storage of resume tokens and database UUIDs.
+		std::array<unsigned char, EVP_MAX_MD_SIZE> digest{};
+		unsigned int digest_size = 0;
+		EVP_MD_CTX* context = EVP_MD_CTX_new();
+		if(!context || EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1
+			|| EVP_DigestUpdate(context, value.data(), value.size()) != 1
+			|| EVP_DigestFinal_ex(context, digest.data(), &digest_size) != 1) {
+			EVP_MD_CTX_free(context);
+			return {};
+		}
+		EVP_MD_CTX_free(context);
+		return hex_encode(digest.data(), digest_size);
+	}
+
+	std::string hmac_sha256(const std::string& secret, const std::string& value)
+	{
+		// HMAC binds the resume signature to a server-side secret as well as the
+		// value, preventing a client from minting a valid signature by itself.
+		std::array<unsigned char, EVP_MAX_MD_SIZE> digest{};
+		unsigned int digest_size = 0;
+		if(!HMAC(EVP_sha256(), secret.data(), static_cast<int>(secret.size()),
+			reinterpret_cast<const unsigned char*>(value.data()), value.size(), digest.data(), &digest_size)) {
+			return {};
+		}
+		return hex_encode(digest.data(), digest_size);
+	}
+}

--- a/src/server/common/competitive_game_security.hpp
+++ b/src/server/common/competitive_game_security.hpp
@@ -1,0 +1,39 @@
+/*
+	Part of the Battle for Wesnoth Project
+*/
+
+#pragma once
+
+#include <string>
+
+namespace competitive_game_security
+{
+	/**
+	 * Competitive save authentication flow:
+	 *
+	 * 1. The server generates a public match identifier and a private resume
+	 *    token using cryptographically secure random bytes.
+	 * 2. Only the SHA-256 digest of the resume token is stored in the database;
+	 *    the plaintext token is kept in the save metadata and sent to clients.
+	 * 3. The server creates an HMAC signature over "match_id:resume_token" using
+	 *    the server-only competitive resume secret. The signature is also sent
+	 *    with the save metadata.
+	 * 4. When a save is loaded, the server hashes the supplied token and checks
+	 *    the database record, verifies the HMAC signature, and confirms that the
+	 *    tournament metadata and lifecycle status still match. Player and team
+	 *    eligibility are validated separately by the server before continuation.
+	 *
+	 * The match identifier is therefore a lookup key, not an authentication
+	 * secret. A database copy alone cannot be used to resume a game because the
+	 * plaintext token and the server-only HMAC secret are required.
+	 */
+	/** Generate a UUID-shaped identifier that is safe to expose to clients. */
+	std::string generate_identifier();
+	/** Generate a private random token used to authorize a competitive resume. */
+	std::string generate_resume_token();
+
+	/** Return the lowercase hexadecimal SHA-256 digest of a value. */
+	std::string sha256(const std::string& value);
+	/** Return the lowercase hexadecimal HMAC-SHA-256 digest of a value. */
+	std::string hmac_sha256(const std::string& secret, const std::string& value);
+}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -22,6 +22,8 @@
 #include "serialization/unicode.hpp"
 #include "utils/general.hpp"
 
+#include <boost/algorithm/string.hpp>
+
 #include <type_traits>
 
 static lg::log_domain log_sql_handler("sql_executor");
@@ -39,6 +41,9 @@ dbconn::dbconn(const config& c)
 	, db_game_content_info_table_(c["db_game_content_info_table"].str())
 	, db_user_group_table_(c["db_user_group_table"].str())
 	, db_tournament_query_(c["db_tournament_query"].str())
+	, db_player_tournaments_query_(c["db_player_tournaments_query"].str())
+	, db_ranked_user_query_(c["db_ranked_user_query"].str())
+	, db_tournament_join_query_(c["db_tournament_join_query"].str())
 	, db_topics_table_(c["db_topics_table"].str())
 	, db_addon_info_table_(c["db_addon_info_table"].str())
 	, db_connection_history_table_(c["db_connection_history_table"].str())
@@ -55,6 +60,107 @@ dbconn::dbconn(const config& c)
 	catch(const mariadb::exception::base& e)
 	{
 		log_sql_exception("Failed to connect to the database!", e);
+	}
+
+	// Tournament Manager may use a different schema, account, or port from the
+	// forum database. Only create this connection when at least one competitive
+	// query is configured, so existing servers without Tournament Manager support
+	// retain their previous startup behavior.
+	if(!db_player_tournaments_query_.empty() || !db_ranked_user_query_.empty() || !db_tournament_join_query_.empty()) {
+		try
+		{
+			tournament_account_ = mariadb::account::create(
+				c["tournament_db_host"].str(),
+				c["tournament_db_user"].str(),
+				c["tournament_db_password"].str(),
+				c["tournament_db_name"].str(),
+				c["tournament_db_port"].to_int(3306));
+			tournament_account_->set_connect_option(mysql_option::MYSQL_SET_CHARSET_NAME, std::string("utf8mb4"));
+			tournament_connection_ = mariadb::connection::create(tournament_account_);
+		}
+		catch(const mariadb::exception::base& e)
+		{
+			log_sql_exception("Failed to connect to the Tournament Manager database!", e);
+		}
+	}
+}
+
+config dbconn::get_player_tournaments(const std::string& name)
+{
+	// The query is optional to retain compatibility with servers that do not
+	// configure Tournament/Ranked support.
+	config result;
+	if(db_player_tournaments_query_.empty() || !tournament_connection_) {
+		return result;
+	}
+	try {
+		mariadb::result_set_ref rows = select(tournament_connection_, db_player_tournaments_query_, {name});
+		while(rows->next()) {
+			config& tournament = result.add_child("tournament");
+			tournament["id"] = rows->get_string("ID");
+			tournament["name"] = rows->get_string("NAME");
+			tournament["game_id"] = rows->get_string("GAME_ID");
+			tournament["phase_name"] = rows->get_string("PHASE_NAME");
+			tournament["group_name"] = rows->get_string("GROUP_NAME");
+			// The configured query returns these tournament sequence columns as
+			// SMALLINT. Convert them to strings for the WML payload consumed by the
+			// client.
+			tournament["round_number"] = std::to_string(rows->get_signed16("ROUND_NUMBER"));
+			tournament["game_number"] = std::to_string(rows->get_signed16("GAME_NUMBER"));
+			tournament["mode"] = rows->get_string("MODE");
+		}
+	} catch(const mariadb::exception::base& e) {
+		log_sql_exception("Could not retrieve the player's tournaments!", e);
+	}
+	return result;
+}
+
+bool dbconn::can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked)
+{
+	// Reuse the exact query that populated the selector. Keep its result alive
+	// while iterating child_range(); otherwise the range would reference a
+	// temporary config and could crash wesnothd during game creation.
+	const config tournaments = get_player_tournaments(name);
+	for(const config& tournament : tournaments.child_range("tournament")) {
+		if(tournament["id"] == tournament_id && tournament["game_id"] == tournament_game_id) {
+			ranked = boost::algorithm::iequals(tournament["mode"].str(), "ranked");
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool dbconn::is_ranked_user(const std::string& name)
+{
+	// Treat an unavailable query or a database failure as denied competitive
+	// access. Ordinary games do not call this method and remain available when
+	// the Tournament Manager database is absent.
+	if(db_ranked_user_query_.empty() || !tournament_connection_) {
+		return false;
+	}
+	try {
+		return get_single_long(tournament_connection_, db_ranked_user_query_, {name}) == 1;
+	} catch(const mariadb::exception::base& e) {
+		log_sql_exception("Could not verify ranked access!", e);
+		return false;
+	}
+}
+
+bool dbconn::can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id)
+{
+	// The selected game ID identifies both permitted entries, so the query does
+	// not need the host nickname to reject unrelated tournament participants.
+	// A missing connection denies tournament access while ordinary games remain
+	// unaffected because they do not call this method.
+	if(db_tournament_join_query_.empty() || !tournament_connection_) {
+		return false;
+	}
+	try {
+		return get_single_long(tournament_connection_, db_tournament_join_query_, {tournament_id, tournament_game_id, name, name}) == 1;
+	} catch(const mariadb::exception::base& e) {
+		log_sql_exception("Could not verify tournament access!", e);
+		return false;
 	}
 }
 
@@ -793,6 +899,9 @@ long dbconn::get_single_long(const mariadb::connection_ref& connection, const st
 			case mariadb::value::type::unsigned64:
 			case mariadb::value::type::signed64:
 				return rslt->get_signed64(0);
+			case mariadb::value::type::double64:
+				// MariaDB 11.8 returns some aggregate expressions as DOUBLE.
+				return static_cast<long>(rslt->get_double(0));
 			default:
 				throw mariadb::exception::base("Value retrieved was not a long!");
 		}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -44,6 +44,7 @@ dbconn::dbconn(const config& c)
 	, db_player_tournaments_query_(c["db_player_tournaments_query"].str())
 	, db_ranked_user_query_(c["db_ranked_user_query"].str())
 	, db_tournament_join_query_(c["db_tournament_join_query"].str())
+	, db_tournament_team_query_(c["db_tournament_team_query"].str())
 	, db_topics_table_(c["db_topics_table"].str())
 	, db_addon_info_table_(c["db_addon_info_table"].str())
 	, db_connection_history_table_(c["db_connection_history_table"].str())
@@ -96,10 +97,20 @@ config dbconn::get_player_tournaments(const std::string& name)
 	try {
 		mariadb::result_set_ref rows = select(tournament_connection_, db_player_tournaments_query_, {name});
 		while(rows->next()) {
+			const std::string tournament_id = rows->get_string("ID");
+			const std::string tournament_game_id = rows->get_string("GAME_ID");
+			// The Tournament Manager and Wesnoth databases use separate
+			// connections, so filter out pairings already recorded locally after
+			// retrieving the pending tournament rows.
+			if(competitive_tournament_game_exists(tournament_id, tournament_game_id)) {
+				LOG_SQL << "Skipping tournament '" << tournament_id << "', game '" << tournament_game_id
+					<< "' for player '" << name << "' because it already has a competitive game.";
+				continue;
+			}
 			config& tournament = result.add_child("tournament");
-			tournament["id"] = rows->get_string("ID");
+			tournament["id"] = tournament_id;
 			tournament["name"] = rows->get_string("NAME");
-			tournament["game_id"] = rows->get_string("GAME_ID");
+			tournament["game_id"] = tournament_game_id;
 			tournament["phase_name"] = rows->get_string("PHASE_NAME");
 			tournament["group_name"] = rows->get_string("GROUP_NAME");
 			// The configured query returns these tournament sequence columns as
@@ -160,6 +171,41 @@ bool dbconn::can_join_tournament(const std::string& name, const std::string& tou
 		return get_single_long(tournament_connection_, db_tournament_join_query_, {tournament_id, tournament_game_id, name, name}) == 1;
 	} catch(const mariadb::exception::base& e) {
 		log_sql_exception("Could not verify tournament access!", e);
+		return false;
+	}
+}
+
+std::string dbconn::get_tournament_team_id(const std::string& tournament_id, const std::string& tournament_game_id, const std::string& name)
+{
+	// Team membership is authoritative in the Tournament Manager database; the
+	// result is copied into the Wesnoth competitive record for later validation.
+	if(db_tournament_team_query_.empty() || !tournament_connection_) {
+		return "";
+	}
+	try {
+		return get_single_string(tournament_connection_, db_tournament_team_query_, { tournament_id, tournament_game_id, name });
+	} catch(const mariadb::exception::base& e) {
+		log_sql_exception("Could not retrieve the tournament team for player `" + name + "`", e);
+		return "";
+	}
+}
+
+bool dbconn::competitive_tournament_game_exists(const std::string& tournament_id, const std::string& tournament_game_id)
+{
+	// This check intentionally uses the local Wesnoth database because the
+	// Tournament Manager query and this connection may use different databases.
+	if(tournament_id.empty() || tournament_game_id.empty()) {
+		return false;
+	}
+	try {
+		const std::string query =
+			"SELECT 1 FROM competitive_game "
+			"WHERE TOURNAMENT_ID = ? AND TOURNAMENT_GAME_ID = ? "
+			"LIMIT 1";
+		return exists(connection_, query,
+			{ tournament_id, tournament_game_id });
+	} catch(const mariadb::exception::base& e) {
+		log_sql_exception("Could not check whether tournament game `" + tournament_game_id + "` already has a competitive game", e);
 		return false;
 	}
 }
@@ -552,16 +598,210 @@ void dbconn::write_user_int(const std::string& column, const std::string& name, 
 	}
 }
 
-void dbconn::insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password)
+void dbconn::insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password, const std::string& competitive_game_id)
 {
+	// Ordinary games pass an empty competitive ID; NULL keeps them distinct from
+	// games that belong to a ranked or tournament lifecycle.
 	try
 	{
-		modify(connection_, "INSERT INTO `"+db_game_info_table_+"`(INSTANCE_UUID, GAME_ID, INSTANCE_VERSION, GAME_NAME, RELOAD, OBSERVERS, PUBLIC, PASSWORD) VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-			{ uuid, game_id, version, name, reload, observers, is_public, has_password });
+		const std::string query = "INSERT INTO `"+db_game_info_table_+"` "
+			"(INSTANCE_UUID, GAME_ID, INSTANCE_VERSION, GAME_NAME, RELOAD, OBSERVERS, PUBLIC, PASSWORD, COMPETITIVE_GAME_ID) "
+			"VALUES(?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''))";
+		modify(connection_, query,
+			{ uuid, game_id, version, name, reload, observers, is_public, has_password, competitive_game_id });
 	}
 	catch(const mariadb::exception::base& e)
 	{
 		log_sql_exception("Failed to insert game info row for UUID `"+uuid+"` and game ID `"+std::to_string(game_id)+"`", e);
+	}
+}
+
+void dbconn::insert_competitive_game(const std::string& competitive_game_id, const std::string& mode, const std::string& tournament_id, const std::string& tournament_game_id, const std::string& resume_token_hash)
+{
+	// The plaintext resume token never reaches this method; only its digest is
+	// stored so a database read does not grant resume authorization.
+	try
+	{
+		const std::string query =
+			"INSERT INTO competitive_game "
+			"(COMPETITIVE_GAME_ID, MODE, TOURNAMENT_ID, TOURNAMENT_GAME_ID, RESUME_TOKEN_HASH) "
+			"VALUES(?, ?, ?, ?, ?)";
+		modify(connection_, query,
+			{ competitive_game_id, mode, tournament_id, tournament_game_id, resume_token_hash });
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to insert competitive game `"+competitive_game_id+"`", e);
+	}
+}
+
+void dbconn::update_competitive_player(const std::string& competitive_game_id, int side_number, const std::string&, const std::string& status, const std::string& reason)
+{
+	try
+	{
+		// A disconnect or controller change must not erase a terminal outcome already
+		// detected by the server. Terminal updates may replace a transient state,
+		// while transient updates are ignored after a side is defeated or surrendered.
+		const bool terminal_status = status == "defeated" || status == "surrendered" || status == "victory";
+		const std::string terminal_guard = terminal_status ? "" : " AND STATUS NOT IN ('defeated', 'surrendered', 'victory')";
+		// USER_NAME is the immutable original owner of the side. Lifecycle
+		// transitions must never replace it with a later controller or quitter.
+		const std::string query = "UPDATE competitive_game_player SET STATUS = ?, STATUS_REASON = ? "
+			"WHERE COMPETITIVE_GAME_ID = ? AND SIDE_NUMBER = ?" + terminal_guard;
+		modify(connection_, query,
+			{ status, reason, competitive_game_id, side_number });
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to update side " + std::to_string(side_number) + " in competitive game `" + competitive_game_id + "`", e);
+	}
+}
+
+void dbconn::insert_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, bool starter, const std::string& wesnoth_team_id, const std::string& tournament_team_id)
+{
+	// This row is created once per side. Later lifecycle updates change only the
+	// status and reason, preserving the original player/team assignment.
+	try
+	{
+		const std::string query =
+			"INSERT INTO competitive_game_player "
+			"(COMPETITIVE_GAME_ID, SIDE_NUMBER, USER_NAME, STARTER, WESNOTH_TEAM_ID, TOURNAMENT_TEAM_ID) "
+			"VALUES(?, ?, ?, ?, ?, ?)";
+		modify(connection_, query,
+			{ competitive_game_id, side_number, username, starter, wesnoth_team_id, tournament_team_id });
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to insert side " + std::to_string(side_number) + " in competitive game `" + competitive_game_id + "`", e);
+	}
+}
+
+void dbconn::insert_competitive_save(const std::string& competitive_game_id, const std::string& uuid, int game_id, const std::string& username, const std::string& kind)
+{
+	try
+	{
+		const std::string query =
+			"INSERT INTO competitive_game_save "
+			"(COMPETITIVE_GAME_ID, INSTANCE_UUID, GAME_ID, USER_NAME, SAVE_KIND) "
+			"VALUES(?, ?, ?, ?, ?)";
+		modify(connection_, query,
+			{ competitive_game_id, uuid, game_id, username, kind });
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to record a save for competitive game `" + competitive_game_id + "`", e);
+	}
+}
+
+config dbconn::competitive_game_resume_info(const std::string& competitive_game_id, const std::string& resume_token_hash)
+{
+	// A valid token identifies the stored lifecycle, but does not by itself make
+	// a completed game resumable; the caller still applies the returned status.
+	config result;
+	try
+	{
+		const std::string query =
+			"SELECT STATUS, MODE, TOURNAMENT_ID, TOURNAMENT_GAME_ID "
+			"FROM competitive_game "
+			"WHERE COMPETITIVE_GAME_ID = ? AND RESUME_TOKEN_HASH = ?";
+		mariadb::result_set_ref rows = select(connection_, query,
+			{ competitive_game_id, resume_token_hash });
+		if(rows->next()) {
+			result["valid"] = true;
+			result["status"] = rows->get_string("STATUS");
+			result["mode"] = rows->get_string("MODE");
+			result["tournament_id"] = rows->get_string("TOURNAMENT_ID");
+			result["tournament_game_id"] = rows->get_string("TOURNAMENT_GAME_ID");
+		}
+		return result;
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to validate resume metadata for competitive game `" + competitive_game_id + "`", e);
+		return {};
+	}
+}
+
+bool dbconn::competitive_game_players_match(const std::string& competitive_game_id, const std::vector<std::pair<int, std::string>>& players)
+{
+	// Reload validation is based on the starter sides and exact side numbers;
+	// usernames are compared case-insensitively to match account semantics.
+	try
+	{
+		const std::string starter_count_query =
+			"SELECT COUNT(*) FROM competitive_game_player "
+			"WHERE COMPETITIVE_GAME_ID = ? AND STARTER = 1";
+		if(get_single_long(connection_, starter_count_query, { competitive_game_id }) != static_cast<long>(players.size())) {
+			return false;
+		}
+		for(const auto& [side_number, username] : players) {
+			const std::string player_query =
+				"SELECT 1 FROM competitive_game_player "
+				"WHERE COMPETITIVE_GAME_ID = ? AND SIDE_NUMBER = ? "
+				"AND STARTER = 1 AND UPPER(USER_NAME) = UPPER(?)";
+			if(!exists(connection_, player_query,
+				{ competitive_game_id, side_number, username })) {
+				return false;
+			}
+		}
+		return true;
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to validate players for competitive game `" + competitive_game_id + "`", e);
+		return false;
+	}
+}
+
+void dbconn::complete_competitive_game(const std::string& competitive_game_id)
+{
+	try
+	{
+		// A surrender can end the game while the surviving player is already
+		// leaving, so the client may not get a chance to report its victory.
+		// Finalize remaining sides only after a complete team has lost. A single
+		// surrender in a multi-side team game must not decide the whole match.
+		const std::string winner_query =
+			"UPDATE competitive_game_player AS winner "
+			"SET STATUS = 'victory', STATUS_REASON = 'opponent_surrendered' "
+			"WHERE COMPETITIVE_GAME_ID = ? "
+			"AND STATUS NOT IN ('defeated', 'surrendered', 'victory') "
+			"AND EXISTS ("
+				"SELECT 1 FROM competitive_game_player AS losing_side "
+				"WHERE losing_side.COMPETITIVE_GAME_ID = winner.COMPETITIVE_GAME_ID "
+				"AND losing_side.STATUS IN ('defeated', 'surrendered') "
+				"AND NOT EXISTS ("
+					"SELECT 1 FROM competitive_game_player AS teammate "
+					"WHERE teammate.COMPETITIVE_GAME_ID = losing_side.COMPETITIVE_GAME_ID "
+					"AND COALESCE(NULLIF(teammate.TOURNAMENT_TEAM_ID, ''), teammate.WESNOTH_TEAM_ID) "
+					"= COALESCE(NULLIF(losing_side.TOURNAMENT_TEAM_ID, ''), losing_side.WESNOTH_TEAM_ID) "
+					"AND teammate.STATUS NOT IN ('defeated', 'surrendered')"
+				")"
+			")";
+		modify(connection_, winner_query,
+			{ competitive_game_id });
+		// Leaving a game with only transient idle states is not a competitive
+		// result. Keep it active so the Tournament Manager can await confirmation
+		// or a later continuation from a save. Complete as soon as one complete
+		// team has a final outcome, without waiting for scenario cleanup.
+		const std::string completion_query =
+			"UPDATE competitive_game "
+			"SET STATUS = 'completed', COMPLETED_AT = CURRENT_TIMESTAMP "
+			"WHERE COMPETITIVE_GAME_ID = ? AND STATUS = 'active' "
+			"AND EXISTS ("
+				"SELECT COALESCE(NULLIF(TOURNAMENT_TEAM_ID, ''), WESNOTH_TEAM_ID) AS TEAM_ID "
+				"FROM competitive_game_player "
+				"WHERE COMPETITIVE_GAME_ID = ? "
+				"GROUP BY COALESCE(NULLIF(TOURNAMENT_TEAM_ID, ''), WESNOTH_TEAM_ID) "
+				"HAVING COUNT(*) = SUM(STATUS IN ('defeated', 'surrendered')) "
+				"OR COUNT(*) = SUM(STATUS = 'victory')"
+			")";
+		modify(connection_, completion_query,
+			{ competitive_game_id, competitive_game_id });
+	}
+	catch(const mariadb::exception::base& e)
+	{
+		log_sql_exception("Failed to complete competitive game `" + competitive_game_id + "`", e);
 	}
 }
 void dbconn::update_game_end(const std::string& uuid, int game_id, const std::string& replay_location)

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -61,6 +61,23 @@ public:
 	std::string get_tournaments();
 
 	/**
+	 * Execute db_player_tournaments_query for a lobby login. The query returns
+	 * one entry per pending tournament game where the player has an active
+	 * entry. Required result columns are ID, NAME, GAME_ID, PHASE_NAME,
+	 * GROUP_NAME, ROUND_NUMBER, GAME_NUMBER, and MODE. The
+	 * phase/group names are organizer-defined presentation data, not localized
+	 * strings; the client localizes only the fixed Round/Game labels.
+	 */
+	config get_player_tournaments(const std::string& name);
+	/** Recheck that a host may create the selected pending tournament game and
+	 * return whether its Tournament Manager mode is ranked. */
+	bool can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked);
+	/** Execute db_ranked_user_query for ranked authorization. */
+	bool is_ranked_user(const std::string& name);
+	/** Execute db_tournament_join_query for a player's entry in a pending game. */
+	bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id);
+
+	/**
 	 * This is an asynchronous query that is executed on a separate connection to retrieve the game history for the
 	 * provided player.
 	 *
@@ -269,6 +286,9 @@ private:
 	mariadb::account_ref account_;
 	/** The actual connection to the database. */
 	mariadb::connection_ref connection_;
+	/** Account and connection used for Tournament Manager queries. */
+	mariadb::account_ref tournament_account_;
+	mariadb::connection_ref tournament_connection_;
 
 	/** The name of the table that contains forum user information. */
 	std::string db_users_table_;
@@ -286,6 +306,10 @@ private:
 	std::string db_user_group_table_;
 	/** The text of the SQL query to use to retrieve any currently active tournaments. */
 	std::string db_tournament_query_;
+	/** SQL queries executed against the separately configured Tournament Manager database. */
+	std::string db_player_tournaments_query_;
+	std::string db_ranked_user_query_;
+	std::string db_tournament_join_query_;
 	/** The name of the table that contains phpbb forum thread information */
 	std::string db_topics_table_;
 	/** The name of the table that contains add-on information. */

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -76,6 +76,10 @@ public:
 	bool is_ranked_user(const std::string& name);
 	/** Execute db_tournament_join_query for a player's entry in a pending game. */
 	bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id);
+	/** Return the Tournament Manager team assigned to a player in a pending game. */
+	std::string get_tournament_team_id(const std::string& tournament_id, const std::string& tournament_game_id, const std::string& name);
+	/** Check the local competitive table before exposing a pending game again. */
+	bool competitive_tournament_game_exists(const std::string& tournament_id, const std::string& tournament_game_id);
 
 	/**
 	 * This is an asynchronous query that is executed on a separate connection to retrieve the game history for the
@@ -147,6 +151,7 @@ public:
 
 	/**
 	 * @see forum_user_handler::db_insert_game_info().
+	 * Empty competitive IDs are stored as SQL NULL for ordinary games.
 	 */
 	void insert_game_info(
 		const std::string& uuid,
@@ -156,7 +161,28 @@ public:
 		int reload,
 		int observers,
 		int is_public,
-		int has_password);
+		int has_password,
+		const std::string& competitive_game_id);
+
+	/** Create the logical lifecycle row and store only the hashed resume token. */
+	void insert_competitive_game(
+		const std::string& competitive_game_id,
+		const std::string& mode,
+		const std::string& tournament_id,
+		const std::string& tournament_game_id,
+		const std::string& resume_token_hash);
+	/** Update a side without replacing its immutable original username. */
+	void update_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, const std::string& status, const std::string& reason);
+	/** Record the original side owner and both tournament and Wesnoth team IDs. */
+	void insert_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, bool starter, const std::string& wesnoth_team_id, const std::string& tournament_team_id);
+	/** Record a successful manual save without storing save contents or tokens. */
+	void insert_competitive_save(const std::string& competitive_game_id, const std::string& uuid, int game_id, const std::string& username, const std::string& kind);
+	/** Return the authoritative lifecycle metadata for a valid competitive save token. */
+	config competitive_game_resume_info(const std::string& competitive_game_id, const std::string& resume_token_hash);
+	/** Require an exact starter-side and case-insensitive username match on reload. */
+	bool competitive_game_players_match(const std::string& competitive_game_id, const std::vector<std::pair<int, std::string>>& players);
+	/** Mark a match complete when a whole team has a terminal result. */
+	void complete_competitive_game(const std::string& competitive_game_id);
 
 	/**
 	 * @see forum_user_handler::db_update_game_end().
@@ -310,6 +336,7 @@ private:
 	std::string db_player_tournaments_query_;
 	std::string db_ranked_user_query_;
 	std::string db_tournament_join_query_;
+	std::string db_tournament_team_query_;
 	/** The name of the table that contains phpbb forum thread information */
 	std::string db_topics_table_;
 	/** The name of the table that contains add-on information. */

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -23,6 +23,7 @@
 #include "config.hpp"
 
 #include <boost/asio/post.hpp>
+#include <boost/asio/system_executor.hpp>
 
 #include <cstdlib>
 #include <sstream>
@@ -229,8 +230,30 @@ std::string fuh::get_tournaments(){
 	return conn_.get_tournaments();
 }
 
+// Expose the player's pending tournament games through user_handler.
+config fuh::get_player_tournaments(const std::string& name){
+	// Keep tournament policy in dbconn; this handler only exposes it through
+	// the server-wide user_handler interface.
+	return conn_.get_player_tournaments(name);
+}
+
+// Delegate host eligibility and the tournament mode lookup to dbconn.
+bool fuh::can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked){
+	return conn_.can_create_tournament_game(name, tournament_id, tournament_game_id, ranked);
+}
+
+// Delegate ranked-access verification to the Tournament Manager database.
+bool fuh::is_ranked_user(const std::string& name){
+	return conn_.is_ranked_user(name);
+}
+
+// Delegate tournament-game join authorization to dbconn.
+bool fuh::can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id){
+	return conn_.can_join_tournament(name, tournament_id, tournament_game_id);
+}
+
 void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
-	boost::asio::post([this, &s, socket, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
+	boost::asio::post(boost::asio::system_executor{}, [this, &s, socket, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
 		boost::asio::post(io_service, [socket, &s, doc = conn_.get_game_history(player_id, offset, search_game_name, search_content_type, search_content)]{
 			s.send_to_player(socket, *doc);
 		});
@@ -258,7 +281,7 @@ void fuh::db_set_oos_flag(const std::string& uuid, int game_id){
 }
 
 void fuh::async_test_query(boost::asio::io_context& io_service, int limit) {
-	boost::asio::post([this, limit, &io_service] {
+	boost::asio::post(boost::asio::system_executor{}, [this, limit, &io_service] {
 		ERR_UH << "async test query starts!";
 		int i = conn_.async_test_query(limit);
 		boost::asio::post(io_service, [i]{ ERR_UH << "async test query output: " << i; });

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -252,6 +252,17 @@ bool fuh::can_join_tournament(const std::string& name, const std::string& tourna
 	return conn_.can_join_tournament(name, tournament_id, tournament_game_id);
 }
 
+std::string fuh::db_get_tournament_team_id(const std::string& tournament_id, const std::string& tournament_game_id, const std::string& name){
+	// Keep Tournament Manager lookup and SQL connection details inside dbconn.
+	return conn_.get_tournament_team_id(tournament_id, tournament_game_id, name);
+}
+
+bool fuh::db_competitive_tournament_game_exists(const std::string& tournament_id, const std::string& tournament_game_id){
+	// The handler exposes the local duplicate check to the Wesnoth server while
+	// leaving the query and database ownership in dbconn.
+	return conn_.competitive_tournament_game_exists(tournament_id, tournament_game_id);
+}
+
 void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
 	boost::asio::post(boost::asio::system_executor{}, [this, &s, socket, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
 		boost::asio::post(io_service, [socket, &s, doc = conn_.get_game_history(player_id, offset, search_game_name, search_content_type, search_content)]{
@@ -260,8 +271,38 @@ void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, w
 	 });
 }
 
-void fuh::db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password){
-	conn_.insert_game_info(uuid, game_id, version, name, reload, observers, is_public, has_password);
+void fuh::db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password, const std::string& competitive_game_id){
+	conn_.insert_game_info(uuid, game_id, version, name, reload, observers, is_public, has_password, competitive_game_id);
+}
+
+void fuh::db_insert_competitive_game(const std::string& competitive_game_id, const std::string& mode, const std::string& tournament_id, const std::string& tournament_game_id, const std::string& resume_token_hash){
+	// Competitive lifecycle policy remains in dbconn; this class only adapts the
+	// server-wide user_handler interface.
+	conn_.insert_competitive_game(competitive_game_id, mode, tournament_id, tournament_game_id, resume_token_hash);
+}
+
+void fuh::db_update_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, const std::string& status, const std::string& reason){
+	conn_.update_competitive_player(competitive_game_id, side_number, username, status, reason);
+}
+
+void fuh::db_insert_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, bool starter, const std::string& wesnoth_team_id, const std::string& tournament_team_id){
+	conn_.insert_competitive_player(competitive_game_id, side_number, username, starter, wesnoth_team_id, tournament_team_id);
+}
+
+void fuh::db_insert_competitive_save(const std::string& competitive_game_id, const std::string& uuid, int game_id, const std::string& username, const std::string& kind){
+	conn_.insert_competitive_save(competitive_game_id, uuid, game_id, username, kind);
+}
+
+config fuh::db_competitive_game_resume_info(const std::string& competitive_game_id, const std::string& resume_token_hash){
+	return conn_.competitive_game_resume_info(competitive_game_id, resume_token_hash);
+}
+
+bool fuh::db_competitive_game_players_match(const std::string& competitive_game_id, const std::vector<std::pair<int, std::string>>& players){
+	return conn_.competitive_game_players_match(competitive_game_id, players);
+}
+
+void fuh::db_complete_competitive_game(const std::string& competitive_game_id){
+	conn_.complete_competitive_game(competitive_game_id);
 }
 
 void fuh::db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location){

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -122,10 +122,18 @@ public:
 
 	/** Tournament/Ranked authorization facade used by wesnothd. The tournament
 	 * methods work with a concrete pending tournament-game ID. */
+	/** Return pending tournament games available to the authenticated player. */
 	config get_player_tournaments(const std::string& name);
+	/** Revalidate the selected game and return whether Tournament Manager marks it ranked. */
 	bool can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked);
+	/** Check whether the player is enabled for ranked games. */
 	bool is_ranked_user(const std::string& name);
+	/** Validate that the player may join the selected tournament game. */
 	bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id);
+	/** Return the Tournament Manager team assigned to the player and game. */
+	std::string db_get_tournament_team_id(const std::string& tournament_id, const std::string& tournament_game_id, const std::string& name);
+	/** Check whether the selected tournament game already has a local match. */
+	bool db_competitive_tournament_game_exists(const std::string& tournament_id, const std::string& tournament_game_id);
 
 	/**
 	 * Runs an asynchronous query to fetch the user's game history data.
@@ -153,8 +161,24 @@ public:
 	 * @param observers Whether observers are allowed.
 	 * @param is_public Whether the game's replay will be publicly available.
 	 * @param has_password Whether the game has a password.
+	 * @param competitive_game_id The competitive match identifier, when this
+	 *        game is associated with ranked or tournament metadata.
 	 */
-	void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password);
+	void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password, const std::string& competitive_game_id);
+	/** Persist the logical ranked or tournament match and its token hash. */
+	void db_insert_competitive_game(const std::string& competitive_game_id, const std::string& mode, const std::string& tournament_id, const std::string& tournament_game_id, const std::string& resume_token_hash);
+	/** Persist a lifecycle transition for one side without changing ownership. */
+	void db_update_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, const std::string& status, const std::string& reason);
+	/** Persist the immutable starter, side, and team assignments. */
+	void db_insert_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, bool starter, const std::string& wesnoth_team_id, const std::string& tournament_team_id);
+	/** Record a manual save or replay associated with the logical match. */
+	void db_insert_competitive_save(const std::string& competitive_game_id, const std::string& uuid, int game_id, const std::string& username, const std::string& kind);
+	/** Retrieve resume status and tournament metadata after token validation. */
+	config db_competitive_game_resume_info(const std::string& competitive_game_id, const std::string& resume_token_hash);
+	/** Validate that the current players match the recorded starter sides. */
+	bool db_competitive_game_players_match(const std::string& competitive_game_id, const std::vector<std::pair<int, std::string>>& players);
+	/** Complete the logical match once a team has reached a terminal result. */
+	void db_complete_competitive_game(const std::string& competitive_game_id);
 
 	/**
 	 * Update the game related information when the game ends.

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -120,6 +120,13 @@ public:
 	 */
 	std::string get_tournaments();
 
+	/** Tournament/Ranked authorization facade used by wesnothd. The tournament
+	 * methods work with a concrete pending tournament-game ID. */
+	config get_player_tournaments(const std::string& name);
+	bool can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked);
+	bool is_ranked_user(const std::string& name);
+	bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id);
+
 	/**
 	 * Runs an asynchronous query to fetch the user's game history data.
 	 * The result is then posted back to the main boost::asio thread to be sent to the requesting player.

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -126,6 +126,12 @@ public:
 
 	virtual std::string get_uuid() = 0;
 	virtual std::string get_tournaments() = 0;
+	/** Tournament/Ranked authorization API implemented by forum_user_handler.
+	 * Tournament operations use a concrete pending tournament-game ID. */
+	virtual config get_player_tournaments(const std::string& name) = 0;
+	virtual bool can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked) = 0;
+	virtual bool is_ranked_user(const std::string& name) = 0;
+	virtual bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id) = 0;
 	virtual void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
 	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -20,6 +20,8 @@ class config;
 #include "exceptions.hpp"
 
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <boost/asio/io_context.hpp>
 
@@ -132,8 +134,17 @@ public:
 	virtual bool can_create_tournament_game(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id, bool& ranked) = 0;
 	virtual bool is_ranked_user(const std::string& name) = 0;
 	virtual bool can_join_tournament(const std::string& name, const std::string& tournament_id, const std::string& tournament_game_id) = 0;
+	virtual std::string db_get_tournament_team_id(const std::string& tournament_id, const std::string& tournament_game_id, const std::string& name) = 0;
+	virtual bool db_competitive_tournament_game_exists(const std::string& tournament_id, const std::string& tournament_game_id) = 0;
 	virtual void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
-	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
+	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password, const std::string& competitive_game_id) = 0;
+	virtual void db_insert_competitive_game(const std::string& competitive_game_id, const std::string& mode, const std::string& tournament_id, const std::string& tournament_game_id, const std::string& resume_token_hash) = 0;
+	virtual void db_update_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, const std::string& status, const std::string& reason) = 0;
+	virtual void db_insert_competitive_player(const std::string& competitive_game_id, int side_number, const std::string& username, bool starter, const std::string& wesnoth_team_id, const std::string& tournament_team_id) = 0;
+	virtual void db_insert_competitive_save(const std::string& competitive_game_id, const std::string& uuid, int game_id, const std::string& username, const std::string& kind) = 0;
+	virtual config db_competitive_game_resume_info(const std::string& competitive_game_id, const std::string& resume_token_hash) = 0;
+	virtual bool db_competitive_game_players_match(const std::string& competitive_game_id, const std::vector<std::pair<int, std::string>>& players) = 0;
+	virtual void db_complete_competitive_game(const std::string& competitive_game_id) = 0;
 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;
 	virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user, const std::string& leaders) = 0;
 	virtual unsigned long long db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& name, const std::string& id, const std::string& addon_id, const std::string& addon_version) = 0;

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -547,6 +547,14 @@ void game::transfer_side_control(player_iterator player, const simple_wml::node&
 		return;
 	}
 
+	// This second server-side check protects control transfers requested after
+	// staging, including chat commands and requests from older clients.
+	if(const simple_wml::node* settings = level_.root().child("multiplayer");
+		settings && !server.user_can_join_game(*settings, (*newplayer)->info().name())) {
+		server.send_localized_message(player, "side_assignment_denied");
+		return;
+	}
+
 	if(newplayer == old_player) {
 		// if the player is unchanged and the controller type (human or ai) is also unchanged then nothing to do
 		// else only need to change the controller type rather than the player who controls the side
@@ -1519,7 +1527,15 @@ bool game::remove_player(player_iterator player, const bool disconnect, const bo
 			ai_transfer = true;
 		}
 
-		change_controller(side_index, owner_, username(owner_));
+		// A departing player normally transfers their side to the host. Do not
+		// grant that side to an ineligible host: leave it idle instead.
+		if(const simple_wml::node* settings = level_.root().child("multiplayer");
+			settings && !server.user_can_join_game(*settings, owner_->info().name())) {
+			sides_[side_index].reset();
+			side_controllers_[side_index] = side_controller::type::none;
+		} else {
+			change_controller(side_index, owner_, username(owner_));
+		}
 
 		// Check whether the host is actually a player and make him one if not.
 		if(!is_player(owner_)) {
@@ -1563,6 +1579,9 @@ void game::send_user_list(utils::optional<player_iterator> exclude)
 
 	simple_wml::document cfg;
 	simple_wml::node& list = cfg.root();
+	// The complete user list doubles as an authorization snapshot for staging.
+	// `eligible_for_side` deliberately covers both ranked and tournament rules.
+	const simple_wml::node* settings = level_.root().child("multiplayer");
 
 	for(auto pl : all_game_users()) {
 		simple_wml::node& user = list.add_child("user");
@@ -1572,6 +1591,8 @@ void game::send_user_list(utils::optional<player_iterator> exclude)
 		user.set_attr_dup("name", pl->info().name().c_str());
 		user.set_attr("host", is_owner(pl) ? "yes" : "no");
 		user.set_attr("observer", is_observer(pl) ? "yes" : "no");
+		const bool eligible_for_side = !settings || server.user_can_join_game(*settings, pl->info().name());
+		user.set_attr("eligible_for_side", eligible_for_side ? "yes" : "no");
 	}
 
 	send_data(cfg, exclude);

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -1461,6 +1461,19 @@ bool game::remove_player(player_iterator player, const bool disconnect, const bo
 
 	DBG_GAME << debug_player_info();
 	DBG_GAME << "removing player...";
+	// Preserve the transient idle state in the competitive record before the
+	// player is removed from the side list. Terminal outcomes are protected by
+	// dbconn and cannot be overwritten by this disconnect update.
+	if(const simple_wml::node* settings = level_.root().child("multiplayer"); settings && server.get_user_handler()) {
+		const std::string competitive_game_id = settings->attr("ranked_game_id").to_string();
+		if(!competitive_game_id.empty()) {
+			for(std::size_t side_index = 0; side_index < sides_.size(); ++side_index) {
+				if(sides_[side_index] == player) {
+					server.get_user_handler()->db_update_competitive_player(competitive_game_id, static_cast<int>(side_index + 1), player->info().name(), "idle", disconnect ? "disconnect" : "leave");
+				}
+			}
+		}
+	}
 
 	const bool host = (player == owner_);
 	const bool observer = is_observer(player);

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 // class player;
+class user_handler;
 
 namespace wesnothd
 {

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -40,6 +40,7 @@
 #include "server/wesnothd/player_network.hpp"
 #include "server/common/simple_wml.hpp"
 #include "server/common/user_handler.hpp"
+#include "server/common/competitive_game_security.hpp"
 
 #ifdef HAVE_MYSQLPP
 #include "server/common/forum_user_handler.hpp"
@@ -73,6 +74,25 @@ static lg::log_domain log_server("server");
 /** normal events */
 #define LOG_SERVER LOG_STREAM(info, log_server)
 #define DBG_SERVER LOG_STREAM(debug, log_server)
+
+namespace
+{
+	// Resume metadata is optional for ordinary games, but partial metadata must
+	// still be rejected rather than silently treated as a normal game.
+	bool has_any_competitive_resume_metadata(const simple_wml::node& settings)
+	{
+		return !settings["ranked_game_id"].empty()
+			|| !settings["ranked_resume_token"].empty()
+			|| !settings["ranked_resume_signature"].empty();
+	}
+
+	bool has_complete_competitive_resume_metadata(const simple_wml::node& settings)
+	{
+		return !settings["ranked_game_id"].empty()
+			&& !settings["ranked_resume_token"].empty()
+			&& !settings["ranked_resume_signature"].empty();
+	}
+}
 
 static lg::log_domain log_config("config");
 #define ERR_CONFIG LOG_STREAM(err, log_config)
@@ -227,6 +247,7 @@ server::server(int port,
 	, input_path_()
 #endif
 	, uuid_("")
+	, competitive_resume_secret_()
 	, config_file_(config_file)
 	, cfg_(read_config())
 	, accepted_versions_()
@@ -461,6 +482,7 @@ void server::load_config(bool reload)
 
 	save_replays_ = cfg_["save_replays"].to_bool();
 	replay_save_path_ = cfg_["replay_save_path"].str();
+	competitive_resume_secret_ = cfg_["competitive_resume_secret"].str();
 
 	tor_ip_list_ = utils::split(cfg_["tor_ip_list_path"].empty()
 		? ""
@@ -1599,6 +1621,14 @@ void server::cleanup_game(game* game_ptr)
 
 	if(user_handler_){
 		user_handler_->db_update_game_end(uuid_, game_ptr->db_id(), game_ptr->get_replay_filename());
+		if(const simple_wml::node* settings = game_ptr->level().root().child("multiplayer")) {
+			// Cleanup is the final fallback for games that ended without receiving a
+			// client victory report, such as a window close after game over.
+			const std::string competitive_game_id = settings->attr("ranked_game_id").to_string();
+			if(!competitive_game_id.empty()) {
+				user_handler_->db_complete_competitive_game(competitive_game_id);
+			}
+		}
 	}
 
 	simple_wml::node* const gamelist = games_and_users_list_.child("gamelist");
@@ -1627,6 +1657,77 @@ void server::cleanup_game(game* game_ptr)
 	delete game_ptr;
 }
 
+bool server::validate_competitive_resume(const simple_wml::node& settings, config* resume_info) const
+{
+	// The token is checked both against the database hash and the server-only
+	// HMAC signature; matching tournament metadata prevents cross-game reuse.
+	const std::string resume_id = settings["ranked_game_id"].to_string();
+	const std::string resume_token = settings["ranked_resume_token"].to_string();
+	const std::string resume_signature = settings["ranked_resume_signature"].to_string();
+	if(resume_id.empty() || resume_token.empty() || resume_signature.empty() || competitive_resume_secret_.empty() || !user_handler_) {
+		return false;
+	}
+
+	const config info = user_handler_->db_competitive_game_resume_info(resume_id, competitive_game_security::sha256(resume_token));
+	if(resume_info) {
+		*resume_info = info;
+	}
+	return resume_signature == competitive_game_security::hmac_sha256(competitive_resume_secret_, resume_id + ":" + resume_token)
+		&& info["valid"].to_bool()
+		&& info["tournament_id"].str() == settings["tournament_id"].to_string()
+		&& info["tournament_game_id"].str() == settings["tournament_game_id"].to_string()
+		&& (info["status"] == "active" || info["status"] == "completed");
+}
+
+bool server::validate_tournament_team_composition(
+	const game& g,
+	player_iterator player,
+	const std::string& tournament_id,
+	const std::string& tournament_game_id,
+	std::map<int, std::string>& tournament_team_ids) const
+{
+	// Build the side-to-team mapping from the current lobby setup, then compare
+	// its equality relations with Tournament Manager rather than trusting a
+	// client-provided team identifier.
+	std::vector<std::pair<std::string, std::string>> team_composition;
+	bool valid_team_composition = true;
+
+	for(const simple_wml::node* side : g.get_sides_list()) {
+		const std::string username = side->attr("player_id").to_string();
+		if(username.empty()) {
+			continue;
+		}
+		const std::string wesnoth_team_id = side->attr("team_name").to_string().empty()
+			? side->attr("side").to_string()
+			: side->attr("team_name").to_string();
+		const std::string tournament_team_id = user_handler_->db_get_tournament_team_id(tournament_id, tournament_game_id, username);
+		if(tournament_team_id.empty()) {
+			valid_team_composition = false;
+			WRN_SERVER << player->client_ip() << "\t" << username << " has no tournament team assignment for tournament '"
+				<< tournament_id << "', game '" << tournament_game_id << "', side " << side->attr("side").to_int() << ".";
+			continue;
+		}
+		tournament_team_ids[side->attr("side").to_int()] = tournament_team_id;
+		team_composition.emplace_back(wesnoth_team_id, tournament_team_id);
+	}
+
+	for(std::size_t i = 0; i < team_composition.size(); ++i) {
+		for(std::size_t j = i + 1; j < team_composition.size(); ++j) {
+			// Team membership is identified by the complete Wesnoth team_name.
+			if((team_composition[i].first == team_composition[j].first) != (team_composition[i].second == team_composition[j].second)) {
+				valid_team_composition = false;
+			}
+		}
+	}
+
+	if(!valid_team_composition) {
+		WRN_SERVER << player->client_ip() << "\t" << player->info().name() << " attempted to start tournament game '" << g.name()
+			<< "' with a team composition that does not match Tournament Manager (tournament '" << tournament_id
+			<< "', game '" << tournament_game_id << "').";
+	}
+	return valid_team_composition;
+}
+
 void server::handle_join_game(player_iterator player, simple_wml::node& join)
 {
 	int game_id = join["id"].to_int();
@@ -1645,6 +1746,7 @@ void server::handle_join_game(player_iterator player, simple_wml::node& join)
 	// a ranked or tournament join.
 	const simple_wml::node* game_settings_node = g ? g->level().root().child("multiplayer") : nullptr;
 	const simple_wml::node& game_settings = game_settings_node ? *game_settings_node : games_and_users_list_.root();
+	const bool valid_competitive_resume = validate_competitive_resume(game_settings);
 
 	static simple_wml::document leave_game_doc("[leave_game]\n[/leave_game]\n", simple_wml::INIT_COMPRESSED);
 	if(!g) {
@@ -1668,7 +1770,9 @@ void server::handle_join_game(player_iterator player, simple_wml::node& join)
 		send_localized_message(player, "ranked_access_required");
 		send_to_player(player, games_and_users_list_);
 		return;
-	} else if(!observer && !game_settings["tournament_id"].empty() && (!user_handler_ || !user_handler_->can_join_tournament(player->info().name(), game_settings["tournament_id"].to_string(), game_settings["tournament_game_id"].to_string()))) {
+	} else if(!observer && !game_settings["tournament_id"].empty() && !valid_competitive_resume && (!user_handler_ || !user_handler_->can_join_tournament(player->info().name(), game_settings["tournament_id"].to_string(), game_settings["tournament_game_id"].to_string()))) {
+		// A valid resume keeps the original match authorization; a new join must
+		// still be checked against the current Tournament Manager assignment.
 		send_to_player(player, leave_game_doc);
 		send_localized_message(player, "tournament_join_denied");
 		send_to_player(player, games_and_users_list_);
@@ -1846,13 +1950,26 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 			// Validate the creator before publishing the game in the lobby. Client
 			// widget state is not trusted for ranked or tournament authorization.
 			if(const simple_wml::node* m = data.child("multiplayer")) {
+				const std::string resume_id = m->attr("ranked_game_id").to_string();
+				config resume_info;
+				bool valid_resume = false;
+				const bool resume_attempt = has_any_competitive_resume_metadata(*m);
+				if(resume_attempt) {
+					valid_resume = validate_competitive_resume(*m, &resume_info);
+					if(!valid_resume) {
+						WRN_SERVER << p->client_ip() << "\t" << player.name() << " attempted to load altered or unavailable competitive save for game '"
+							<< g.name() << "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ", logical ID '" << resume_id << "').";
+						delete_game(g.id());
+						return;
+					}
+				}
 				if(m->attr("ranked_mode").to_bool(false) && (!user_handler_ || !user_handler_->is_ranked_user(player.name()))) {
 					send_localized_message(p, "ranked_access_required");
 					delete_game(g.id());
 					return;
 				}
 				const std::string tournament_id = m->attr("tournament_id").to_string();
-				if(!tournament_id.empty()) {
+				if(!tournament_id.empty() && !valid_resume) {
 					bool tournament_is_ranked = false;
 					if(!user_handler_ || !user_handler_->can_create_tournament_game(player.name(), tournament_id, m->attr("tournament_game_id").to_string(), tournament_is_ranked)) {
 						send_localized_message(p, "tournament_creation_denied");
@@ -2080,6 +2197,27 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		// perform controller tweaks, assigning sides as human for their owners etc.
 		g.perform_controller_tweaks();
 
+		std::map<int, std::string> tournament_team_ids;
+		const simple_wml::node& game_settings = *g.level().root().child("multiplayer");
+		const std::string tournament_id = game_settings["tournament_id"].to_string();
+		const std::string tournament_game_id = game_settings["tournament_game_id"].to_string();
+		const bool resume_attempt = has_complete_competitive_resume_metadata(game_settings);
+		if(!resume_attempt && !tournament_id.empty() && user_handler_) {
+			// Do not create a second logical match for the same Tournament Manager
+			// game, and do not start until the side/team relationships are valid.
+			if(user_handler_->db_competitive_tournament_game_exists(tournament_id, tournament_game_id)) {
+				WRN_SERVER << p->client_ip() << "\t" << player.name() << " attempted to start tournament game '" << g.name()
+					<< "' more than once (tournament '" << tournament_id << "', game '" << tournament_game_id << "').";
+				send_localized_message(p, "tournament_game_already_recorded");
+				return;
+			}
+			if(!validate_tournament_team_composition(g, p, tournament_id, tournament_game_id, tournament_team_ids)) {
+				send_localized_message(p, "tournament_team_mismatch");
+				// Keep the lobby alive so the host can correct the sides and retry.
+				return;
+			}
+		}
+
 		// Send notification of the game starting immediately.
 		// g.start_game() will send data that assumes
 		// the [start_game] message has been sent
@@ -2087,8 +2225,54 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		g.start_game(p);
 
 		if(user_handler_) {
-			const simple_wml::node& m = *g.level().root().child("multiplayer");
+			simple_wml::node& m = *g.level().root().child("multiplayer");
 			DBG_SERVER << simple_wml::node_to_string(m);
+			const std::string saved_competitive_game_id = m["ranked_game_id"].to_string();
+			const std::string saved_resume_token = m["ranked_resume_token"].to_string();
+			const bool resume_attempt = has_complete_competitive_resume_metadata(m);
+			const bool logical_reload = g.is_reload() || resume_attempt;
+			// Reloads reuse the existing logical match; only a new game receives fresh
+			// competitive credentials and a new database lifecycle row.
+			const config resume_info = resume_attempt
+				? user_handler_->db_competitive_game_resume_info(saved_competitive_game_id, competitive_game_security::sha256(saved_resume_token))
+				: config{};
+			std::vector<std::pair<int, std::string>> loaded_players;
+			for(const simple_wml::node* side : g.get_sides_list()) {
+				const std::string username = side->attr("player_id").to_string();
+				if(!username.empty()) {
+					loaded_players.emplace_back(side->attr("side").to_int(), username);
+				}
+			}
+			const bool different_players = resume_attempt && resume_info["status"] == "active"
+				&& !user_handler_->db_competitive_game_players_match(saved_competitive_game_id, loaded_players);
+			if(resume_attempt && resume_info["status"] == "active" && !different_players) {
+				// Manual saves leave competitive sides idle. The original players
+				// resume control of those sides when the active match is continued.
+				for(const auto& [side_number, username] : loaded_players) {
+					user_handler_->db_update_competitive_player(saved_competitive_game_id, side_number, username, "active", "resume");
+				}
+			}
+			if(resume_attempt && (resume_info["status"] == "completed" || different_players)) {
+				// A completed competitive save is opened as an ordinary analysis
+				// game. A save loaded with different players follows the same rule.
+				// Keep the result notification, but remove all competitive metadata
+				// before the game can generate new lifecycle updates.
+				simple_wml::document reload_notice;
+				simple_wml::node& reload = reload_notice.root().add_child("competitive_reload");
+				reload.set_attr_dup("status", resume_info["status"].str().c_str());
+				reload.set_attr_dup("mode", resume_info["mode"].str().c_str());
+				reload.set_attr("different_players", different_players ? "yes" : "no");
+				reload.set_attr_dup("tournament_id", resume_info["tournament_id"].str().c_str());
+				reload.set_attr_dup("tournament_game_id", resume_info["tournament_game_id"].str().c_str());
+				g.send_data(reload_notice);
+				m.set_attr("ranked_mode", "no");
+				m.set_attr("ranked_game_id", "");
+				m.set_attr("ranked_resume_token", "");
+				m.set_attr("ranked_resume_signature", "");
+				m.set_attr("tournament_id", "");
+				m.set_attr("tournament_game_id", "");
+				m.set_attr("tournament_name", "");
+			}
 			// [addon] info handling
 			std::set<std::string> primary_keys;
 			for(const auto& addon : m.children("addon")) {
@@ -2113,20 +2297,53 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 				WRN_SERVER << "Game content info missing for game with uuid '" << uuid_ << "', game ID '" << g.db_id() << "', named '" << g.name() << "'";
 			}
 
-			// Store both human-readable names and immutable IDs in game_content_info.
-			// Together, tournament and tournament_game identify the exact pending
-			// Tournament Manager pairing that this Wesnoth game reports.
-			const std::string ranked = m["ranked_mode"].to_bool(false) ? "yes" : "no";
-			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "ranked", ranked, ranked, "", "");
 			const std::string tournament_id = m["tournament_id"].to_string();
-			const std::string tournament_name = tournament_id.empty() || m["tournament_name"].empty()
-				? (tournament_id.empty() ? "No" : tournament_id)
-				: m["tournament_name"].to_string();
-			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "tournament", tournament_name, tournament_id.empty() ? "No" : tournament_id, "", "");
 			const std::string tournament_game_id = m["tournament_game_id"].to_string();
-			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "tournament_game", tournament_name, tournament_game_id.empty() ? "No" : tournament_game_id, "", "");
 
-			user_handler_->db_insert_game_info(uuid_, g.db_id(), server_id_, g.name(), g.is_reload(), m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password());
+			const bool competitive = m["ranked_mode"].to_bool(false) || !tournament_game_id.empty();
+			std::string competitive_game_id = m["ranked_game_id"].to_string();
+			std::string resume_token = m["ranked_resume_token"].to_string();
+			if(competitive && competitive_game_id.empty() && !logical_reload) {
+				// Generate credentials only after authorization and team checks pass.
+				competitive_game_id = competitive_game_security::generate_identifier();
+				resume_token = competitive_game_security::generate_resume_token();
+				if(competitive_game_id.empty() || resume_token.empty()) {
+					ERR_SERVER << "Could not generate secure metadata for competitive game '" << g.name() << "' (game ID " << g.db_id() << ").";
+					competitive_game_id.clear();
+					resume_token.clear();
+				}
+			}
+			if(competitive && !competitive_game_id.empty() && !resume_token.empty()) {
+				if(competitive_resume_secret_.empty()) {
+					ERR_SERVER << "Competitive game '" << competitive_game_id << "' cannot enable save continuation because competitive_resume_secret is not configured.";
+				} else if(!logical_reload) {
+					// Persist only the token hash; the plaintext token is sent to clients
+					// through the signed metadata packet and is never stored in SQL.
+					const std::string mode = m["ranked_mode"].to_bool(false) ? "ranked" : "tournament";
+					user_handler_->db_insert_competitive_game(competitive_game_id, mode, tournament_id, tournament_game_id,
+						competitive_game_security::sha256(resume_token));
+				}
+				simple_wml::document metadata;
+				simple_wml::node& competitive_node = metadata.root().add_child("competitive_game");
+				const std::string signature = competitive_game_security::hmac_sha256(competitive_resume_secret_, competitive_game_id + ":" + resume_token);
+				competitive_node.set_attr_dup("id", competitive_game_id.c_str());
+				competitive_node.set_attr_dup("resume_token", resume_token.c_str());
+				competitive_node.set_attr_dup("signature", signature.c_str());
+				if(logical_reload) {
+					const config resume_info = user_handler_->db_competitive_game_resume_info(competitive_game_id, competitive_game_security::sha256(resume_token));
+					competitive_node.set_attr("reload", "yes");
+					competitive_node.set_attr_dup("status", resume_info["status"].str().c_str());
+					competitive_node.set_attr_dup("mode", resume_info["mode"].str().c_str());
+					competitive_node.set_attr_dup("tournament_id", resume_info["tournament_id"].str().c_str());
+					competitive_node.set_attr_dup("tournament_game_id", resume_info["tournament_game_id"].str().c_str());
+				}
+				m.set_attr_dup("ranked_game_id", competitive_game_id.c_str());
+				m.set_attr_dup("ranked_resume_token", resume_token.c_str());
+				m.set_attr_dup("ranked_resume_signature", signature.c_str());
+				g.send_data(metadata);
+			}
+
+			user_handler_->db_insert_game_info(uuid_, g.db_id(), server_id_, g.name(), logical_reload, m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password(), competitive_game_id);
 
 			const simple_wml::node::child_list& sides = g.get_sides_list();
 			for(unsigned side_index = 0; side_index < sides.size(); ++side_index) {
@@ -2168,6 +2385,14 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 				}
 
 				user_handler_->db_insert_game_player_info(uuid_, g.db_id(), side["player_id"].to_string(), side["side"].to_int(), side["is_host"].to_bool(), side["faction"].to_string(), version, source, side["current_player"].to_string(), utils::join(leaders));
+				if(competitive && !competitive_game_id.empty() && !logical_reload) {
+					// Starter usernames and team assignments are immutable; later events
+					// update only the lifecycle status and reason.
+					const std::string wesnoth_team_id = side["team_name"].to_string().empty() ? side["side"].to_string() : side["team_name"].to_string();
+					const auto tournament_team = tournament_team_ids.find(side["side"].to_int());
+					const std::string tournament_team_id = tournament_team == tournament_team_ids.end() ? "" : tournament_team->second;
+					user_handler_->db_insert_competitive_player(competitive_game_id, side["side"].to_int(), side["player_id"].to_string(), !side["player_id"].empty(), wesnoth_team_id, tournament_team_id);
+				}
 			}
 		}
 
@@ -2247,6 +2472,14 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 			return;
 		}
 		g.transfer_side_control(p, *change);
+		if(user_handler_) {
+			const simple_wml::node* competitive_settings = g.level().root().child("multiplayer");
+			const std::string competitive_game_id = competitive_settings ? competitive_settings->attr("ranked_game_id").to_string() : "";
+			const int side_number = change->attr("side").to_int();
+			if(!competitive_game_id.empty() && side_number > 0) {
+				user_handler_->db_update_competitive_player(competitive_game_id, side_number, change->attr("player").to_string(), "active", "control_transfer");
+			}
+		}
 		g.describe_slots();
 		update_game_in_lobby(g);
 
@@ -2293,6 +2526,82 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		}
 
 		return;
+	} else if(const simple_wml::node* defeated = data.child("side_defeated")) {
+		// Accept defeat reports only from the player currently assigned to that
+		// side, then persist the result before broadcasting it to the game.
+		if(!g.is_player(p)) {
+			return;
+		}
+		const simple_wml::node* settings = g.level().root().child("multiplayer");
+		const std::string competitive_game_id = settings ? settings->attr("ranked_game_id").to_string() : "";
+		const int side_number = defeated->attr("side").to_int();
+		const auto& sides = g.get_sides_list();
+		if(competitive_game_id.empty() || side_number < 1 || static_cast<std::size_t>(side_number) > sides.size()
+			|| (*sides[side_number - 1])["player_id"].to_string() != player.name()) {
+			WRN_SERVER << p->client_ip() << "\t" << player.name() << " reported invalid defeat for game '" << g.name()
+				<< "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ", side " << side_number << ").";
+			return;
+		}
+		const std::string reason = defeated->attr("reason").to_string();
+		if(reason.empty()) {
+			WRN_SERVER << p->client_ip() << "\t" << player.name() << " reported defeat without a reason for game '" << g.name() << "'.";
+			return;
+		}
+		if(user_handler_) {
+			user_handler_->db_update_competitive_player(competitive_game_id, side_number, player.name(), "defeated", reason);
+			user_handler_->db_complete_competitive_game(competitive_game_id);
+		}
+		LOG_SERVER << p->client_ip() << "\t" << player.name() << " reported side " << side_number << " defeated in game '" << g.name()
+			<< "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ", reason '" << reason << "').";
+		g.send_data(data);
+		return;
+	} else if(const simple_wml::node* victorious = data.child("side_victorious")) {
+		// Persist victory independently of scenario cleanup so external consumers
+		// can determine the result from the database without the server log.
+		if(!g.is_player(p)) {
+			return;
+		}
+		const simple_wml::node* settings = g.level().root().child("multiplayer");
+		const std::string competitive_game_id = settings ? settings->attr("ranked_game_id").to_string() : "";
+		const int side_number = victorious->attr("side").to_int();
+		const auto& sides = g.get_sides_list();
+		if(competitive_game_id.empty() || side_number < 1 || static_cast<std::size_t>(side_number) > sides.size()
+			|| (*sides[side_number - 1])["player_id"].to_string() != player.name()) {
+			WRN_SERVER << p->client_ip() << "\t" << player.name() << " reported invalid victory for game '" << g.name()
+				<< "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ", side " << side_number << ").";
+			return;
+		}
+		if(user_handler_) {
+			user_handler_->db_update_competitive_player(competitive_game_id, side_number, player.name(), "victory", "victory_check");
+			user_handler_->db_complete_competitive_game(competitive_game_id);
+		}
+		LOG_SERVER << p->client_ip() << "\t" << player.name() << " reported side " << side_number << " victorious in game '" << g.name()
+			<< "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ").";
+		g.send_data(data);
+		return;
+	} else if(const simple_wml::node* save = data.child("competitive_save_created")) {
+		// Record only that an artifact was created; save contents and credentials
+		// remain outside the database lifecycle row.
+		const std::string kind = save->attr("kind").to_string();
+		if(!g.is_player(p) || (kind != "manual" && kind != "replay")) {
+			return;
+		}
+		const simple_wml::node* settings = g.level().root().child("multiplayer");
+		const std::string competitive_game_id = settings ? settings->attr("ranked_game_id").to_string() : "";
+		if(competitive_game_id.empty()) {
+			return;
+		}
+		if(user_handler_) {
+			user_handler_->db_insert_competitive_save(competitive_game_id, uuid_, g.db_id(), player.name(), kind);
+		}
+		LOG_SERVER << p->client_ip() << "\t" << player.name() << " created a competitive " << kind << " for game '" << g.name()
+			<< "' (instance UUID '" << uuid_ << "', game ID " << g.db_id() << ").";
+		simple_wml::document notification;
+		simple_wml::node& saved = notification.root().add_child("competitive_save");
+		saved.set_attr_dup("player", player.name().c_str());
+		saved.set_attr_dup("kind", kind.c_str());
+		g.send_data(notification);
+		return;
 	} else if(const simple_wml::node* unban = data.child("unban")) {
 		g.unban_user(*unban, p);
 		return;
@@ -2314,6 +2623,31 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 
 		return;
 	} else if(data.child("turn")) {
+		// Surrender is carried inside the synchronized turn command, so record it
+		// before forwarding the turn to the game state.
+		if(user_handler_) {
+			bool surrender_recorded = false;
+			const simple_wml::node* settings = g.level().root().child("multiplayer");
+			const std::string competitive_game_id = settings ? settings->attr("ranked_game_id").to_string() : "";
+			const simple_wml::node* turn = data.child("turn");
+			if(!competitive_game_id.empty() && turn) {
+				for(const auto& command : turn->children("command")) {
+					if(!command->child("surrender")) {
+						continue;
+					}
+					const auto& sides = g.get_sides_list();
+					for(std::size_t side_index = 0; side_index < sides.size(); ++side_index) {
+						if((*sides[side_index])["player_id"].to_string() == player.name()) {
+							user_handler_->db_update_competitive_player(competitive_game_id, static_cast<int>(side_index + 1), player.name(), "surrendered", "surrender");
+							surrender_recorded = true;
+						}
+					}
+				}
+			}
+			if(surrender_recorded) {
+				user_handler_->db_complete_competitive_game(competitive_game_id);
+			}
+		}
 		// Notify the game of the commands, and if it changes
 		// the description, then sync the new description
 		// to players in the lobby.

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -766,6 +766,43 @@ void server::handle_new_client(tls_socket_ptr socket)
 	);
 }
 
+// Modularize the session data prepared during login so it can also be reused
+// when the client requests a refresh_session update.
+void server::make_session_response(simple_wml::document& response, const std::string& username, bool is_moderator)
+{
+	simple_wml::node& session = response.root().add_child("join_lobby");
+	session.set_attr("is_moderator", is_moderator ? "yes" : "no");
+	session.set_attr_dup("profile_url_prefix", "https://r.wesnoth.org/u");
+	session.set_attr("ranked_enabled", user_handler_ && user_handler_->is_ranked_user(username) ? "yes" : "no");
+
+	// Queues and tournament-game entries are session data and must be refreshed
+	// when the player opens the create-game dialog, not only at login time.
+	simple_wml::node& queues = session.add_child("queues");
+	for(const auto& [id, queue] : queue_info_) {
+		simple_wml::node& queue_node = queues.add_child("queue");
+		queue_node.set_attr_int("id", queue.id);
+		queue_node.set_attr_dup("display_name", queue.display_name.c_str());
+		queue_node.set_attr_int("players_required", queue.players_required);
+		queue_node.set_attr_dup("current_players", utils::join(queue.players_in_queue).c_str());
+	}
+
+	if(user_handler_) {
+		config tournaments = user_handler_->get_player_tournaments(username);
+		for(const config& tournament : tournaments.child_range("tournament")) {
+			simple_wml::node& node = session.add_child("tournament");
+			node.set_attr_dup("id", tournament["id"].str().c_str());
+			node.set_attr_dup("name", tournament["name"].str().c_str());
+			node.set_attr_dup("game_id", tournament["game_id"].str().c_str());
+			node.set_attr_dup("phase_name", tournament["phase_name"].str().c_str());
+			node.set_attr_dup("group_name", tournament["group_name"].str().c_str());
+			node.set_attr_dup("round_number", tournament["round_number"].str().c_str());
+			node.set_attr_dup("game_number", tournament["game_number"].str().c_str());
+			node.set_attr_dup("mode", tournament["mode"].str().c_str());
+		}
+	}
+
+}
+
 template<class SocketPtr>
 void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 {
@@ -844,7 +881,10 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 		async_send_error(socket, "You must login first.", MP_MUST_LOGIN);
 	}
 
+	// Publish ranked capability in the lobby user list for the small laurel
+	// indicator. It is informational only; all authorization is rechecked.
 	simple_wml::node& player_cfg = games_and_users_list_.root().add_child("user");
+	player_cfg.set_attr("ranked_enabled", user_handler_ && user_handler_->is_ranked_user(username) ? "yes" : "no");
 
 	player_iterator new_player;
 	bool inserted;
@@ -865,17 +905,7 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 	assert(inserted && "unexpected duplicate username");
 
 	simple_wml::document join_lobby_response;
-	join_lobby_response.root().add_child("join_lobby").set_attr("is_moderator", is_moderator ? "yes" : "no");
-	simple_wml::node& join_lobby_node = join_lobby_response.root().child("join_lobby")->set_attr_dup("profile_url_prefix", "https://r.wesnoth.org/u");
-	// add server-side queues info
-	simple_wml::node& queues_node = join_lobby_node.add_child("queues");
-	for(const auto& [id, queue] : queue_info_) {
-		simple_wml::node& queue_node = queues_node.add_child("queue");
-		queue_node.set_attr_int("id", queue.id);
-		queue_node.set_attr_dup("display_name", queue.display_name.c_str());
-		queue_node.set_attr_int("players_required", queue.players_required);
-		queue_node.set_attr_dup("current_players", utils::join(queue.players_in_queue).c_str());
-	}
+	make_session_response(join_lobby_response, username, is_moderator);
 	coro_send_doc(socket, join_lobby_response, yield);
 
 	boost::asio::spawn(io_service_,
@@ -1196,6 +1226,13 @@ template<class SocketPtr> void server::handle_player(boost::asio::yield_context 
 		if(!doc) return;
 
 		// DBG_SERVER << client_address(socket) << "\tWML received:\n" << doc->output();
+		if(doc->child("refresh_session")) {
+			simple_wml::document response;
+			make_session_response(response, player->name(), player->info().is_moderator());
+			coro_send_doc(socket, response, yield);
+			continue;
+		}
+
 		if(doc->child("refresh_lobby")) {
 			async_send_doc_queued(socket, games_and_users_list_);
 			continue;
@@ -1227,6 +1264,20 @@ template<class SocketPtr> void server::handle_player(boost::asio::yield_context 
 			handle_player_in_game(player, *doc);
 		}
 	}
+}
+
+// Centralize the server-side eligibility checks used when joining a game or
+// assigning a competitive side to a player.
+bool server::user_can_join_game(const simple_wml::node& settings, const std::string& name)
+{
+	// A server without a configured user handler may still host ordinary games,
+	// but cannot safely authorize Ranked/Tournament participation.
+	if(!user_handler_) {
+		return !settings["ranked_mode"].to_bool(false) && settings["tournament_id"].empty();
+	}
+	return (!settings["ranked_mode"].to_bool(false) || user_handler_->is_ranked_user(name))
+		&& (settings["tournament_id"].empty()
+			|| user_handler_->can_join_tournament(name, settings["tournament_id"].to_string(), settings["tournament_game_id"].to_string()));
 }
 
 void server::handle_player_in_lobby(player_iterator player, simple_wml::document& data)
@@ -1589,6 +1640,11 @@ void server::handle_join_game(player_iterator player, simple_wml::node& join)
 	if(g_iter != player_connections_.get<game_t>().end()) {
 		g = g_iter->get_game();
 	}
+	// Game settings are authoritative only after level initialization. The
+	// fallback keeps malformed/missing game state from accidentally authorizing
+	// a ranked or tournament join.
+	const simple_wml::node* game_settings_node = g ? g->level().root().child("multiplayer") : nullptr;
+	const simple_wml::node& game_settings = game_settings_node ? *game_settings_node : games_and_users_list_.root();
 
 	static simple_wml::document leave_game_doc("[leave_game]\n[/leave_game]\n", simple_wml::INIT_COMPRESSED);
 	if(!g) {
@@ -1605,8 +1661,21 @@ void server::handle_join_game(player_iterator player, simple_wml::node& join)
 		send_server_message(player, "Attempt to join an uninitialized game.", "error");
 		send_to_player(player, games_and_users_list_);
 		return;
+	} else if(!observer && game_settings["ranked_mode"].to_bool(false) && (!user_handler_ || !user_handler_->is_ranked_user(player->info().name()))) {
+		// Observers are permitted. They cannot receive a side later unless the
+		// staging eligibility check permits it.
+		send_to_player(player, leave_game_doc);
+		send_localized_message(player, "ranked_access_required");
+		send_to_player(player, games_and_users_list_);
+		return;
+	} else if(!observer && !game_settings["tournament_id"].empty() && (!user_handler_ || !user_handler_->can_join_tournament(player->info().name(), game_settings["tournament_id"].to_string(), game_settings["tournament_game_id"].to_string()))) {
+		send_to_player(player, leave_game_doc);
+		send_localized_message(player, "tournament_join_denied");
+		send_to_player(player, games_and_users_list_);
+		return;
 	} else if(player->info().is_moderator()) {
-		// Admins are always allowed to join.
+		// Moderators retain the existing ban/password bypass for ordinary games.
+		// Competitive games have already passed the Tournament Manager checks.
 	} else if(g->player_is_banned(player, player->info().name())) {
 		DBG_SERVER << player->client_ip()
 				   << "\tReject banned player: " << player->info().name()
@@ -1774,6 +1843,31 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		// place a pointer to that summary in the game's description.
 		// g.level() should then receive the full data for the game.
 		if(!g.level_init()) {
+			// Validate the creator before publishing the game in the lobby. Client
+			// widget state is not trusted for ranked or tournament authorization.
+			if(const simple_wml::node* m = data.child("multiplayer")) {
+				if(m->attr("ranked_mode").to_bool(false) && (!user_handler_ || !user_handler_->is_ranked_user(player.name()))) {
+					send_localized_message(p, "ranked_access_required");
+					delete_game(g.id());
+					return;
+				}
+				const std::string tournament_id = m->attr("tournament_id").to_string();
+				if(!tournament_id.empty()) {
+					bool tournament_is_ranked = false;
+					if(!user_handler_ || !user_handler_->can_create_tournament_game(player.name(), tournament_id, m->attr("tournament_game_id").to_string(), tournament_is_ranked)) {
+						send_localized_message(p, "tournament_creation_denied");
+						delete_game(g.id());
+						return;
+					}
+					// Do not trust a modified client to choose a ranked flag that
+					// conflicts with the selected Tournament Manager pairing.
+					if(m->attr("ranked_mode").to_bool(false) != tournament_is_ranked) {
+						send_localized_message(p, "tournament_mode_mismatch");
+						delete_game(g.id());
+						return;
+					}
+				}
+			}
 			LOG_SERVER << p->client_ip() << "\t" << player.name() << "\tcreated game:\t\"" << g.name() << "\" ("
 					   << g.id() << ", " << g.db_id() << ").";
 			// Update our config object which describes the open games,
@@ -1999,12 +2093,18 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 			std::set<std::string> primary_keys;
 			for(const auto& addon : m.children("addon")) {
 				for(const auto& content : addon->children("content")) {
-					std::string key = uuid_+"-"+std::to_string(g.db_id())+"-"+content->attr("type").to_string()+"-"+content->attr("id").to_string()+"-"+addon->attr("id").to_string();
+					const std::string content_type = content->attr("type").to_string();
+					const std::string content_id = content->attr("id").to_string();
+					const std::string content_name = content->attr("name").to_string();
+					const std::string addon_id = addon->attr("id").to_string();
+					const std::string addon_version = addon->attr("version").to_string();
+					const std::string key = uuid_ + "-" + std::to_string(g.db_id()) + "-"
+						+ content_type + "-" + content_id + "-" + addon_id;
 					if(primary_keys.count(key) == 0) {
 						primary_keys.emplace(key);
-						unsigned long long rows_inserted = user_handler_->db_insert_game_content_info(uuid_, g.db_id(), content->attr("type").to_string(), content->attr("name").to_string(), content->attr("id").to_string(), addon->attr("id").to_string(), addon->attr("version").to_string());
+						unsigned long long rows_inserted = user_handler_->db_insert_game_content_info(uuid_, g.db_id(), content_type, content_name, content_id, addon_id, addon_version);
 						if(rows_inserted == 0) {
-							WRN_SERVER << "Did not insert content row for [addon] data with uuid '" << uuid_ << "', game ID '" << g.db_id() << "', type '" << content->attr("type").to_string() << "', and content ID '" << content->attr("id").to_string() << "'";
+							WRN_SERVER << "Did not insert content row for [addon] data with uuid '" << uuid_ << "', game ID '" << g.db_id() << "', type '" << content_type << "', and content ID '" << content_id << "'";
 						}
 					}
 				}
@@ -2012,6 +2112,19 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 			if(m.children("addon").size() == 0) {
 				WRN_SERVER << "Game content info missing for game with uuid '" << uuid_ << "', game ID '" << g.db_id() << "', named '" << g.name() << "'";
 			}
+
+			// Store both human-readable names and immutable IDs in game_content_info.
+			// Together, tournament and tournament_game identify the exact pending
+			// Tournament Manager pairing that this Wesnoth game reports.
+			const std::string ranked = m["ranked_mode"].to_bool(false) ? "yes" : "no";
+			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "ranked", ranked, ranked, "", "");
+			const std::string tournament_id = m["tournament_id"].to_string();
+			const std::string tournament_name = tournament_id.empty() || m["tournament_name"].empty()
+				? (tournament_id.empty() ? "No" : tournament_id)
+				: m["tournament_name"].to_string();
+			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "tournament", tournament_name, tournament_id.empty() ? "No" : tournament_id, "", "");
+			const std::string tournament_game_id = m["tournament_game_id"].to_string();
+			user_handler_->db_insert_game_content_info(uuid_, g.db_id(), "tournament_game", tournament_name, tournament_game_id.empty() ? "No" : tournament_game_id, "", "");
 
 			user_handler_->db_insert_game_info(uuid_, g.db_id(), server_id_, g.name(), g.is_reload(), m["observer"].to_bool(), !m["private_replay"].to_bool(), g.has_password());
 
@@ -2125,6 +2238,14 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		return;
 		// If the owner of a side is changing the controller.
 	} else if(const simple_wml::node* change = data.child("change_controller")) {
+		const simple_wml::node* settings = g.level().root().child("multiplayer");
+		if(settings && !user_can_join_game(*settings, change->attr("player").to_string())) {
+			send_localized_message(p, "side_assignment_denied");
+			// A rejected control request must not be represented as a side_drop:
+			// that message means that a player actually left the game, and the
+			// client may terminate the current game when it receives one.
+			return;
+		}
 		g.transfer_side_control(p, *change);
 		g.describe_slots();
 		update_game_in_lobby(g);
@@ -2240,6 +2361,17 @@ template<class SocketPtr> void server::send_server_message(SocketPtr socket, con
 	msg.set_attr_dup("type", type.c_str());
 
 	async_send_doc_queued(socket, server_message);
+}
+
+// Send a localized informational message to a player.
+void server::send_localized_message(player_iterator player, const char* message_id)
+{
+	simple_wml::document server_message;
+	simple_wml::node& message = server_message.root().add_child("message");
+	message.set_attr("sender", "server");
+	message.set_attr("type", "info");
+	message.set_attr("message_id", message_id);
+	send_to_player(player, server_message);
 }
 
 void server::disconnect_player(player_iterator player)

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -30,6 +30,7 @@
 #include <boost/asio/steady_timer.hpp>
 
 #include <chrono>
+#include <map>
 #include <random>
 
 namespace wesnothd
@@ -46,6 +47,10 @@ public:
 	~server() {
 		destructed = true;
 	}
+
+	/** Accessors used by game state transitions that need competitive persistence. */
+	user_handler* get_user_handler() const { return user_handler_.get(); }
+	const std::string& database_uuid() const { return uuid_; }
 
 private:
 	void handle_new_client(socket_ptr socket);
@@ -73,6 +78,15 @@ private:
 	void disconnect_player(player_iterator player);
 	void remove_player(player_iterator player);
 	void make_session_response(simple_wml::document& response, const std::string& username, bool is_moderator);
+	/** Validate the signed metadata embedded in a competitive save or reload. */
+	bool validate_competitive_resume(const simple_wml::node& settings, config* resume_info = nullptr) const;
+	/** Validate Wesnoth-side teams against Tournament Manager assignments. */
+	bool validate_tournament_team_composition(
+		const game& g,
+		player_iterator player,
+		const std::string& tournament_id,
+		const std::string& tournament_game_id,
+		std::map<int, std::string>& tournament_team_ids) const;
 
 public:
 	template<class SocketPtr> void send_server_message(SocketPtr socket, const std::string& message, const std::string& type);
@@ -182,6 +196,8 @@ private:
 #endif
 
 	std::string uuid_;
+	/** Secret used to authenticate competitive-save metadata. Never sent to clients. */
+	std::string competitive_resume_secret_;
 
 	const std::string config_file_;
 	config cfg_;

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -72,6 +72,7 @@ private:
 	void handle_leave_server_queue(player_iterator p, simple_wml::node& data);
 	void disconnect_player(player_iterator player);
 	void remove_player(player_iterator player);
+	void make_session_response(simple_wml::document& response, const std::string& username, bool is_moderator);
 
 public:
 	template<class SocketPtr> void send_server_message(SocketPtr socket, const std::string& message, const std::string& type);
@@ -81,6 +82,13 @@ public:
 			player->socket()
 		);
 	}
+	/**
+	 * Send an informational identifier for translation by the receiving client.
+	 *
+	 * wesnothd does not know the client's locale, so competitive-play errors
+	 * must not be formatted as English text on the server.
+	 */
+	void send_localized_message(player_iterator player, const char* message_id);
 	void send_to_lobby(simple_wml::document& data, utils::optional<player_iterator> exclude = {});
 	void send_to_player(player_iterator player, simple_wml::document& data) {
 		utils::visit(
@@ -97,6 +105,14 @@ public:
 			);
 		}
 	}
+	/**
+	 * Evaluate ranked and tournament eligibility from a game's [multiplayer]
+	 * settings. This is shared by joins, staging controller changes, and
+	 * disconnect recovery so those paths enforce the same policy. If the
+	 * Tournament Manager database is unavailable, ordinary games remain allowed
+	 * while ranked and tournament games fail closed.
+	 */
+	bool user_can_join_game(const simple_wml::node& settings, const std::string& name);
 	void send_server_message_to_lobby(const std::string& message, utils::optional<player_iterator> exclude = {});
 	void send_server_message_to_all(const std::string& message, utils::optional<player_iterator> exclude = {});
 

--- a/src/tests/test_tournament_ranked_server.cpp
+++ b/src/tests/test_tournament_ranked_server.cpp
@@ -1,0 +1,42 @@
+/*
+	Part of the Battle for Wesnoth Project
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-test"
+
+#include <boost/test/unit_test.hpp>
+
+#include "server/common/competitive_game_security.hpp"
+
+BOOST_AUTO_TEST_SUITE(competitive_server)
+
+BOOST_AUTO_TEST_CASE(sha256_returns_the_expected_digest)
+{
+	BOOST_CHECK_EQUAL(
+		competitive_game_security::sha256("abc"),
+		"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha256_returns_the_expected_digest)
+{
+	BOOST_CHECK_EQUAL(
+		competitive_game_security::hmac_sha256("key", "The quick brown fox jumps over the lazy dog"),
+		"f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8");
+}
+
+BOOST_AUTO_TEST_CASE(resume_identifiers_have_the_expected_shape)
+{
+	const std::string identifier = competitive_game_security::generate_identifier();
+	const std::string token = competitive_game_security::generate_resume_token();
+
+	BOOST_CHECK_EQUAL(identifier.size(), 36);
+	BOOST_CHECK_EQUAL(token.size(), 64);
+	BOOST_CHECK_EQUAL(identifier[8], '-');
+	BOOST_CHECK_EQUAL(identifier[13], '-');
+	BOOST_CHECK_EQUAL(identifier[18], '-');
+	BOOST_CHECK_EQUAL(identifier[23], '-');
+	BOOST_CHECK_NE(identifier, competitive_game_security::generate_identifier());
+	BOOST_CHECK_NE(token, competitive_game_security::generate_resume_token());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -68,6 +68,7 @@ create table extra
 -- OBSERVERS: Y/N flag for whether the game allows observers
 -- PASSWORD: Y/N flag for whether the game had a password set
 -- PUBLIC: Y/N flag for whether the game will have a publicly accesible replay created for it
+-- COMPETITIVE_GAME_ID: logical ranked/tournament match identifier shared by reloads
 create table game_info
 (
     INSTANCE_UUID    CHAR(36) NOT NULL,
@@ -82,9 +83,11 @@ create table game_info
     OBSERVERS        BIT(1) NOT NULL,
     PASSWORD         BIT(1) NOT NULL,
     PUBLIC           BIT(1) NOT NULL,
+    COMPETITIVE_GAME_ID CHAR(36) COLLATE utf8mb4_general_ci NULL,
     PRIMARY KEY (INSTANCE_UUID, GAME_ID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 CREATE INDEX START_TIME_IDX ON game_info(START_TIME);
+CREATE INDEX COMPETITIVE_GAME_IDX ON game_info(COMPETITIVE_GAME_ID);
 
 -- information about the players in a particular game present in game_info
 -- this is accurate at the start of the game, but is not currently updated if a side changes owners, someone disconnects, etc
@@ -111,6 +114,60 @@ create table game_player_info
     PRIMARY KEY (INSTANCE_UUID, GAME_ID, SIDE_NUMBER)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 CREATE INDEX USER_ID_IDX ON game_player_info(USER_ID);
+
+-- One logical ranked or tournament match. A reload creates another game_info
+-- row, while this row remains the authoritative match lifecycle.
+-- RESUME_TOKEN_HASH stores only a digest; the opaque token is never persisted.
+create table competitive_game
+(
+    COMPETITIVE_GAME_ID CHAR(36) COLLATE utf8mb4_general_ci NOT NULL,
+    MODE                VARCHAR(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+    TOURNAMENT_ID       VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    TOURNAMENT_GAME_ID  VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    RESUME_TOKEN_HASH   CHAR(64) NOT NULL,
+    STATUS              VARCHAR(20) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'active',
+    CREATED_AT          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    COMPLETED_AT        TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (COMPETITIVE_GAME_ID),
+    UNIQUE KEY RESUME_TOKEN_HASH_IDX (RESUME_TOKEN_HASH)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE INDEX COMPETITIVE_TOURNAMENT_GAME_IDX ON competitive_game(TOURNAMENT_ID, TOURNAMENT_GAME_ID);
+
+-- Current state of every side in a logical competitive match. This is
+-- intentionally separate from game_player_info, which is only a start snapshot.
+-- STATUS may be active, victory, defeated, surrendered, or idle.
+create table competitive_game_player
+(
+    COMPETITIVE_GAME_ID CHAR(36) COLLATE utf8mb4_general_ci NOT NULL,
+    SIDE_NUMBER         SMALLINT UNSIGNED NOT NULL,
+    USER_NAME           VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    WESNOTH_TEAM_ID     VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    TOURNAMENT_TEAM_ID  VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    STATUS              VARCHAR(20) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'active',
+    STATUS_REASON       VARCHAR(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    STARTER             BIT(1) NOT NULL DEFAULT 1,
+    UPDATED_AT          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (COMPETITIVE_GAME_ID, SIDE_NUMBER),
+    CONSTRAINT COMPETITIVE_PLAYER_GAME_FK FOREIGN KEY (COMPETITIVE_GAME_ID)
+        REFERENCES competitive_game(COMPETITIVE_GAME_ID)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Audit of manual saves. Autosaves and replay files are deliberately not
+-- inserted here, so inspecting a replay cannot create a continuation event.
+create table competitive_game_save
+(
+    SAVE_ID             BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    COMPETITIVE_GAME_ID CHAR(36) COLLATE utf8mb4_general_ci NOT NULL,
+    INSTANCE_UUID       CHAR(36) COLLATE utf8mb4_general_ci NOT NULL,
+    GAME_ID             INT UNSIGNED NOT NULL,
+    USER_NAME           VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    SAVE_KIND           VARCHAR(20) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'manual',
+    CREATED_AT          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (SAVE_ID),
+    KEY COMPETITIVE_SAVE_GAME_IDX (COMPETITIVE_GAME_ID),
+    CONSTRAINT COMPETITIVE_SAVE_GAME_FK FOREIGN KEY (COMPETITIVE_GAME_ID)
+        REFERENCES competitive_game(COMPETITIVE_GAME_ID)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- information about the scenario/era/modifications for the game
 -- TYPE: one of era/scenario/modification/campaign


### PR DESCRIPTION
- Add Tournament Manager database configuration and queries.
- Validate ranked and tournament game creation and joins server-side.
- Expose eligible tournament games during session refresh.
- Persist ranked, tournament, and tournament-game metadata.
- Document the new wesnothd configuration options.