### PR TITLE
Clear overlays on reset (replay reload) so halos don't pile up

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -133,6 +133,11 @@ void display::remove_overlay(const map_location& loc)
 	get_overlays().erase(loc);
 }
 
+void display::remove_overlays()
+{
+	get_overlays().clear();
+}
+
 void display::remove_single_overlay(const map_location& loc, const std::string& toDelete)
 {
 	utils::erase_if(get_overlays()[loc],

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -170,6 +170,9 @@ public:
 	/** remove_overlay will remove all overlays on a tile. */
 	void remove_overlay(const map_location& loc);
 
+	/** remove_overlays will remove all overlays on the map. */
+	void remove_overlays();
+
 	/** remove_single_overlay will remove a single overlay from a tile */
 	void remove_single_overlay(const map_location& loc, const std::string& toDelete);
 

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -342,6 +342,10 @@ void play_controller::reset_gamestate(const config& level, int replay_pos)
 
 	gui_->labels().set_team(nullptr);
 
+	// Item overlays (including their halos) are stored on the display, not the
+	// game state, so they need to be cleared here on reset. Refer GitHub #10866.
+	gui_->remove_overlays();
+
 	/* First destroy the old game state, then create the new one.
 	This is necessary to ensure that while the old AI manager is being destroyed,
 	all its member objects access the old manager instead of the new. */


### PR DESCRIPTION
Resolves #10866.