### PR TITLE
Fix wmlxgettext handling of leading newlines

### DIFF
--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -165,15 +165,18 @@ class PendingPlural:
         self.pluraltype = 0
         self.numequals = 0
         self.ismultiline = False
+        self.skip_initial_newline = False
 
     def addline(self, value, isfirstline=False):
         if self.pluraltype == 3 and isfirstline and value == "":
-            # This should be handled by not adding (self.string + '\n') on the next call,
-            # but someone can implement that if they start using long-bracket strings.
-            raise NotImplementedError("Not implemented: handling of long-bracket strings that start with a newline.")
+            # Lua ignores the newline immediately after an opening long bracket.
+            self.skip_initial_newline = True
         if self.pluraltype == 3:
             value = value.replace('\\', r'\\')
-        if isfirstline:
+        if self.skip_initial_newline and not isfirstline:
+            self.skip_initial_newline = False
+            self.string = value
+        elif isfirstline:
             self.string = value
         else:
             self.string = self.string + '\n' + value
@@ -205,18 +208,21 @@ class PendingLuaString:
         self.ismultiline = ismultiline
         self.istranslatable = istranslatable
         self.numequals = numequals
+        self.skip_initial_newline = False
         if luatype != 'lua_plural':
             self.addline(luastring, True)
         self.plural = plural
 
     def addline(self, value, isfirstline=False):
         if self.luatype == 'luastr3' and isfirstline and value == "":
-            # This should be handled by not adding (self.string + '\n') on the next call,
-            # but someone can implement that if they start using long-bracket strings.
-            raise NotImplementedError("Not implemented: handling of long-bracket strings that start with a newline.")
+            # Lua ignores the newline immediately after an opening long bracket.
+            self.skip_initial_newline = True
         if self.luatype == 'luastr3':
             value = value.replace('\\', r'\\')
-        if isfirstline:
+        if self.skip_initial_newline and not isfirstline:
+            self.skip_initial_newline = False
+            self.luastring = value
+        elif isfirstline:
             self.luastring = value
         else:
             self.luastring = self.luastring + '\n' + value


### PR DESCRIPTION
Fixes #11536

## Summary
- Handle Lua long-bracket strings whose opening delimiter is followed by a newline.
- Drop only the opening syntax newline and preserve subsequent content.
- Apply the same behavior to normal and plural pending strings.

## Tests
- Parsed the changed Python file with `ast.parse`.
- Ran the issue reproduction case and verified exit status 0 with no traceback.
- Ran a non-translatable multiline case and verified its text is absent from the POT output.
- Ran a translatable multiline case and verified its text is present in the POT output.

This change was implemented with AI assistance; the implementation and command-line checks were reviewed by the author.