### PR TITLE
Resolve turn-timer warning sound not playing after SDL3 migration

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -917,11 +917,10 @@ void play_sound_internal(const std::string& files,
 
 	sdl3_properties props;
 	if(loop_ticks > 0ms) {
+		SDL_SetNumberProperty(props, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
 		if(fadein_ticks > 0ms) {
 			SDL_SetNumberProperty(props, MIX_PROP_PLAY_FADE_IN_MILLISECONDS_NUMBER, fadein_ticks.count());
 			SDL_SetNumberProperty(props, MIX_PROP_PLAY_MAX_MILLISECONDS_NUMBER, loop_ticks.count());
-		} else {
-			SDL_SetNumberProperty(props, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
 		}
 	} else {
 		if(fadein_ticks > 0ms) {


### PR DESCRIPTION
Resolves #11508.

`play_sound_internal()` dropped the always-loop-infinitely behaviour when also fading in a track (`Mix_FadeInChannel()` in SDL2). So `MIX_PROP_PLAY_LOOPS_NUMBER` was never set - the count-down warning sound played once while fading in, but stayed silent thereafter instead of looping until time expired.