### PR TITLE
Server: expose ranked capability in lobby users

### DIFF
--- a/doc/man/es/wesnothd.6
+++ b/doc/man/es/wesnothd.6
@@ -228,6 +228,21 @@ El nombre del usuario con el cual iniciar sesión en la base de datos
 \fBdb_password\fP
 La contraseña de este usuario
 .TP 
+\fBtournament_db_host\fP
+El nombre del host del servidor de base de datos de Tournament Manager.
+.TP
+\fBtournament_db_user\fP
+El usuario con el que wesnothd se conecta a la base de datos de Tournament Manager.
+.TP
+\fBtournament_db_password\fP
+La contraseña del usuario de la base de datos de Tournament Manager.
+.TP
+\fBtournament_db_name\fP
+El nombre de la base de datos de Tournament Manager.
+.TP
+\fBtournament_db_port\fP
+El puerto TCP del servidor de base de datos de Tournament Manager. El valor predeterminado es 3306.
+.TP
 \fBdb_users_table\fP
 El nombre de la tabla en la que sus foros phpBB almacenan los datos de sus
 usuarios. Generalmente éste será <table\-prefix>_users (por ej.:
@@ -258,6 +273,11 @@ grupos de usuarios. Generalmente éste será <table\-prefix>_user_group
 La consulta SQL para encontrar torneos que se anunciarán al iniciar
 sesión. Debe devolver el torneo \fBtitle\fP, \fBstatus\fP y \fBurl\fP.
 .TP 
+\fBdb_ranked_user_query\fP
+Consulta SQL parametrizada que recibe un apodo y devuelve \fB1\fP si el
+usuario puede jugar partidas clasificatorias, o \fB0\fP en caso contrario.
+La consulta se ejecuta en la base de datos de Tournament Manager.
+.TP
 \fBdb_connection_history_table\fP
 El nombre de la tabla en la que almacenar los tiempos de inicio/cierre de
 sesión. También se utiliza para hacer coincidir las direcciones IP con los
@@ -314,4 +334,3 @@ PROPÓSITO PARTICULAR.
 .SH "VÉASE TAMBIÉN"
 .
 \fBwesnoth\fP(6)
-

--- a/doc/man/wesnothd.6
+++ b/doc/man/wesnothd.6
@@ -228,6 +228,21 @@ The name of the user under which to log into the database
 .B db_password
 This user's password
 .TP
+.B tournament_db_host
+The hostname of the database server hosting the Tournament Manager database.
+.TP
+.B tournament_db_user
+The user under which wesnothd connects to the Tournament Manager database.
+.TP
+.B tournament_db_password
+The password for the Tournament Manager database user.
+.TP
+.B tournament_db_name
+The name of the Tournament Manager database.
+.TP
+.B tournament_db_port
+The TCP port of the Tournament Manager database server. Defaults to 3306.
+.TP
 .B db_users_table
 The name of the table in which your phpbb forum saves its user data. Most likely this will be <table-prefix>_users (e.g. phpbb3_users).
 .TP
@@ -248,6 +263,9 @@ The name of the table in which your phpbb forum saves its user group data. Most 
 .TP
 .B db_tournament_query
 The SQL query to find tournaments to announce on login. Should return tournament \fBtitle\fR, \fBstatus\fR and \fBurl\fR.
+.TP
+.B db_ranked_user_query
+Parameterized SQL query receiving a nickname and returning \fB1\fR when ranked access is enabled, otherwise \fB0\fR. The query is executed against the Tournament Manager database.
 .TP
 .B db_connection_history_table
 The name of the table in which to store login/logout times. Also used for matching IPs to users and vice versa.
@@ -290,4 +308,3 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 .SH SEE ALSO
 .
 .BR wesnoth (6)
-

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -39,6 +39,7 @@ dbconn::dbconn(const config& c)
 	, db_game_content_info_table_(c["db_game_content_info_table"].str())
 	, db_user_group_table_(c["db_user_group_table"].str())
 	, db_tournament_query_(c["db_tournament_query"].str())
+	, db_ranked_user_query_(c["db_ranked_user_query"].str())
 	, db_topics_table_(c["db_topics_table"].str())
 	, db_addon_info_table_(c["db_addon_info_table"].str())
 	, db_connection_history_table_(c["db_connection_history_table"].str())
@@ -55,6 +56,26 @@ dbconn::dbconn(const config& c)
 	catch(const mariadb::exception::base& e)
 	{
 		log_sql_exception("Failed to connect to the database!", e);
+	}
+
+	// Ranked capability is optional. Do not attempt a second connection for
+	// servers that have not configured Tournament Manager support.
+	if(!db_ranked_user_query_.empty()) {
+		try
+		{
+			tournament_account_ = mariadb::account::create(
+				c["tournament_db_host"].str(),
+				c["tournament_db_user"].str(),
+				c["tournament_db_password"].str(),
+				c["tournament_db_name"].str(),
+				c["tournament_db_port"].to_int(3306));
+			tournament_account_->set_connect_option(mysql_option::MYSQL_SET_CHARSET_NAME, std::string("utf8mb4"));
+			tournament_connection_ = mariadb::connection::create(tournament_account_);
+		}
+		catch(const mariadb::exception::base& e)
+		{
+			log_sql_exception("Failed to connect to the Tournament Manager database!", e);
+		}
 	}
 }
 
