### PR TITLE
MP Lobby: Connect live user list to staging and join game screens so auto-complete can function as expected

### DIFF
--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -508,7 +508,8 @@ void mp_join_game::network_handler()
 	}
 
 	// Update chat
-	find_widget<chatbox>("chat").process_network_data(data);
+	chatbox& chat = find_widget<chatbox>("chat");
+	chat.process_network_data(data);
 
 	if(!data["message"].empty()) {
 		gui2::show_transient_message(_("Response") , data["message"]);
@@ -557,6 +558,14 @@ void mp_join_game::network_handler()
 	// Update player list
 	if(data.has_child("user")) {
 		player_list_->update_list(data.child_range("user"));
+
+		// This screen doesn't receive the main lobby's user list updates, so keep
+		// the chat's auto-completion roster synchronised with who is actually connected.
+		std::set<std::string> names;
+		for(const config& user : data.child_range("user")) {
+			names.insert(user["name"]);
+		}
+		chat.set_available_users(names);
 	}
 }
 

--- a/src/gui/dialogs/multiplayer/mp_staging.cpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.cpp
@@ -105,6 +105,7 @@ void mp_staging::pre_show()
 	chat.room_window_open(N_("this game"), true, false);
 	chat.active_window_changed();
 	chat.load_log(default_chat_log, false);
+	chat.set_available_users(connect_engine_.connected_users());
 
 	//
 	// Set up player list
@@ -532,11 +533,16 @@ void mp_staging::network_handler()
 	}
 
 	// Update chat
-	find_widget<chatbox>("chat").process_network_data(data);
+	chatbox& chat = find_widget<chatbox>("chat");
+	chat.process_network_data(data);
 
 	// TODO: why is this needed...
 	const bool was_able_to_start = connect_engine_.can_start_game();
 	const bool quit_signal_received = connect_engine_.process_network_data(data);
+
+	// Keep the chat's auto-completion roster synchronised with who is actually connected,
+	// since this screen no longer receives the main lobby's user list updates.
+	chat.set_available_users(connect_engine_.connected_users());
 
 	if(quit_signal_received) {
 		set_retval(retval::CANCEL);

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -180,17 +180,17 @@ void chatbox::chat_input_keypress_callback(const SDL_Keycode key)
 	}
 
 	case SDLK_TAB: {
-		auto* li = mp::get_lobby_info();
-		if(!li) {
-			break;
-		}
+		std::set<std::string> unique_matches(available_users_);
 
-		std::vector<std::string> matches;
-		for(const auto& ui : li->users()) {
-			if(ui.name != prefs::get().login()) {
-				matches.push_back(ui.name);
+		if(auto* li = mp::get_lobby_info()) {
+			for(const auto& ui : li->users()) {
+				unique_matches.insert(ui.name);
 			}
 		}
+
+		unique_matches.erase(prefs::get().login());
+
+		std::vector<std::string> matches(unique_matches.begin(), unique_matches.end());
 
 		const bool line_start = utils::word_completion(input, matches);
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -20,6 +20,7 @@
 #include "gui/widgets/container_base.hpp"
 
 #include <map>
+#include <set>
 #include <string>
 
 class config;
@@ -85,6 +86,21 @@ public:
 
 	void load_log(std::map<std::string, chatroom_log>& log, bool show_lobby);
 
+	/**
+	 * Supplies an additional set of names to offer for auto-completion, on top of
+	 * whatever @ref mp::get_lobby_info reports.
+	 *
+	 * The main lobby's user list (@ref mp::lobby_info) is only kept up to date while
+	 * the main lobby screen is shown; a host or player sitting in the game staging
+	 * screen no longer receives lobby-wide roster updates from the server, so
+	 * callers there should keep this synchronised with their own live player/observer
+	 * list instead.
+	 */
+	void set_available_users(const std::set<std::string>& names)
+	{
+		available_users_ = names;
+	}
+
 protected:
 	/**
 	 * Initializes the internal sub-widget pointers.
@@ -134,6 +150,8 @@ private:
 	std::function<void(void)> active_window_changed_callback_;
 
 	std::map<std::string, chatroom_log>* log_;
+
+	std::set<std::string> available_users_;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */


### PR DESCRIPTION
Resolves #3729.

`mp::lobby_info::users()` stops updating once the client is attached to a game (whether host or guest). So update those screens with the live user list explicitly to retain expected auto-complete behaviour.

LLM-assisted but I understand the high-level concepts here (as usual, I wrote/reviewed the commentary).