### PR TITLE
Resolve broken Windows language selection

### DIFF
--- a/data/languages/en@shaw.cfg
+++ b/data/languages/en@shaw.cfg
@@ -3,5 +3,6 @@
     sort_name = "English (·𐑖𐑭𐑝𐑾𐑯)"
     locale=en@shaw
     alternates=en_AG@shaw, en_AU@shaw, en_CA@shaw, en_BW@shaw, en_DK@shaw, en_GB@shaw, en_HK@shaw, en_IE@shaw, en_IN@shaw, en_NG@shaw, en_NZ@shaw, en_PH@shaw, en_SG@shaw, en_US@shaw, en_ZA@shaw, en_ZW@shaw
+    windows_locale=en-US
     percent=24
 [/locale]

--- a/data/languages/sr_RS@ijekavian.cfg
+++ b/data/languages/sr_RS@ijekavian.cfg
@@ -2,5 +2,6 @@
     name="Српски (ијекавски)"
     sort_name = "Srpski (ijekavski)"
     locale=sr_RS@ijekavian
+    windows_locale=sr-Cyrl-RS
     percent=33
 [/locale]

--- a/data/languages/sr_RS@ijekavianlatin.cfg
+++ b/data/languages/sr_RS@ijekavianlatin.cfg
@@ -1,5 +1,6 @@
 [locale]
     name="Srpski (ijekavski latinica)"
     locale=sr_RS@ijekavianlatin
+    windows_locale=sr-Latn
     percent=33
 [/locale]

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -118,13 +118,10 @@ language_def::language_def()
 }
 
 language_def::language_def(const config& cfg)
-#ifndef _WIN32
 	: localename(cfg["locale"])
 	, alternates(utils::split(cfg["alternates"]))
-#else
-	: localename(cfg["windows_locale"].str("C"))
-	, alternates(utils::split(cfg["windows_alternates"]))
-#endif
+	, windows_locale(cfg["windows_locale"].str("C"))
+	, windows_alternates(utils::split(cfg["windows_alternates"]))
 	, language(cfg["name"].t_str())
 	, sort_name(cfg["sort_name"].str(language))
 	, rtl(cfg["dir"] == "rtl")
@@ -287,8 +284,17 @@ void set_language(const language_def& locale)
 	}
 #endif
 
+#ifdef _WIN32
+	// Windows has no knowledge of most POSIX locale IDs, so the OS-level setlocale() call
+	// (date/time formatting and collation only) uses the windows_locale override instead.
+	// Catalogue look-up below still uses the portable POSIX locale name, since gettext-style
+	// catalogue matching doesn't go through the OS locale database.
+	wesnoth_setlocale(LC_COLLATE, locale.windows_locale, &locale.windows_alternates);
+	wesnoth_setlocale(LC_TIME, locale.windows_locale, &locale.windows_alternates);
+#else
 	wesnoth_setlocale(LC_COLLATE, localename, &locale.alternates);
 	wesnoth_setlocale(LC_TIME, localename, &locale.alternates);
+#endif
 	translation::set_language(localename, &locale.alternates);
 	load_strings(false);
 }

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -31,6 +31,17 @@ struct language_def
 
 	std::string localename;
 	std::vector<std::string> alternates;
+
+	/**
+	 * Windows has no knowledge of most POSIX locale IDs, so on that platform the OS-level
+	 * setlocale() call (LC_COLLATE/LC_TIME only) uses these instead. Everything else —
+	 * translation catalogue look-up, preferences saving, language_selection matching — always
+	 * uses localename/alternates above, so languages with no real Windows locale don't
+	 * collide with each other or lose their translations.
+	 */
+	std::string windows_locale;
+	std::vector<std::string> windows_alternates;
+
 	t_string language;
 	std::string sort_name;
 


### PR DESCRIPTION
Resolves #11503

`language_def::localename` was being used for both identifying translations and the string given to the OS `setlocale()` call. Several niche languages did not receive a windows_locale entry in #11094, so they were being given `C` locale by default. With several languages having the same `C` identifier, choosing one (such as Latin) would result in whatever `C`-tagged language was sorted first.

This restores the separation present before #11094: `localename` or `alternates` are used unconditionally on all platforms again. A new `windows_locale`/`alternates` pair now holds the Windows-specific override, used by `windows_setlocale()`, to avoid confusion with the language identity.