### PR TITLE
Take extra care when working with Lua userdata

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -23,6 +23,8 @@
 
 #include "ai/lua/core.hpp"
 #include "ai/composite/aspect.hpp"
+#include "scripting/lua_attributes.hpp"
+#include "scripting/lua_common.hpp" // for new(L)
 #include "scripting/lua_unit.hpp"
 #include "scripting/push_check.hpp"
 #include "ai/lua/lua_object.hpp" // (Nephro)
@@ -45,6 +47,15 @@ static lg::log_domain log_ai_engine_lua("ai/engine/lua");
 #define ERR_LUA LOG_STREAM(err, log_ai_engine_lua)
 
 static char const aisKey[] = "ai contexts";
+static char const atkKey[] = "attack analysis";
+
+template<> struct lua_object_traits<ai::attack_analysis> {
+	inline static auto metatable = atkKey;
+	inline static ai::attack_analysis get(lua_State* L, int n) {
+		auto atk = static_cast<ai::attack_analysis*>(luaL_checkudata(L, n, atkKey));
+		return *atk;
+	}
+};
 
 namespace ai {
 
@@ -109,10 +120,14 @@ void lua_ai_context::set_persistent_data(const config &cfg)
 	lua_settop(L, top);
 }
 
+static ai::engine_lua &get_engine(lua_State *L, int n)
+{
+	return *(static_cast<ai::engine_lua*>(lua_touserdata(L, n)));
+}
+
 static ai::engine_lua &get_engine(lua_State *L)
 {
-	return *(static_cast<ai::engine_lua*>(
-			lua_touserdata(L, lua_upvalueindex(1))));
+	return get_engine(L, lua_upvalueindex(1));
 }
 
 static ai::readonly_context &get_readonly_context(lua_State *L)
@@ -502,21 +517,16 @@ static int cfun_ai_get_villages_per_scout(lua_State *L)
 }
 // End of aspect section
 
