### PR TITLE
Highlight the active unit when using Next/Previous Unit

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1739,6 +1739,7 @@ void mouse_handler::cycle_units(const bool browse, const bool reverse)
 
 	if(unit_in_cycle(it)) {
 		gui().scroll_to_tile(it->get_location(), game_display::WARP);
+		gui().highlight_hex(it->get_location());
 
 		select_hex(it->get_location(), browse);
 		//		mouse_update(browse);


### PR DESCRIPTION
## Summary
- The Next/Previous Unit hotkeys (`n`/`N`) scroll to and select the newly active unit, but give no visual indicator distinguishing it from nearby units (#11474).
- Adds a `gui().highlight_hex()` call in `mouse_handler::cycle_units()`, reusing the same call "Find Label or Unit" already makes after locating a match — the active unit now gets the same hex overlay normally shown on mouse hover.

## Test plan
- [x] Built locally (CMake, Debug) and confirmed it compiles cleanly
- [x] Verified in-game: pressing `n`/`N` with the mouse held off the map shows the highlight overlay landing precisely on the newly active unit, tracking correctly across multiple presses and multiple units, and disappearing once a unit is no longer active

This change was implemented with AI assistance (Claude Code), which traced the root cause and proposed the fix; testing and verification in-game were done by the author.

Fixes #11474