### PR TITLE
Fix ENABLE_SYSTEM_LUA quoting in CI to Re-Enable Bundled Lua Build Coverage

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -113,7 +113,7 @@ jobs:
                 cmake "$@" -DCMAKE_BUILD_TYPE="$CFG" -DCXX_STD="$CXX_STD" \
                   -DEXTRA_FLAGS_CONFIG="-pipe" -DENABLE_MYSQL=true -DENABLE_STRICT_COMPILATION=true \
                   -DENABLE_NLS=false -DENABLE_LTO="$LTO" -DFORCE_COLOR_OUTPUT=true -DLTO_JOBS=2 \
-                  -DENABLE_SYSTEM_LUA="$SYS_LUA -DCLANG_TIDY=true" -DCMAKE_PREFIX_PATH="/usr/local/lib/cmake/SDL3;/usr/local/lib/cmake/SDL3_image;/usr/local/lib/cmake/SDL3_mixer" -S . -B .
+                  -DENABLE_SYSTEM_LUA="$SYS_LUA" -DCLANG_TIDY=true -DCMAKE_PREFIX_PATH="/usr/local/lib/cmake/SDL3;/usr/local/lib/cmake/SDL3_image;/usr/local/lib/cmake/SDL3_mixer" -S . -B .
               }
               # still need the rest of /usr/local/lib/cmake for SDL3 for now
               rm -R /usr/local/lib/cmake/boost*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ if(NOT MSVC)
 
 ### Enable clang-tidy linting
 	if (CLANG_TIDY)
-		set(CMAKE_CXX_CLANG_TIDY "clang-tidy -Wno-unknown-warning-option")
+		set(CMAKE_CXX_CLANG_TIDY clang-tidy --extra-arg=-Wno-unknown-warning-option)
 	endif()
 
 ### Set the final compiler flags.


### PR DESCRIPTION
# Summary

Fixes the CMake option quoting in Ubuntu CI builds so the build matrix actually tests both bundled Lua and system Lua as intended.

## Bug

For the bundled-Lua build, `SYS_LUA` is set to `false`, but a misplaced quote causes the shell to pass `-DENABLE_SYSTEM_LUA=false -DCLANG_TIDY=true` as one CMake argument, instead of as separate arguments. CMake therefore receives `false -DCLANG_TIDY=true` as the value of `ENABLE_SYSTEM_LUA`. Because this nonempty string is not one of CMake's recognized false constants, it evaluates as true. The result is visible, for example, in a recent [`sys_lua: false` job](https://github.com/wesnoth/wesnoth/actions/runs/31965461970/job/95209847591), which reports `-- Found Lua: /usr/lib/x86_64-linux-gnu/liblua5.4-c++.so (found version "5.4.6")`.

As a result, the CI job intended to use bundled Lua uses system Lua instead.

## Fix

Closing the quote after `$SYS_LUA` makes the `false` configuration use bundled Lua as intended, while the `true` configuration continues to use system Lua.