-static int cfun_attack_rating(lua_State *L)
+static int impl_attack_rating(lua_State *L)
 {
-	int top = lua_gettop(L);
-	// the attack_analysis table should be on top of the stack
-	lua_getfield(L, -1, "att_ptr"); // [-2: attack_analysis; -1: pointer to attack_analysis object in c++]
-	// now the pointer to our attack_analysis C++ object is on top
-	const attack_analysis* aa_ptr = static_cast< attack_analysis * >(lua_touserdata(L, -1));
+	// the attack_analysis userdata should be on top of the stack
+	const attack_analysis* aa_ptr = static_cast< attack_analysis * >(luaL_checkudata(L, -1, atkKey));
+	// the engine pointer is stored as the first uservalue
+	lua_getiuservalue(L, -1, 1);
+	auto& roc = get_engine(L, -1).get_readonly_context();
 
-	//[-2: attack_analysis; -1: pointer to attack_analysis object in c++]
-
-	double aggression = get_readonly_context(L).get_aggression();
-
-	double rating = aa_ptr->rating(aggression, get_readonly_context(L));
-
-	lua_settop(L, top);
+	double aggression = roc.get_aggression();
+	double rating = aa_ptr->rating(aggression, roc);
 
 	lua_pushnumber(L, rating);
 	return 1;
@@ -547,84 +557,129 @@ static void push_movements(lua_State *L, const std::vector< std::pair < map_loca
 
 }
 
+static int impl_atkstat_destroy(lua_State* L)
+{
+	auto atk = static_cast<attack_analysis*>(luaL_checkudata(L, -1, atkKey));
+	atk->~attack_analysis();
+	return 0;
+}
+
+static int impl_atkstat_tostring(lua_State* L)
+{
+	// The attack analysis userdata should be at the top of the stack.
+	auto atk = static_cast<attack_analysis*>(luaL_checkudata(L, -1, atkKey));
+	luaW_getglobal(L, "string", "format");
+	lua_pushstring(L, "attack analysis @ (%d,%d)");
+	lua_pushinteger(L, atk->target.wml_x());
+	lua_pushinteger(L, atk->target.wml_y());
+	lua_call(L, 3, 1);
+	return 1;
+}
+
+#define ATTACK_GETTER(name, type) LATTR_GETTER(name, type, attack_analysis, atk)
+static luaW_Registry atkAnalysisReg{"attack analysis"};
+
+static int impl_atkstat_get(lua_State* L)
+{
+	return atkAnalysisReg.get(L);
+}
+
+static int impl_atkstat_dir(lua_State* L)
+{
+	return atkAnalysisReg.dir(L);
+}
+
 static void push_attack_analysis(lua_State *L, const attack_analysis& aa)
 {
-	lua_newtable(L);
-
-	// Pushing a pointer to the current object
-	lua_pushstring(L, "att_ptr");
-	lua_pushlightuserdata(L, const_cast<attack_analysis*>(&aa));
-	lua_rawset(L, -3);
-
-	// Registering callback function for the rating method
-	lua_pushstring(L, "rating");
+	new(L, 1) attack_analysis(aa);
+	if(luaL_newmetatable(L, atkKey)) {
+		static luaL_Reg const callbacks[] {
+			{ "__gc",           &impl_atkstat_destroy},
+			{ "__tostring",     &impl_atkstat_tostring},
+			{ "__index",        &impl_atkstat_get},
+			{ "__dir",          &impl_atkstat_dir},
+			{ nullptr, nullptr }
+		};
+		luaL_setfuncs(L, callbacks, 0);
+		lua_pushstring(L, atkKey);
+		lua_setfield(L, -2, "__metatable");
+	}
+	lua_setmetatable(L, -2);
+	// Record the engine pointer for this attack analysis
 	lua_pushlightuserdata(L, &get_engine(L));
-	lua_pushcclosure(L, &cfun_attack_rating, 1);
-	lua_rawset(L, -3);
+	lua_setiuservalue(L, -2, 1);
+}
 
-	lua_pushstring(L, "movements");
-	push_movements(L, aa.movements);
-	lua_rawset(L, -3);
+ATTACK_GETTER("rating", lua_index_raw) {
+	(void)atk;
+	lua_pushcfunction(L, &impl_attack_rating);
+	return lua_index_raw(L);
+}
 
-	lua_pushstring(L, "target");
-	luaW_pushlocation(L, aa.target);
-	lua_rawset(L, -3);
+ATTACK_GETTER("movements", lua_index_raw) {
+	(void)atk;
+	push_movements(L, atk.movements);
+	return lua_index_raw(L);
+}
 
-	lua_pushstring(L, "target_value");
-	lua_pushnumber(L, aa.target_value);
-	lua_rawset(L, -3);
+ATTACK_GETTER("target", map_location) {
+	return atk.target;
+}
 
-	lua_pushstring(L, "avg_losses");
-	lua_pushnumber(L, aa.avg_losses);
-	lua_rawset(L, -3);
+ATTACK_GETTER("target_value", double) {
+	return atk.target_value;
+}
 
-	lua_pushstring(L, "chance_to_kill");
-	lua_pushnumber(L, aa.chance_to_kill);
-	lua_rawset(L, -3);
+ATTACK_GETTER("avg_losses", double) {
+	return atk.avg_losses;
+}
 
-	lua_pushstring(L, "avg_damage_inflicted");
-	lua_pushnumber(L, aa.avg_damage_inflicted);
-	lua_rawset(L, -3);
+ATTACK_GETTER("chance_to_kill", double) {
+	return atk.chance_to_kill;
+}
 
-	lua_pushstring(L, "target_starting_damage");
-	lua_pushinteger(L, aa.target_starting_damage);
-	lua_rawset(L, -3);
+ATTACK_GETTER("avg_damage_inflicted", double) {
+	return atk.avg_damage_inflicted;
+}
 
-	lua_pushstring(L, "avg_damage_taken");
-	lua_pushnumber(L, aa.avg_damage_taken);
-	lua_rawset(L, -3);
+ATTACK_GETTER("target_starting_damage", int) {
+	return atk.target_starting_damage;
+}
 
-	lua_pushstring(L, "resources_used");
-	lua_pushnumber(L, aa.resources_used);
-	lua_rawset(L, -3);
+ATTACK_GETTER("avg_damage_taken", double) {
+	return atk.avg_damage_taken;
+}
 
-	lua_pushstring(L, "terrain_quality");
-	lua_pushnumber(L, aa.terrain_quality);
-	lua_rawset(L, -3);
+ATTACK_GETTER("resources_used", double) {
+	return atk.resources_used;
+}
 
-	lua_pushstring(L, "alternative_terrain_quality");
-	lua_pushnumber(L, aa.alternative_terrain_quality);
-	lua_rawset(L, -3);
+ATTACK_GETTER("terrain_quality", double) {
+	return atk.terrain_quality;
+}
 
-	lua_pushstring(L, "vulnerability");
-	lua_pushnumber(L, aa.vulnerability);
-	lua_rawset(L, -3);
+ATTACK_GETTER("alternative_terrain_quality", double) {
+	return atk.alternative_terrain_quality;
+}
 
-	lua_pushstring(L, "support");
-	lua_pushnumber(L, aa.support);
-	lua_rawset(L, -3);
+ATTACK_GETTER("vulnerability", double) {
+	return atk.vulnerability;
+}
 
-	lua_pushstring(L, "leader_threat");
-	lua_pushboolean(L, aa.leader_threat);
-	lua_rawset(L, -3);
+ATTACK_GETTER("support", double) {
+	return atk.support;
+}
 
-	lua_pushstring(L, "uses_leader");
-	lua_pushboolean(L, aa.uses_leader);
-	lua_rawset(L, -3);
+ATTACK_GETTER("leader_threat", bool) {
+	return atk.leader_threat;
+}
 
-	lua_pushstring(L, "is_surrounded");
-	lua_pushboolean(L, aa.is_surrounded);
-	lua_rawset(L, -3);
+ATTACK_GETTER("uses_leader", bool) {
+	return atk.uses_leader;
+}
+
+ATTACK_GETTER("is_surrounded", bool) {
+	return atk.is_surrounded;
 }
 
 static void push_move_map(lua_State *L, const move_map& m)

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -122,6 +122,11 @@ void lua_ai_context::set_persistent_data(const config &cfg)
 
 static ai::engine_lua &get_engine(lua_State *L, int n)
 {
+	if(!lua_islightuserdata(L, n)) {
+		lua_pushstring(L, "AI engine pointer was invalid");
+		lua_error(L);
+		// lua_error never returns, so the below return will not execute.
+	}
 	return *(static_cast<ai::engine_lua*>(lua_touserdata(L, n)));
 }
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1498,10 +1498,11 @@ static int impl_end_level_data_collect(lua_State* L)
 	return 0;
 }
 
