### PR TITLE
GUI: show ranked capability in multiplayer lobby

### DIFF
--- a/data/gui/themes/default/dialogs/lobby_main.cfg
+++ b/data/gui/themes/default/dialogs/lobby_main.cfg
@@ -430,6 +430,18 @@
 
 											[/column]
 
+											[column]
+												grow_factor = 0
+												border = "all"
+												border_size = 5
+
+												[image]
+													id = "ranked_enabled"
+													definition = "default"
+													label = "misc/laurel.png~SCALE(18,18)"
+												[/image]
+											[/column]
+
 										[/row]
 
 									[/grid]

--- a/po/wesnoth-lib/wesnoth-lib.pot
+++ b/po/wesnoth-lib/wesnoth-lib.pot
@@ -9295,3 +9295,7 @@ msgstr ""
 #: src/wml_exception.cpp:104
 msgid "In section ‘[$section|]’ the mandatory subtag ‘[$tag|]’ is missing."
 msgstr ""
+
+#: src/gui/dialogs/multiplayer/lobby_player_list_helper.cpp:156
+msgid "Ranked matches enabled"
+msgstr ""

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -53,6 +53,7 @@ user_info::user_info(const config& c)
 	, forum_id(c["forum_id"].to_int())
 	, game_id(c["game_id"].to_int())
 	, registered(c["registered"].to_bool())
+	, ranked_enabled(c["ranked_enabled"].to_bool(false))
 	, observing(c["status"] == "observing")
 	, moderator(c["moderator"].to_bool(false))
 {

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -51,6 +51,8 @@ struct user_info
 	int forum_id;
 	int game_id;
 	bool registered;
+	/** Whether the player has ranked matches enabled in Tournament Manager. */
+	bool ranked_enabled;
 	bool observing;
 	bool moderator;
 };

--- a/src/gui/dialogs/multiplayer/lobby_player_list_helper.cpp
+++ b/src/gui/dialogs/multiplayer/lobby_player_list_helper.cpp
@@ -18,6 +18,7 @@
 #include "serialization/markup.hpp"
 #include "game_initialization/lobby_data.hpp"
 #include "gettext.hpp"
+#include "gui/widgets/image.hpp"
 #include "gui/widgets/label.hpp"
 #include "gui/widgets/toggle_panel.hpp"
 #include "gui/widgets/tree_view.hpp"
@@ -147,6 +148,12 @@ void lobby_player_list_helper::update(const std::vector<mp::user_info>& user_inf
 
 			// Note the user_info associated with this node
 			info_map.try_emplace(node, info);
+
+			// This icon describes the player's ranked capability, not the game
+			// currently being played. The server remains authoritative for access.
+			auto& ranked_icon = node->find_widget<image>("ranked_enabled");
+			ranked_icon.set_visible(info->ranked_enabled ? widget::visibility::visible : widget::visibility::invisible);
+			ranked_icon.set_tooltip(_("Ranked matches enabled"));
 
 			connect_signal_mouse_left_double_click(
 				node->find_widget<toggle_panel>("tree_view_node_label"),


### PR DESCRIPTION
#### Summary

  Display a ranked capability indicator next to players who have ranked matches enabled.

  #### Changes

  - Parse the optional `ranked_enabled` attribute from lobby user data.
  - Default the value to `false` for compatibility with older servers.
  - Add a laurel icon next to the player name in the multiplayer lobby.
  - Use the existing `data/core/images/misc/laurel.png` asset.
  - Add a translatable tooltip: `Ranked matches enabled`.
  - Update the `wesnoth-lib` translation template.
