### PR TITLE
#11512 Carry over Combat RNG settings from Campaign selection to start-of-scenario saves

### DIFF
--- a/data/gui/themes/default/dialogs/game_load.cfg
+++ b/data/gui/themes/default/dialogs/game_load.cfg
@@ -546,52 +546,60 @@
 													grow_factor = 0
 
 													[column]
-														horizontal_alignment = "left"
-
-														border = "all"
-														border_size = 5
-
-														[label]
-															definition = "default_small"
-															label = _ "Combat:"
-														[/label]
-
-													[/column]
-
-												[/row]
-
-												[row]
-													grow_factor = 0
-
-													[column]
 														horizontal_grow = true
 
-														border = "all"
-														border_size = 5
+														[grid]
 
-														[menu_button]
-															id = "rng_menu"
-															use_markup = true
+															[row]
 
-															[option]
-																label = _ "Default RNG"
-																tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
+																[column]
+																	grow_factor = 0
+																	horizontal_alignment = "right"
+																	border = "all"
+																	border_size = 5
+
+																	[label]
+																		definition = "default"
+																		label = _ "Combat:"
+																	[/label]
+
+																[/column]
+
+																[column]
+																	grow_factor = 1
+																	horizontal_grow = true
+																	border = "all"
+																	border_size = 5
+
+																	[menu_button]
+																		id = "rng_menu"
+																		use_markup = true
+
+																		[option]
+																			label = _ "Default RNG"
+																			tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
 
 Example: if you strike twice with 50% accuracy, you’re most likely to hit once and miss once, but might also hit twice or miss twice."
-															[/option]
-															[option]
-																label = _ "Predictable RNG"
-																tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
+																		[/option]
+																		[option]
+																			label = _ "Predictable RNG"
+																			tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
 
 Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. Both strikes will still hit."
-															[/option]
-															[option]
-																label = _ "Reduced RNG"
-																tooltip = _ "Hits and misses are much more consistent. This tends to make small-scale engagements easier to plan.
+																		[/option]
+																		[option]
+																			label = _ "Reduced RNG"
+																			tooltip = _ "Hits and misses are much more consistent. This tends to make small-scale engagements easier to plan.
 
 Example: if you strike three times with 50% accuracy, you will always hit at least once and miss at least once."
-															[/option]
-														[/menu_button]
+																		[/option]
+																	[/menu_button]
+
+																[/column]
+
+															[/row]
+
+														[/grid]
 
 													[/column]
 

--- a/data/gui/themes/default/dialogs/game_load.cfg
+++ b/data/gui/themes/default/dialogs/game_load.cfg
@@ -547,6 +547,61 @@
 
 													[column]
 														horizontal_alignment = "left"