+static const char mpsettingKey[] = "mp settings";
 static int impl_mp_settings_get(lua_State* L)
 {
-	void* p = lua_touserdata(L, lua_upvalueindex(1));
-	const mp_game_settings& settings = static_cast<play_controller*>(p)->get_mp_settings();
+	play_controller* p = *static_cast<play_controller**>(luaL_checkudata(L, 1, mpsettingKey));
+	const mp_game_settings& settings = p->get_mp_settings();
 	if(lua_type(L, 2) == LUA_TNUMBER) {
 		// Simulates a WML table with one [options] child and a variable number of [addon] children
 		// TODO: Deprecate this -> mp_settings.options and mp_settings.addons
@@ -1620,8 +1621,8 @@ static int impl_mp_settings_get(lua_State* L)
 
 static int impl_mp_settings_len(lua_State* L)
 {
-	void* p = lua_touserdata(L, lua_upvalueindex(1));
-	const mp_game_settings& settings = static_cast<play_controller*>(p)->get_mp_settings();
+	play_controller* p = *static_cast<play_controller**>(luaL_checkudata(L, 1, mpsettingKey));
+	const mp_game_settings& settings = p->get_mp_settings();
 	lua_pushinteger(L, settings.addons.size() + 1);
 	return 1;
 }
@@ -1790,15 +1791,14 @@ SCENARIO_GETTER("mp_settings", lua_index_raw) {
 		lua_pushnil(L);
 		return lua_index_raw(L);
 	}
-	lua_newuserdatauv(L, 0, 0);
+	using type = play_controller*;
+	new(L) type(&k.pc());
 	if(luaL_newmetatable(L, "mp settings")) {
-		lua_pushlightuserdata(L, &k.pc());
-		lua_pushcclosure(L, impl_mp_settings_get, 1);
+		lua_pushcfunction(L, impl_mp_settings_get);
 		lua_setfield(L, -2, "__index");
-		lua_pushlightuserdata(L, &k.pc());
-		lua_pushcclosure(L, impl_mp_settings_len, 1);
+		lua_pushcfunction(L, impl_mp_settings_len);
 		lua_setfield(L, -2, "__len");
-		lua_pushstring(L, "mp settings");
+		lua_pushstring(L, mpsettingKey);
 		lua_setfield(L, -2, "__metatable");
 	}
 	lua_setmetatable(L, -2);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1442,9 +1442,10 @@ namespace {
 	}
 }
 
+static const char endLvlKey[] = "end level data";
 static int impl_end_level_data_get(lua_State* L)
 {
-	const end_level_data& data = *static_cast<end_level_data*>(lua_touserdata(L, 1));
+	const end_level_data& data = *static_cast<end_level_data*>(luaL_checkudata(L, 1, endLvlKey));
 	const char* m = luaL_checkstring(L, 2);
 
 	return_bool_attrib("linger_mode", data.transient.linger_mode);
@@ -1476,7 +1477,7 @@ namespace {
 
 int game_lua_kernel::impl_end_level_data_set(lua_State* L)
 {
-	end_level_data& data = *static_cast<end_level_data*>(lua_touserdata(L, 1));
+	end_level_data& data = *static_cast<end_level_data*>(luaL_checkudata(L, 1, endLvlKey));
 	const char* m = luaL_checkstring(L, 2);
 	end_level_committer commit(data, play_controller_);
 
@@ -1492,7 +1493,7 @@ int game_lua_kernel::impl_end_level_data_set(lua_State* L)
 
 static int impl_end_level_data_collect(lua_State* L)
 {
-	end_level_data* data = static_cast<end_level_data*>(lua_touserdata(L, 1));
+	end_level_data* data = static_cast<end_level_data*>(luaL_checkudata(L, 1, endLvlKey));
 	data->~end_level_data();
 	return 0;
 }
@@ -1751,13 +1752,15 @@ SCENARIO_GETTER("end_level_data", lua_index_raw) {
 	}
 	auto data = k.pc().get_end_level_data();
 	new(L) end_level_data(data);
-	if(luaL_newmetatable(L, "end level data")) {
+	if(luaL_newmetatable(L, endLvlKey)) {
 		static luaL_Reg const callbacks[] {
 			{ "__index", 	    &impl_end_level_data_get},
 			{ "__newindex",     k.end_level_set()},
 			{ "__gc",           &impl_end_level_data_collect},
 			{ nullptr, nullptr }
 		};
+		lua_pushstring(L, endLvlKey);
+		lua_setfield(L, -2, "__metatable");
 		luaL_setfuncs(L, callbacks, 0);
 	}
 	lua_setmetatable(L, -2);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4639,12 +4639,16 @@ static int intf_modify_ai_old(lua_State *L)
 	return 0;
 }
 
-static int cfun_exec_candidate_action(lua_State *L)
+static int impl_exec_candidate_action(lua_State *L)
 {
 	bool exec = luaW_toboolean(L, -1);
 	lua_pop(L, 1);
 
 	lua_getfield(L, -1, "ca_ptr");
+	if(!lua_islightuserdata(L, -1)) {
+		lua_pushstring(L, "Could not execute candidate action - invalid pointer");
+		return lua_error(L);
+	}
 
 	ai::candidate_action *ca = static_cast<ai::candidate_action*>(lua_touserdata(L, -1));
 	lua_pop(L, 2);
@@ -4656,9 +4660,13 @@ static int cfun_exec_candidate_action(lua_State *L)
 	return 1;
 }
 
-static int cfun_exec_stage(lua_State *L)
+static int impl_exec_stage(lua_State *L)
 {
 	lua_getfield(L, -1, "stg_ptr");
+	if(!lua_islightuserdata(L, -1)) {
+		lua_pushstring(L, "Could not execute stage - invalid pointer");
+		return lua_error(L);
+	}
 	ai::stage *stg = static_cast<ai::stage*>(lua_touserdata(L, -1));
 	lua_pop(L, 2);
 	stg->play_stage();
@@ -4687,7 +4695,7 @@ static void push_component(lua_State *L, ai::component* c, const std::string &ct
 		lua_rawset(L, -3);
 
 		lua_pushstring(L, "exec");
-		lua_pushcclosure(L, &cfun_exec_candidate_action, 0);
+		lua_pushcfunction(L, &impl_exec_candidate_action);
 		lua_rawset(L, -3);
 	}
 
@@ -4697,7 +4705,7 @@ static void push_component(lua_State *L, ai::component* c, const std::string &ct
 		lua_rawset(L, -3);
 
 		lua_pushstring(L, "exec");
-		lua_pushcclosure(L, &cfun_exec_stage, 0);
+		lua_pushcfunction(L, &impl_exec_stage);
 		lua_rawset(L, -3);
 	}
 
@@ -5969,6 +5977,10 @@ void game_lua_kernel::push_builtin_effect()
  */
 int game_lua_kernel::cfun_wml_action(lua_State *L)
 {
+	if(!lua_islightuserdata(L, lua_upvalueindex(1))) {
+		lua_pushstring(L, "Could not execute wml action: upvalue was tampered with");
+		return lua_error(L);
+	}
 	game_events::wml_action::handler h = reinterpret_cast<game_events::wml_action::handler>
 		(lua_touserdata(L, lua_upvalueindex(1)));
 
@@ -6001,6 +6013,10 @@ using wml_conditional_handler = bool(*)(const vconfig&);
  */
 static int cfun_wml_condition(lua_State *L)
 {
+	if(!lua_islightuserdata(L, lua_upvalueindex(1))) {
+		lua_pushstring(L, "Could not evaluate wml condition: upvalue was tampered with");
+		return lua_error(L);
+	}
 	wml_conditional_handler h = reinterpret_cast<wml_conditional_handler>
 		(lua_touserdata(L, lua_upvalueindex(1)));
 

--- a/src/scripting/lua_color.cpp
+++ b/src/scripting/lua_color.cpp
@@ -25,18 +25,9 @@ static lg::log_domain log_scripting_lua("scripting/lua");
 
 static const char colorKey[] = "color range";
 
-static bool luaW_iscolor(lua_State* L, int index)
-{
-	return luaL_testudata(L, index, colorKey) != nullptr;
-}
-
 static color_range& LuaW_checkcolor(lua_State *L, int index)
 {
-	if(!luaW_iscolor(L, index)) {
-		luaW_type_error(L, index, "color");
-		throw "luaW_type_error returned";
-	}
-	return *static_cast<color_range*>(lua_touserdata(L, index));
+	return *static_cast<color_range*>(luaL_checkudata(L, index, colorKey));
 }
 
 
@@ -59,7 +50,7 @@ static int luaW_pushsinglecolor(lua_State *L, const color_t& color)
 
 static int impl_color_collect(lua_State *L)
 {
-	color_range *c = static_cast<color_range *>(lua_touserdata(L, 1));
+	color_range *c = static_cast<color_range *>(luaL_checkudata(L, 1, colorKey));
 	c->color_range::~color_range();
 	return 0;
 }

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -204,7 +204,7 @@ static int impl_vconfig_get(lua_State *L)
 {
 	static const lua_named_tuple_builder tuple_builder{ {"tag", "contents"} };
 
-	vconfig *v = static_cast<vconfig *>(lua_touserdata(L, 1));
+	vconfig *v = static_cast<vconfig *>(luaL_checkudata(L, 1, vconfigKey));
 
 	if (lua_isnumber(L, 2))
 	{
@@ -268,7 +268,7 @@ static int impl_vconfig_get(lua_State *L)
 
 static int impl_vconfig_dir(lua_State* L)
 {
-	vconfig *v = static_cast<vconfig *>(lua_touserdata(L, 1));
+	vconfig *v = static_cast<vconfig *>(luaL_checkudata(L, 1, vconfigKey));
 	std::vector<std::string> attributes;
 	for(const auto& [key, value] : v->get_config().attribute_range()) {
 		attributes.push_back(key);
@@ -282,7 +282,7 @@ static int impl_vconfig_dir(lua_State* L)
  */
 static int impl_vconfig_size(lua_State *L)
 {
-	vconfig *v = static_cast<vconfig *>(lua_touserdata(L, 1));
+	vconfig *v = static_cast<vconfig *>(luaL_checkudata(L, 1, vconfigKey));
 	lua_pushinteger(L, v->null() ? 0 :
 		std::distance(v->ordered_begin(), v->ordered_end()));
 	return 1;
@@ -293,7 +293,7 @@ static int impl_vconfig_size(lua_State *L)
  */
 static int impl_vconfig_collect(lua_State *L)
 {
-	vconfig *v = static_cast<vconfig *>(lua_touserdata(L, 1));
+	vconfig *v = static_cast<vconfig *>(luaL_checkudata(L, 1, vconfigKey));
 	v->~vconfig();
 	return 0;
 }
@@ -322,7 +322,7 @@ static int impl_vconfig_pairs_iter(lua_State *L)
 static int impl_vconfig_pairs_collect(lua_State *L)
 {
 	typedef config::const_attr_itors const_attr_itors;
-	void* p = lua_touserdata(L, 1);
+	void* p = luaL_checkudata(L, 1, vconfigpairsKey);
 
 	// Triggers a false positive of C4189 with Visual Studio. Suppress.
 #if defined(_MSC_VER)

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -63,7 +63,7 @@ namespace lua_common {
 static int impl_gettext(lua_State *L)
 {
 	char const *m = luaL_checkstring(L, 2);
-	char const *d = static_cast<char *>(lua_touserdata(L, 1));
+	char const *d = static_cast<char *>(luaL_checkudata(L, 1, gettextKey));
 	// Hidden metamethod, so d has to be a string. Use it to create a t_string.
 	if(lua_isstring(L, 3)) {
 		const char* pl = luaL_checkstring(L, 3);
@@ -77,7 +77,7 @@ static int impl_gettext(lua_State *L)
 
 static int impl_gettext_tostr(lua_State* L)
 {
-	char* d = static_cast<char*>(lua_touserdata(L, 1));
+	char* d = static_cast<char*>(luaL_checkudata(L, 1, gettextKey));
 	using namespace std::literals;
 	std::string str = "textdomain: "s + d;
 	lua_push(L, str);

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -145,7 +145,7 @@ static int impl_tstring_concat(lua_State *L)
 
 static int impl_tstring_len(lua_State* L)
 {
-	t_string* t = static_cast<t_string*>(lua_touserdata(L, 1));
+	t_string* t = static_cast<t_string*>(luaL_checkudata(L, 1, tstringKey));
 	lua_pushnumber(L, t->size());
 	return 1;
 }
@@ -155,7 +155,7 @@ static int impl_tstring_len(lua_State* L)
  */
 static int impl_tstring_collect(lua_State *L)
 {
-	t_string *t = static_cast<t_string *>(lua_touserdata(L, 1));
+	t_string *t = static_cast<t_string *>(luaL_checkudata(L, 1, tstringKey));
 	t->t_string::~t_string();
 	return 0;
 }
@@ -178,8 +178,8 @@ static int impl_tstring_le(lua_State *L)
 
 static int impl_tstring_eq(lua_State *L)
 {
-	t_string *t1 = static_cast<t_string *>(lua_touserdata(L, 1));
-	t_string *t2 = static_cast<t_string *>(lua_touserdata(L, 2));
+	t_string *t1 = static_cast<t_string *>(luaL_checkudata(L, 1, tstringKey));
+	t_string *t2 = static_cast<t_string *>(luaL_checkudata(L, 2, tstringKey));
 	lua_pushboolean(L, translation::compare(t1->get(), t2->get()) == 0);
 	return 1;
 }
@@ -190,7 +190,7 @@ static int impl_tstring_eq(lua_State *L)
  */
 static int impl_tstring_tostring(lua_State *L)
 {
-	t_string *t = static_cast<t_string *>(lua_touserdata(L, 1));
+	t_string *t = static_cast<t_string *>(luaL_checkudata(L, 1, tstringKey));
 	lua_pushstring(L, t->c_str());
 	return 1;
 }

--- a/src/scripting/lua_cpp_function.cpp
+++ b/src/scripting/lua_cpp_function.cpp
@@ -89,7 +89,7 @@ void register_metatable ( lua_State* L )
 	lua_setfield(L, -2, "__index");
 
 	lua_pop(L, 1);
-	
+
 	// Also set the metatable for regular functions
 	lua_pushcfunction(L, intf_tostring2);
 	lua_createtable(L, 0, 1);

--- a/src/scripting/lua_formula_bridge.cpp
+++ b/src/scripting/lua_formula_bridge.cpp
@@ -301,14 +301,14 @@ variant lua_formula_bridge::fwrapper::evaluate(const formula_callable& variables
 
 static int impl_formula_collect(lua_State* L)
 {
-	lua_formula_bridge::fwrapper* form = static_cast<lua_formula_bridge::fwrapper*>(lua_touserdata(L, 1));
+	lua_formula_bridge::fwrapper* form = static_cast<lua_formula_bridge::fwrapper*>(luaL_checkudata(L, 1, formulaKey));
 	form->~fwrapper();
 	return 0;
 }
 
 static int impl_formula_tostring(lua_State* L)
 {
-	lua_formula_bridge::fwrapper* form = static_cast<lua_formula_bridge::fwrapper*>(lua_touserdata(L, 1));
+	lua_formula_bridge::fwrapper* form = static_cast<lua_formula_bridge::fwrapper*>(luaL_checkudata(L, 1, formulaKey));
 	const std::string str = form->str();
 	lua_pushlstring(L, str.c_str(), str.size());
 	return 1;

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -338,6 +338,17 @@ static int impl_name_generator_call(lua_State *L)
 	return 1;
 }
 
+static int impl_name_generator_tostring(lua_State *L)
+{
+	name_generator* gen = static_cast<name_generator*>(luaL_checkudata(L, 1, Gen));
+	luaW_getglobal(L, "string", "format");
+	lua_pushstring(L, "%s: %s");
+	lua_pushstring(L, Gen);
+	lua_pushstring(L, gen->type().c_str());
+	lua_call(L, 2, 1);
+	return 1;
+}
+
 static int impl_name_generator_collect(lua_State *L)
 {
 	name_generator* gen = static_cast<name_generator*>(luaL_checkudata(L, 1, Gen));
@@ -941,6 +952,7 @@ lua_kernel_base::lua_kernel_base()
 	luaL_newmetatable(L, Gen);
 	static luaL_Reg const generator[] {
 		{ "__call", &impl_name_generator_call},
+		{ "__tostring", &impl_name_generator_tostring},
 		{ "__gc", &impl_name_generator_collect},
 		{ nullptr, nullptr}
 	};

--- a/src/scripting/lua_rng.cpp
+++ b/src/scripting/lua_rng.cpp
@@ -93,7 +93,7 @@ void load_tables(lua_State* L)
 	lua_pushcfunction(L, &impl_rng_create);
 	lua_setfield(L, -2, "create");
 	lua_setglobal(L, Rng);
-	
+
 	// Create the metatable for Rng objects
 	luaL_newmetatable(L, Rng);
 	static luaL_Reg const meta_callbacks[] {

--- a/src/scripting/lua_rng.cpp
+++ b/src/scripting/lua_rng.cpp
@@ -19,6 +19,7 @@
 #include "mt_rng.hpp"
 #include "scripting/lua_kernel_base.hpp"
 #include "scripting/lua_common.hpp" // for new(L)
+#include "scripting/push_check.hpp"
 
 #include <string>
 
@@ -84,6 +85,13 @@ int impl_rng_tostring(lua_State* L)
 	return 1;
 }
 
+int impl_rng_dir(lua_State* L)
+{
+	static const std::vector<std::string> fields = {"draw", "seed"};
+	lua_push(L, fields);
+	return 1;
+}
+
 // End Lua Rng bindings
 
 void load_tables(lua_State* L)
@@ -99,6 +107,7 @@ void load_tables(lua_State* L)
 	static luaL_Reg const meta_callbacks[] {
 		{ "__gc",           &impl_rng_destroy},
 		{ "__tostring",     &impl_rng_tostring},
+		{ "__dir",          &impl_rng_dir},
 		{ nullptr, nullptr }
 	};
 	luaL_setfuncs(L, meta_callbacks, 0);

--- a/src/scripting/lua_terrainfilter.cpp
+++ b/src/scripting/lua_terrainfilter.cpp
@@ -738,10 +738,7 @@ bool luaW_is_mgfilter(lua_State* L, int index)
 
 lua_mapgen::filter* luaW_to_mgfilter(lua_State *L, int index)
 {
-	if(luaW_is_mgfilter(L, index)) {
-		return static_cast<lua_mapgen::filter*>(lua_touserdata(L, index));
-	}
-	return nullptr;
+	return static_cast<lua_mapgen::filter*>(luaL_checkudata(L, index, terrinfilterKey));
 }
 
 lua_mapgen::filter_ptr luaW_check_mgfilter(lua_State *L, int index, bool allow_compile)
@@ -749,7 +746,7 @@ lua_mapgen::filter_ptr luaW_check_mgfilter(lua_State *L, int index, bool allow_c
 	if(luaW_is_mgfilter(L, index)) {
 		lua_mapgen::filter_ptr ptr;
 		ptr.get_deleter() = [](lua_mapgen::filter*) {}; // don't delete the Lua-held filter pointer
-		ptr.reset(static_cast<lua_mapgen::filter*>(lua_touserdata(L, index)));
+		ptr.reset(static_cast<lua_mapgen::filter*>(luaL_checkudata(L, index, terrinfilterKey)));
 		return ptr;
 	}
 	if(allow_compile && lua_istable(L, index)) {

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -129,7 +129,7 @@ static lua_unit* internal_get_unit(lua_State *L, int index, bool only_on_map, in
 		error = LU_NOT_UNIT;
 		return nullptr;
 	}
-	lua_unit* lu = static_cast<lua_unit*>(lua_touserdata(L, index));
+	lua_unit* lu = static_cast<lua_unit*>(luaL_checkudata(L, index, getunitKey));
 	if(only_on_map && !lu->on_map()) {
 		error = LU_NOT_ON_MAP;
 	}
@@ -221,7 +221,7 @@ lua_unit* luaW_pushlocalunit(lua_State *L, unit& u)
  */
 static int impl_unit_collect(lua_State *L)
 {
-	lua_unit *u = static_cast<lua_unit *>(lua_touserdata(L, 1));
+	lua_unit *u = static_cast<lua_unit *>(luaL_checkudata(L, 1, getunitKey));
 	u->lua_unit::~lua_unit();
 	return 0;
 }

--- a/src/utils/context_free_grammar_generator.hpp
+++ b/src/utils/context_free_grammar_generator.hpp
@@ -50,6 +50,7 @@ public:
 	 * @return the word
 	 */
 	std::string generate() const override;
+	std::string type() const override { return "cfg"; }
 
 	~context_free_grammar_generator();
 };

--- a/src/utils/markov_generator.hpp
+++ b/src/utils/markov_generator.hpp
@@ -27,4 +27,5 @@ class markov_generator : public name_generator {
 public:
 	markov_generator(const std::vector<std::string>& items, std::size_t chain_size, std::size_t max_len);
 	std::string generate() const override;
+	std::string type() const override { return "markov"; }
 };

--- a/src/utils/name_generator.hpp
+++ b/src/utils/name_generator.hpp
@@ -34,6 +34,7 @@ public:
 	// Defined in name_generator_factory.cpp
 	std::string generate(const std::map<std::string,std::string>& variables) const;
 	virtual std::string generate() const { return ""; }
+	virtual std::string type() const { return "unknown"; }
 	name_generator() {}
 	virtual ~name_generator() {}
 };
@@ -43,4 +44,5 @@ class proxy_name_generator : public name_generator {
 public:
 	proxy_name_generator(const name_generator& b) : base(b) {}
 	std::string generate() const override { return base.generate(); }
+	std::string type() const override { return base.type(); }
 };


### PR DESCRIPTION
This eliminates most direct use of `lua_touserdata` for getting non-light userdata from the stack, preferring `luaL_checkudata` or occasionally `luaL_testudata` instead. In the case of light userdata, it verifies with `lua_islightuserdata` before using the value.