### PR TITLE
Help: Avoid crash and stale cache on dynamic terrain combinations

### DIFF
--- a/src/gui/dialogs/help_browser.cpp
+++ b/src/gui/dialogs/help_browser.cpp
@@ -107,7 +107,9 @@ void help_browser::pre_show()
 		bool is_contents_visible = (topic_panel.get_visible() == widget::visibility::visible);
 		if (parent) {
 			topic_text.set_width(is_contents_visible ? win_w : rl_init_w);
-			show_topic(history_.at(history_pos_), false, true);
+			if(!history_.empty()) {
+				show_topic(history_.at(history_pos_), false, true);
+			}
 		}
 		topic_panel.set_visible(!is_contents_visible);
 		invalidate_layout();
@@ -194,8 +196,10 @@ void help_browser::show_topic(std::string topic_id, bool add_to_history, bool re
 {
 	if(reshow) {
 		const help::topic* topic = help::find_topic(toplevel_, topic_id);
-		find_widget<rich_label>("topic_text").set_dom(topic->text.parsed_text());
-		invalidate_layout();
+		if(topic) {
+			find_widget<rich_label>("topic_text").set_dom(topic->text.parsed_text());
+			invalidate_layout();
+		}
 		return;
 	}
 
@@ -281,6 +285,10 @@ void help_browser::on_topic_select()
 
 void help_browser::on_history_navigate(bool backwards)
 {
+	if(history_.empty()) {
+		return;
+	}
+
 	if(backwards) {
 		if (history_pos_ > 0) {
 			history_pos_--;

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -26,6 +26,7 @@
 #include "gui/dialogs/help_browser.hpp"
 #include "preferences/preferences.hpp"
 #include "terrain/terrain.hpp"
+#include "terrain/type_data.hpp"
 #include "units/types.hpp"
 #include "units/unit.hpp"
 
@@ -105,6 +106,7 @@ public:
 private:
 	std::size_t last_num_encountered_units_{0};
 	std::size_t last_num_encountered_terrains_{0};
+	std::size_t last_num_terrain_types_{0};
 
 	boost::tribool last_debug_state_{boost::indeterminate};
 
@@ -124,14 +126,21 @@ const section& help_manager::implementation::regenerate()
 	const auto& enc_units = prefs::get().encountered_units();
 	const auto& enc_terrains = prefs::get().encountered_terrains();
 
-	// More units or terrains encountered, or debug mode toggled
+	// Terrain combinations (base+overlay) can be synthesised ad-hoc as in the editor
+	// describing whatever is under the cursor, which grows this list without touching
+	// encountered_terrains.
+	const std::size_t num_terrain_types = terrain_type_data::get()->list().size();
+
+	// More units or terrains encountered, more terrain types known, or debug mode toggled
 	if(boost::indeterminate(last_debug_state_)
 		|| enc_units.size()    != last_num_encountered_units_
 		|| enc_terrains.size() != last_num_encountered_terrains_
+		|| num_terrain_types   != last_num_terrain_types_
 		|| last_debug_state_   != game_config::debug
 	) {
 		last_num_encountered_units_ = enc_units.size();
 		last_num_encountered_terrains_ = enc_terrains.size();
+		last_num_terrain_types_ = num_terrain_types;
 		last_debug_state_ = game_config::debug;
 
 		// Update the contents


### PR DESCRIPTION
Resolves #11529.

Combined terrains are synthesised lazily and not added to the cached Help topic tree, so their hidden topic ID is never found. This causes show_topic() to return before recording the topic in history_, leaving it permanently empty. The 'Show Topics' toggle and Help navigation then try to access the empty vector unconditionally.

This should resolve the issue by guarding against access to an empty history_, and also resolve the root cause by having help_manager invalidate its cache when the terrain_type_data's terrain list grows, not just when encountered_terrains change.

LLM-assisted, but I can see what's going on at a high level, and I rewrote the commentary myself. @soliton- Please try to see if this helps resolve it for you as well.