### PR TITLE
Add error handling if queue has content not know by the client

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -552,12 +552,14 @@ void create_engine::set_current_era_index(const std::size_t index, bool force)
 	current_era_index_ = index;
 
 	dependency_manager_->try_era_by_index(index, force);
+	current_era_id_ = dependency_manager_->get_era();
 }
 
-void create_engine::set_current_era_id(const std::string& id, bool force)
+void create_engine::set_current_era_index(const std::string& id, bool force)
 {
 	std::size_t index = dependency_manager_->get_era_index(id);
 
+	current_era_id_ = id;
 	current_era_index_ = index;
 
 	dependency_manager_->try_era_by_index(index, force);
@@ -653,6 +655,11 @@ const mp_game_settings& create_engine::get_parameters()
 	DBG_MP << "getting parameter values";
 
 	int era_index = current_level().allow_era_choice() ? current_era_index_ : 0;
+	// in case of joining a server queue with an unknown era
+	// the depcheck's get_era_index() returns -1 when not found
+	if(era_index == -1) {
+		throw config::error(_("Era not found: ")+current_era_id_);
+	}
 	state_.classification().era_id = eras_[era_index]->id;
 	state_.mp_settings().mp_era_name = eras_[era_index]->name;
 

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -356,7 +356,7 @@ public:
 	void set_current_level(const std::size_t index);
 
 	void set_current_era_index(const std::size_t index, bool force = false);
-	void set_current_era_id(const std::string& id, bool force = false);
+	void set_current_era_index(const std::string& id, bool force = false);
 
 	std::size_t current_era_index() const
 	{
@@ -408,6 +408,7 @@ private:
 	std::size_t current_level_index_;
 
 	std::size_t current_era_index_;
+	std::string current_era_id_;
 
 	std::string level_name_filter_;
 	int player_count_filter_;

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -584,6 +584,10 @@ bool mp_manager::enter_lobby_mode()
 				gui2::show_error_message(error.message);
 			}
 
+			if(dlg_retval == gui2::dialogs::mp_lobby::CREATE_PRESET) {
+				connection->send_data(config{"leave_server_queue", config{"queue_id", queue_id}});
+			}
+
 			// Update lobby content
 			connection->send_data(config{"refresh_lobby"});
 		}

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -156,13 +156,18 @@ void mp_create_game::quick_mp_setup(saved_game& state, const config presets)
 	// from pre_show
 	create.set_current_level_type(level_type::type::scenario);
 	const auto& levels = create.get_levels_by_type(level_type::type::scenario);
+	bool found_scenario = false;
 	for(std::size_t i = 0; i < levels.size(); i++) {
 		if(levels[i]->id() == presets["scenario"].str()) {
 			create.set_current_level(i);
+			found_scenario = true;
 		}
 	}
+	if(!found_scenario) {
+		throw config::error(_("Scenario not found: ")+presets["scenario"].str());
+	}
 
-	create.set_current_era_id(presets["era"]);
+	create.set_current_era_index(presets["era"]);
 
 	// from post_show
 	create.prepare_for_era_and_mods();
@@ -224,6 +229,13 @@ void mp_create_game::quick_mp_setup(saved_game& state, const config presets)
 	params.name = settings::game_name_default();
 
 	for(const std::string& mod : utils::split(presets["modifications"].str())) {
+		std::vector<std::string> missing_mods;
+		if(!game_config_manager::get()->game_config().find_child("modification", "id", mod)) {
+			missing_mods.emplace_back(mod);
+		}
+		if(!missing_mods.empty()) {
+			throw config::error(_("Modification(s) not found: ")+utils::join(missing_mods));
+		}
 		create.active_mods().push_back(mod);
 	}
 

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -1773,7 +1773,7 @@ void server::handle_leave_server_queue(player_iterator p, simple_wml::node& data
 	// if they're in the queue, remove them
 	if(utils::contains(queue.players_in_queue, p->info().name())) {
 		queue.players_in_queue.erase(std::remove(queue.players_in_queue.begin(), queue.players_in_queue.end(), p->info().name()), queue.players_in_queue.end());
-		p->info().clear_queues();
+		p->info().remove_from_queue(queue_id);
 
 		send_queue_update(queue);
 	} else {


### PR DESCRIPTION
Old situation:
* unknown scenario - defaults to aethermaw
* unknown era - crash
* unknown modification - ignored and game continues without it

New situation: all three possibilities now kick the player back to the MP lobby with an error message stating what wasn't found.

---

This does add three new strings, but they are short so I think they're fine. Otherwise these are strings that players will most likely never see given the queue config is manually setup by us on the server side, so leaving them as not being translatable would probably be fine too.