@@ -119,6 +140,26 @@ std::string dbconn::get_tournaments()
 	{
 		log_sql_exception("Could not retrieve the tournaments!", e);
 		return "";
+	}
+}
+
+bool dbconn::is_ranked_user(const std::string& name)
+{
+	// A missing configuration or unavailable Tournament Manager database must
+	// never grant ranked access. It does not affect ordinary games, which do not
+	// call this method.
+	if(db_ranked_user_query_.empty() || !tournament_connection_) {
+		return false;
+	}
+
+	try {
+		// The configured query is parameterized so nicknames are never inserted
+		// directly into SQL text.
+		return get_single_long(tournament_connection_, db_ranked_user_query_, {name}) == 1;
+	} catch(const mariadb::exception::base& e) {
+		// Fail closed when Tournament Manager cannot answer the capability check.
+		log_sql_exception("Could not verify ranked access!", e);
+		return false;
 	}
 }
 

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -60,6 +60,9 @@ public:
 	 */
 	std::string get_tournaments();
 
+	/** Return whether the Tournament Manager enables ranked games for a player. */
+	bool is_ranked_user(const std::string& name);
+
 	/**
 	 * This is an asynchronous query that is executed on a separate connection to retrieve the game history for the
 	 * provided player.
@@ -286,6 +289,13 @@ private:
 	std::string db_user_group_table_;
 	/** The text of the SQL query to use to retrieve any currently active tournaments. */
 	std::string db_tournament_query_;
+	/**
+	 * SQL query used to determine whether a player may play ranked games.
+	 *
+	 * The query receives the nickname as its only parameter and must return a
+	 * single numeric value: 1 for enabled and 0 for disabled.
+	 */
+	std::string db_ranked_user_query_;
 	/** The name of the table that contains phpbb forum thread information */
 	std::string db_topics_table_;
 	/** The name of the table that contains add-on information. */
@@ -294,6 +304,15 @@ private:
 	std::string db_connection_history_table_;
 	/** The name of the table that contains the add-on authors information */
 	std::string db_addon_authors_table_;
+
+	/**
+	 * Account and connection for the optional Tournament Manager database.
+	 *
+	 * These are kept separate from the forum database because Tournament
+	 * Manager may use a different schema, account, or database host.
+	 */
+	mariadb::account_ref tournament_account_;
+	mariadb::connection_ref tournament_connection_;
 
 	/**
 	 * This is used to write out error text when an SQL-related exception occurs.

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -229,6 +229,13 @@ std::string fuh::get_tournaments(){
 	return conn_.get_tournaments();
 }
 
+bool fuh::is_ranked_user(const std::string& name)
+{
+	// Keep the server dependent on the user_handler interface rather than on
+	// the concrete database implementation.
+	return conn_.is_ranked_user(name);
+}
+
 void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
 	boost::asio::post([this, &s, socket, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
 		boost::asio::post(io_service, [socket, &s, doc = conn_.get_game_history(player_id, offset, search_game_name, search_content_type, search_content)]{

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -121,6 +121,14 @@ public:
 	std::string get_tournaments();
 
 	/**
+	 * Return whether Tournament Manager enables ranked games for a player.
+	 *
+	 * This is a thin facade over the optional Tournament Manager connection in
+	 * dbconn, keeping database details out of wesnothd.
+	 */
+	bool is_ranked_user(const std::string& name);
+
+	/**
 	 * Runs an asynchronous query to fetch the user's game history data.
 	 * The result is then posted back to the main boost::asio thread to be sent to the requesting player.
 	 *

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -126,6 +126,11 @@ public:
 
 	virtual std::string get_uuid() = 0;
 	virtual std::string get_tournaments() = 0;
+	/**
+	 * Check the player's ranked capability in the configured user service.
+	 * Ordinary games must not depend on this optional capability.
+	 */
+	virtual bool is_ranked_user(const std::string& name) = 0;
 	virtual void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
 	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -845,6 +845,10 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 	}
 
 	simple_wml::node& player_cfg = games_and_users_list_.root().add_child("user");
+	// Publish this as a lobby capability. The client uses it only for display;
+	// any future ranked-game authorization must be checked again by the server.
+	const bool ranked_enabled = user_handler_ && user_handler_->is_ranked_user(username);
+	player_cfg.set_attr("ranked_enabled", ranked_enabled ? "yes" : "no");
 
 	player_iterator new_player;
 	bool inserted;


### PR DESCRIPTION
Expose each player’s ranked-play capability from the Tournament Manager database in the multiplayer lobby user list.

 #### Changes

  - Added an optional connection to the Tournament Manager database.
  - Added the db_ranked_user_query configuration option.
  - Added user_handler::is_ranked_user().
  - Query the player’s ranked capability during login.
  - Publish the result as ranked_enabled="yes" or ranked_enabled="no" in the lobby user data.
  - Documented the new configuration options in the English and Spanish wesnothd man pages.

The Tournament Manager connection is only created when db_ranked_user_query is configured. If the configuration is missing, the database is unavailable, or the query fails, ranked capability defaults to disabled. Ordinary games are unaffected.

 #### Configuration

  The following options must be added to the server’s [user_handler] configuration:

  tournament_db_host = ...
  tournament_db_port = 
  tournament_db_name = 
  tournament_db_user = ...
  tournament_db_password = ...

  db_ranked_user_query = 

  The configured query receives the player nickname as its only parameter and must return a single numeric value:

  - 1 — ranked games enabled
  - 0 — ranked games disabled



Example query:

db_ranked_user_query="SELECT IF(EXISTS(SELECT 1 FROM users_extension u WHERE LOWER(TRIM(u.nickname)) = LOWER(TRIM(?)) AND u.is_blocked = 0 AND u.enable_ranked = 1), 1, 0)"

