### PR TITLE
keep also 'Back to Turn 1' in the 'Load Turn ...' menu

### DIFF
--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -361,12 +361,13 @@ void append_items(std::vector<T>&& newitems, std::vector<T>& out)
 {
 	auto input = std::move(newitems);
 
-	// Make sure list doesn't get too long: keep top two, midpoint and bottom.
-	if(input.size() > 5) {
+	// Make sure list doesn't get too long: keep top two, two midpoint and bottom two.
+	if(input.size() > 6) {
 		out.push_back(std::move(input[0]));
 		out.push_back(std::move(input[1]));
 		out.push_back(std::move(input[input.size() / 3]));
 		out.push_back(std::move(input[input.size() * 2 / 3]));
+		out.push_back(std::move(input[input.size() - 2]));
 		out.push_back(std::move(input.back()));
 		return;
 	}


### PR DESCRIPTION
If I fail a scenario and want to restart, turn 1 autosave is usually a better choice than the start save, since the start save includes all the initial discussions and animations, which may take a while (even if Esc is pressed to make it shorter). And if I'm restarting a scenario, I do not need the introduction to it again.

This increases the size of the submenu by one, but I don't know why it'd need to be so small (and the link from 19d075af1e0ef0caad0e6806fc0ae5dd67959c43 doesn't work anymore).
