### PR TITLE
Fix Lua animator metatable protection

### DIFF
--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -416,8 +416,8 @@ int game_lua_kernel::intf_create_animator(lua_State* L)
 			{nullptr, nullptr},
 		};
 		luaL_setfuncs(L, metafuncs, 0);
-		lua_pushstring(L, "__metatable");
-		lua_setfield(L, -2, animatorKey);
+		lua_pushstring(L, animatorKey);
+		lua_setfield(L, -2, "__metatable");
 	}
 	lua_setmetatable(L, -2);
 	return 1;


### PR DESCRIPTION
## Bug
Wesnoth's Lua integration currently attempts to protect the metatable of `unit_animator` by setting the value of the `__metatable` key.  However, the key and value parameters are mistakenly swapped, resulting in the metatable not being protected as intended. 

The Lua docs specify the following:

> `void lua_setfield (lua_State *L, int index, const char *k);`
> Does the equivalent to t[k] = v, where t is the value at the given index and v is the value on the top of the stack.
> 
> This function pops the value from the stack. As in Lua, this function may trigger a metamethod for the "newindex" event (see [§2.4](https://www.lua.org/manual/5.4/manual.html#2.4)).

This means that the current code currently does effectively:
`metatable["unit animator"] = "__metatable"`

rather than

`metatable["__metatable"] = "unit animator"`

## Impact
An attacker can trigger a double free by abusing the native metatable `__gc` method
```
local animator = wesnoth.units.create_animator()
animator:add(wesnoth.units.get("alice"), "standing", "hit", {})

local gc = getmetatable(animator).__gc
gc(animator)
gc(animator)
```

This may be exploitable depending on the specific allocator and grooming primitives achievable. I'm currently exploring the feasibility of an exploit privately.

# Fix
Swapped K/V parameters