### PR TITLE
Find translatable strings in data/internal

### DIFF
--- a/changelog_entries/i18n_missing_internal_units.md
+++ b/changelog_entries/i18n_missing_internal_units.md
@@ -1,0 +1,3 @@
+### Translations
+   * Fixed: Dwarvish Witness was missing from 1.19.26's POT files
+   * Fixed: Rogue Mage was missing from the POT files since 1.19.15

--- a/po/wesnoth-thot/FINDCFG
+++ b/po/wesnoth-thot/FINDCFG
@@ -1,2 +1,4 @@
 find data/campaigns/The_Hammer_of_Thursagan -name '*.cfg' -print
 find data/campaigns/The_Hammer_of_Thursagan -name '*.lua' -print
+find data/internal/Dwarvish_Witness -name '*.cfg' -print
+find data/internal/Dwarvish_Witness -name '*.lua' -print

--- a/po/wesnoth-units/FINDCFG
+++ b/po/wesnoth-units/FINDCFG
@@ -2,3 +2,5 @@ find data/core/units -name '*.cfg' -print
 find data/core/units -name '*.lua' -print
 find data/campaigns/*/units -name '*.cfg' -print
 find data/campaigns/*/units -name '*.lua' -print
+find data/internal/*/units -name '*.cfg' -print
+find data/internal/*/units -name '*.lua' -print


### PR DESCRIPTION
There are currently 5 textdomains used in data/internal, of which wesnoth, wesnoth-editor and wesnoth-lib already scan the whole data directory.

The Dwarvish Witness line was translatable in 1.19.25. The relevant commit is f49f62455b112ecf82f307586dd477875ebcd8ee.

The Rogue Mage lines have been missing since 1.19.15. The relevant commit is f13a56c98b17245054849c8d97e65e292da841cf.