+
+														border = "all"
+														border_size = 5
+
+														[label]
+															definition = "default_small"
+															label = _ "Combat:"
+														[/label]
+
+													[/column]
+
+												[/row]
+
+												[row]
+													grow_factor = 0
+
+													[column]
+														horizontal_grow = true
+
+														border = "all"
+														border_size = 5
+
+														[menu_button]
+															id = "rng_menu"
+															use_markup = true
+
+															[option]
+																label = _ "Default RNG"
+																tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
+
+Example: if you strike twice with 50% accuracy, you’re most likely to hit once and miss once, but might also hit twice or miss twice."
+															[/option]
+															[option]
+																label = _ "Predictable RNG"
+																tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
+
+Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. Both strikes will still hit."
+															[/option]
+															[option]
+																label = _ "Reduced RNG"
+																tooltip = _ "Hits and misses are much more consistent. This tends to make small-scale engagements easier to plan.
+
+Example: if you strike three times with 50% accuracy, you will always hit at least once and miss at least once."
+															[/option]
+														[/menu_button]
+
+													[/column]
+
+												[/row]
+
+												[row]
+													grow_factor = 0
+
+													[column]
+														horizontal_alignment = "left"
 														#border = "bottom"
 														#border_size = 10
 

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -54,7 +54,7 @@ static lg::log_domain log_gameloaddlg{"gui/dialogs/game_load_dialog"};
 
 namespace gui2::dialogs
 {
-	
+
 const std::vector<std::string> rng_modes{"", "deterministic", "biased"};
 
 REGISTER_DIALOG(game_load)

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -54,6 +54,8 @@ static lg::log_domain log_gameloaddlg{"gui/dialogs/game_load_dialog"};
 
 namespace gui2::dialogs
 {
+	
+const std::vector<std::string> rng_modes{"", "deterministic", "biased"};
 
 REGISTER_DIALOG(game_load)
 
@@ -85,6 +87,7 @@ game_load::game_load(savegame::load_game_metadata& data)
 	, change_difficulty_(register_bool("change_difficulty", true, data.select_difficulty))
 	, show_replay_(register_bool("show_replay", true, data.show_replay))
 	, cancel_orders_(register_bool("cancel_orders", true, data.cancel_orders))
+	, random_mode_(data.random_mode)
 	, summary_(data.summary)
 	, games_()
 	, cache_config_(game_config_manager::get()->game_config())
@@ -134,6 +137,18 @@ void game_load::pre_show()
 	connect_signal_notify_modified(dir_list, std::bind(&game_load::handle_dir_select, this));
 
 	display_savegame();
+}
+
+void game_load::post_show()
+{
+	if(get_retval() != retval::OK) {
+		return;
+	}
+
+	const menu_button& rng_menu = find_widget<menu_button>("rng_menu");
+	if(rng_menu.get_active()) {
+		random_mode_ = rng_modes[std::clamp<unsigned>(rng_menu.get_value(), 0, rng_modes.size() - 1)];
+	}
 }
 
 void game_load::set_save_dir_list(menu_button& dir_list)
@@ -260,6 +275,7 @@ void game_load::display_savegame_internal(const savegame::save_info& game)
 	toggle_button& replay_toggle            = dynamic_cast<toggle_button&>(*show_replay_->get_widget());
 	toggle_button& cancel_orders_toggle     = dynamic_cast<toggle_button&>(*cancel_orders_->get_widget());
 	toggle_button& change_difficulty_toggle = dynamic_cast<toggle_button&>(*change_difficulty_->get_widget());
+	menu_button& rng_menu                   = find_widget<menu_button>("rng_menu");
 
 	const bool is_replay = savegame::is_replay_save(summary_);
 	const bool is_scenario_start = summary_["turn"].empty();
@@ -273,6 +289,11 @@ void game_load::display_savegame_internal(const savegame::save_info& game)
 
 	// Changing difficulty doesn't make sense on non-start-of-scenario saves
 	change_difficulty_toggle.set_active(!is_replay && is_scenario_start);
+
+	// Only allow changing RNG mode on start-of-scenario save
+	auto rng_it = std::find(rng_modes.begin(), rng_modes.end(), summary_["random_mode"].str());
+	rng_menu.set_selected(rng_it != rng_modes.end() ? static_cast<unsigned>(std::distance(rng_modes.begin(), rng_it)) : 0);
+	rng_menu.set_active(!is_replay && is_scenario_start);
 }
 
 // This is a wrapper that prevents a corrupted save file (if it happens to be
@@ -314,6 +335,7 @@ void game_load::display_savegame()
 		replay_toggle.set_active(false);
 		cancel_orders_toggle.set_active(false);
 		change_difficulty_toggle.set_active(false);
+		find_widget<menu_button>("rng_menu").set_active(false);
 	}
 
 	// Disable Load button if nothing is selected or if the currently selected file can't be loaded
@@ -418,6 +440,19 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 			break;
 		}
 	} else {
+	}
+
+	if(campaign_type_enum == campaign_type::type::scenario && !savegame::is_replay_save(cfg_summary)) {
+		const std::string random_mode = cfg_summary["random_mode"].str();
+
+		str << "\n" << _("Combat:") << " ";
+		if(random_mode == "deterministic") {
+			str << _("Predictable RNG");
+		} else if(random_mode == "biased") {
+			str << _("Reduced RNG");
+		} else {
+			str << _("Default RNG");
+		}
 	}
 
 	if(!cfg_summary["version"].empty()) {

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -34,6 +34,7 @@ public:
 
 private:
 	virtual void pre_show() override;
+	virtual void post_show() override;
 
 	virtual const std::string& window_id() const override;
 
@@ -66,6 +67,8 @@ private:
 	field_bool* change_difficulty_;
 	field_bool* show_replay_;
 	field_bool* cancel_orders_;
+
+	utils::optional<std::string>& random_mode_;
 
 	config& summary_;
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -205,6 +205,10 @@ utils::optional<load_game_metadata> load_interactive()
 		}
 	}
 
+	if(load_data.random_mode) {
+		load_data.load_config["random_mode"] = *load_data.random_mode;
+	}
+
 	if(!check_version_compatibility(load_data.load_config)) {
 		return utils::nullopt;
 	}

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -69,6 +69,9 @@ struct load_game_metadata
 	/** State of the "change_difficulty" checkbox in the load-game dialog. */
 	bool select_difficulty = false;
 
+	/** State of the "rng_menu" dropdown in the load-game dialog. */
+	utils::optional<std::string> random_mode {};
+
 	/** Summary config of the save selected in the load game dialog. */
 	config summary {};
 


### PR DESCRIPTION
This adds support for changing the RNG mode of combat on start-of-scenario-save loads. Addresses feature request in 11512 (https://github.com/wesnoth/wesnoth/issues/11512).