### PR TITLE
[1.18] Tell xgettext that strftime formats aren't printf formats

### DIFF
--- a/src/format_time_summary.cpp
+++ b/src/format_time_summary.cpp
@@ -45,30 +45,36 @@ std::string format_time_summary(std::time_t t) {
 			// save is from today
 			if(preferences::use_twelve_hour_clock_format() == false) {
 				// TRANSLATORS: 24-hour time, eg '13:59'
+				// xgettext: no-c-format
 				format_string = _("%H:%M");
 			}
 			else {
 				// TRANSLATORS: 12-hour time, eg '1:59 PM'
+				// xgettext: no-c-format
 				format_string = _("%I:%M %p");
 			}
 		} else if(days_apart > 0 && days_apart <= current_time.tm_wday) {
 			// save is from this week
 			if(preferences::use_twelve_hour_clock_format() == false) {
 				// TRANSLATORS: Day of week + 24-hour time, eg 'Sunday, 13:59'
+				// xgettext: no-c-format
 				format_string = _("%A, %H:%M");
 			}
 			else {
 				// TRANSLATORS: Day of week + 12-hour time, eg 'Sunday, 1:59 PM'
+				// xgettext: no-c-format
 				format_string = _("%A, %I:%M %p");
 			}
 		} else {
 			// save is from current year
 			// TRANSLATORS: Month + day of month, eg 'Nov 02'. Format for your locale.
+			// xgettext: no-c-format
 			format_string = _("%b %d");
 		}
 	} else {
 		// save is from a different year
 		// TRANSLATORS: Month + day of month + year, eg 'Nov 02 2021'. Format for your locale.
+		// xgettext: no-c-format
 		format_string = _("%b %d %Y");
 	}
 	assert(!format_string.empty());


### PR DESCRIPTION
1.18 equivalent of #11493.

Issue seen with gettext 1.0.3, presumably in gettext 1.0 (Jan 2026).

The heuristics in gettext 1.0.3 think "%b %d" is going to be used with printf. Our date-formatting strings use that for "month day" format, which for many non-US locales will be switched to "%d %b", at which point c-format checks will mark the string as fuzzy.

Only "%b %d" needs this change, but the others may as well have it in case the heuristics change.