### PR TITLE
Prevent out-of-bounds access in multiplayer controller choices

### DIFF
--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -1164,7 +1164,7 @@ void game::handle_add_side_wml()
 
 void game::handle_controller_choice(const simple_wml::node& req)
 {
-	const std::size_t side_index = req["side"].to_int() - 1;
+	const std::size_t side_index = static_cast<std::size_t>(req["side"].to_int()) - 1;
 	auto new_controller = side_controller::get_enum(req["new_controller"].to_string());
 	auto old_controller = side_controller::get_enum(req["old_controller"].to_string());
 
@@ -1180,15 +1180,15 @@ void game::handle_controller_choice(const simple_wml::node& req)
 		return;
 	}
 
-	if(old_controller != this->side_controllers_[side_index]) {
-		send_and_record_server_message(
-			"Found unexpected old_controller= '" + side_controller::get_string(*old_controller) + "' in [request_choice] [change_controller]");
-	}
-
-	if(side_index >= sides_.size()) {
+	if(side_index >= sides_.size() || side_index >= side_controllers_.size()) {
 		send_and_record_server_message(
 			"Could not handle [request_choice] [change_controller] with invalid side '" + req["side"].to_string() + "'");
 		return;
+	}
+
+	if(old_controller != this->side_controllers_[side_index]) {
+		send_and_record_server_message(
+			"Found unexpected old_controller= '" + side_controller::get_string(*old_controller) + "' in [request_choice] [change_controller]");
 	}
 
 	const bool was_null = this->side_controllers_[side_index] == side_controller::type::none;


### PR DESCRIPTION
An incoming [request_choice] [change_controller_wml] packet controls the side index in game::handle_controller_choice. The code read side_controllers_[side_index] before checking whether the side was in range, allowing a logged-in player to trigger undefined behavior in wesnothd with side=0 or an oversized side number.

Parse and validate the side as a positive 1-based value against both side vectors before indexing. Invalid requests now receive the existing server error response.
