### PR TITLE
Support team-specific font colors, different to the team's mid color

### DIFF
--- a/changelog_entries/team_font_color.md
+++ b/changelog_entries/team_font_color.md
@@ -1,0 +1,4 @@
+### User interface
+   * Team-colored text can be a lighter shade than the team color
+### WML Engine
+   * Add `[color_range]font_color=`

--- a/data/schema/core/config.cfg
+++ b/data/schema/core/config.cfg
@@ -130,6 +130,7 @@
 		{REQUIRED_KEY id string}
 		{SIMPLE_KEY name t_string}
 		{SIMPLE_KEY rgb hex_list}
+		{SIMPLE_KEY font_color hex}
 		{DEFAULT_KEY default bool no}
 	[/tag]
 	[tag]

--- a/data/test/scenarios/lua_tests/wesnoth/test_lua_color.cfg
+++ b/data/test/scenarios/lua_tests/wesnoth/test_lua_color.cfg
@@ -2,8 +2,10 @@
 # Check that team colors are accessible via wesnoth.colors, and that the Lua
 # layer is putting the correct channel's value into each of r, g, b and a.
 #
-# This test is lax about the exact values, it's meant to test the API layer
-# rather than detect someone altering the exact hue in team-colors.cfg.
+# These tests are meant to test the API layer, rather than to prevent someone
+# altering the colors in team-colors.cfg. The first test is lax about the exact
+# values for that reason, but the second one hardcodes the exact strings
+# because that made the test easier to write.
 
 #####
 # API(s) being tested: wesnoth.colors
@@ -38,6 +40,8 @@
                 unit_test.assert_greater(green.mid.g, 10 + green.mid.r, "color green's mid is too red")
                 unit_test.assert_greater(green.mid.g, 10 + green.mid.b, "color green's mid is too blue")
                 unit_test.assert_greater(green.minimap.g, 10 + green.minimap.r + green.minimap.b, "color green's minimap isn't green")
+                unit_test.assert_greater(green.font_color.g, 10 + green.font_color.r, "color green's font_color is too red")
+                unit_test.assert_greater(green.font_color.g, 10 + green.font_color.b, "color green's font_color is too blue")
 
                 local blue = wesnoth.colors["blue"]
                 unit_test.assert(blue, "no definition for color 'blue'")

--- a/src/color_range.cpp
+++ b/src/color_range.cpp
@@ -114,6 +114,7 @@ std::string color_range::debug() const
 	  << ',' << max_.to_hex_string()
 	  << ',' << min_.to_hex_string()
 	  << ',' << rep_.to_hex_string()
+	  << ',' << font_color_.to_hex_string()
 	  << '}';
 
 	return o.str();

--- a/src/color_range.hpp
+++ b/src/color_range.hpp
@@ -17,6 +17,7 @@
 
 #include "color.hpp"
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -24,8 +25,14 @@
 using color_mapping = std::unordered_map<color_t, color_t>;
 
 /**
- * A color range definition is made of four reference RGB colors, used
- * for calculating conversions from a source/key palette.
+ * Representing the "team color" information, this C++ class contains a subset
+ * of WML's [color_range] tag. The other content of the [color_range] tags is
+ * parsed by the game_config class, and the data is held by several globals
+ * declared in game_config.hpp.
+ *
+ * The main definition is made of three reference RGB colors, used for
+ * calculating conversions from a source/key palette with the external
+ * generate_color_mapping() method.
  *
  *   1) The average shade of a unit's team-color portions
  *      (default: gray #808080)
@@ -33,11 +40,14 @@ using color_mapping = std::unordered_map<color_t, color_t>;
  *      (default: white)
  *   3) The minimum shadow shade of a unit's team-color portions
  *      (default: black)
- *   4) A plain high-contrast color, used for the markers on the mini-map
- *      (default: same as the provided average shade, or gray #808080)
  *
- * The first three reference colors are used for converting a source palette
- * with the external generate_color_mapping() method.
+ * Some further colors are included because this mixes the responsibilities of
+ * being the "team color" class.
+ *
+ *   4) A color with high contrast to terrain colors, so that it can
+ *      be used for the markers on the mini-map.
+ *      (default: same as the provided average shade, or gray #808080)
+ *   5) A color with high contrast to dark backgrounds, used for text.
  */
 class color_range
 {
@@ -47,24 +57,27 @@ public:
 	* @param mid Average color shade.
 	* @param max Maximum (highlight) color shade
 	* @param min Minimum color shade
-	* @param rep High-contrast reference color
+	* @param rep High-contrast to terrain
+	* @param font High-contrast to a dark background
 	*/
-	color_range(color_t mid, color_t max = {255, 255, 255}, color_t min = {0, 0, 0}, color_t rep = {128, 128, 128})
+	color_range(color_t mid, color_t max, color_t min, color_t rep, color_t font)
 		: mid_(mid)
 		, max_(max)
 		, min_(min)
 		, rep_(rep)
+		, font_color_(font)
 	{}
 
 	/**
-	* Constructor, which expects four reference RGB colors.
-	* @param v STL vector with the four reference colors in order.
+	* Constructor, matching the WML tag's split of the rgb attribute in one argument,
+    * and the color for UI text in a different argument.
 	*/
-	color_range(const std::vector<color_t>& v)
+	color_range(const std::vector<color_t>& v, const std::optional<color_t>& font)
 		: mid_(v.size()     ? v[0] : color_t(128, 128, 128))
 		, max_(v.size() > 1 ? v[1] : color_t(255, 255, 255))
 		, min_(v.size() > 2 ? v[2] : color_t(0  , 0  , 0  ))
 		, rep_(v.size() > 3 ? v[3] : mid_)
+		, font_color_(font ? *font : mid_)
 	{}
 
 	/** Default constructor. */
@@ -73,6 +86,7 @@ public:
 		, max_(255, 255, 255)
 		, min_()
 		, rep_(128, 128, 128)
+		, font_color_(mid_)
 	{}
 
 	/** Average color shade. */
@@ -84,19 +98,23 @@ public:
 	/** Minimum color shade. */
 	color_t min() const { return min_; }
 
-	/** High-contrast shade, intended for the minimap markers. */
+	/** High-contrast against typical terrain colors, intended for the minimap markers. */
 	color_t rep() const { return rep_; }
+
+	/** High-contrast to dark backgrounds, intended for the text in the chat log, etc. */
+	color_t font_color() const { return font_color_; }
 
 	bool operator==(const color_range& b) const
 	{
-		return mid_ == b.mid() && max_ == b.max() && min_ == b.min() && rep_ == b.rep();
+		return mid_ == b.mid() && max_ == b.max() && min_ == b.min()
+			&& rep_ == b.rep() && font_color_ == b.font_color();
 	}
 
 	/** Return a string describing the color range for debug output. */
 	std::string debug() const;
 
 private:
-	color_t mid_ , max_ , min_ , rep_;
+	color_t mid_ , max_ , min_ , rep_, font_color_;
 };
 
 /**

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -115,7 +115,7 @@ void display_chat_manager::add_chat_message(const std::chrono::system_clock::tim
 	}
 	color_t speaker_color;
 	if(side >= 1) {
-		speaker_color = team::get_side_color(side);
+		speaker_color = team::get_font_color(side);
 	}
 
 	color_t message_color = chat_message_color;

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -482,16 +482,22 @@ void add_color_info(const game_config_view& v, bool build_defaults)
 			}
 		}
 
-		team_rgb_range.emplace(id, color_range(temp));
+		std::optional<color_t> font_color = std::nullopt;
+		const config::attribute_value* fc = teamC.get("font_color");
+		if(fc) {
+			font_color = color_t::from_hex_string(fc->str());
+		}
+
+		team_rgb_range.emplace(id, color_range(temp, font_color));
 		team_rgb_name.emplace(id, teamC["name"].t_str());
 
 		LOG_NG << "registered color range '" << id << "': " << team_rgb_range[id].debug();
 
-		// Generate palette of same name;
+		// Generate palette of same name:
 		team_rgb_colors.emplace(id, generate_reference_palette(team_rgb_range[id]));
 
 		if(build_defaults && teamC["default"].to_bool()) {
-			default_colors.push_back(*a1);
+			default_colors.push_back(id);
 		}
 	}
 
@@ -536,7 +542,7 @@ const color_range& color_info(std::string_view name)
 		}
 	}
 
-	team_rgb_range.emplace(name, color_range(temp));
+	team_rgb_range.emplace(name, color_range(temp, std::nullopt));
 	return color_info(name);
 }
 

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -19,6 +19,7 @@ class config;
 class color_range;
 
 #include "color.hpp"
+#include "color_range.hpp"
 #include "tstring.hpp"
 #include "game_config_view.hpp"
 
@@ -161,8 +162,18 @@ namespace game_config
 	 */
 	extern std::map<std::string, color_range, std::less<>> team_rgb_range;
 	extern std::map<std::string, t_string, std::less<>> team_rgb_name;
+	/**
+	 * For colors defined by WML [color_range] tags, the palettes for team-based recoloring.
+	 *
+	 * This is data calculated from the color_range structs, but isn't in those structs,
+	 * allowing them to be Plain Old Data.
+	 */
 	extern std::map<std::string, std::vector<color_t>, std::less<>> team_rgb_colors;
 
+	/**
+	 * The [color_range]id= attributes, equivalently the keys in the team_rgb_* maps,
+	 * for which [color_range]default=yes.
+	 */
 	extern std::vector<std::string> default_colors;
 
 	/**

--- a/src/gui/dialogs/game_stats.cpp
+++ b/src/gui/dialogs/game_stats.cpp
@@ -108,7 +108,7 @@ void game_stats::pre_show()
 				}
 			}
 
-			leader_name = markup::span_color(team::get_side_color(team.side()), leader_name);
+			leader_name = markup::span_color(team::get_font_color(team.side()), leader_name);
 		}
 
 		//

--- a/src/gui/dialogs/multiplayer/mp_change_control.cpp
+++ b/src/gui/dialogs/multiplayer/mp_change_control.cpp
@@ -76,7 +76,7 @@ void mp_change_control::pre_show()
 		const int side = sides_.emplace_back(t.side());
 
 		std::string side_str = VGETTEXT("Side $side", {{"side", std::to_string(side)}});
-		side_str = markup::span_color(team::get_side_color(side), side_str);
+		side_str = markup::span_color(team::get_font_color(side), side_str);
 
 		sides_list.add_row(widget_data{
 			{ "side", {

--- a/src/gui/dialogs/multiplayer/mp_staging.cpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.cpp
@@ -304,13 +304,14 @@ void mp_staging::add_side_node(const ng::side_engine_ptr& side)
 	std::vector<config> color_options;
 	for(const auto& color_opt : side->color_options()) {
 		auto name = game_config::team_rgb_name.find(color_opt);
-		auto color = game_config::team_rgb_colors.find(color_opt);
+		auto color = game_config::team_rgb_range.find(color_opt);
 		auto team_color = _("Invalid Color");
 
-		if (name != game_config::team_rgb_name.end() && color != game_config::team_rgb_colors.end()) {
-			team_color = markup::span_color(color->second[0], name->second);
+		if (name != game_config::team_rgb_name.end() && color != game_config::team_rgb_range.end()) {
+			team_color = markup::span_color(color->second.font_color(), name->second);
 		}
 
+		// The name will be in the font_color shade, but the icon will be in the mid() shade, like a recolored unit
 		color_options.emplace_back(
 			"label", team_color,
 			"icon", (formatter() << "misc/status.png~RC(magenta>" << color_opt << ")").str()

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -155,7 +155,7 @@ chat_msg::chat_msg(const config &cfg)
 	int side = cfg["side"].to_int(0);
 	LOG_REPLAY << "side in message: " << side;
 	if(side != 0) {
-		color_ = team::get_side_color(side);
+		color_ = team::get_font_color(side);
 	}
 }
 

--- a/src/scripting/lua_color.cpp
+++ b/src/scripting/lua_color.cpp
@@ -108,9 +108,12 @@ static int impl_color_get(lua_State *L)
 	if(strcmp(m, "minimap") == 0) {
 		return luaW_pushsinglecolor(L, c.rep());
 	}
+	if(strcmp(m, "font_color") == 0) {
+		return luaW_pushsinglecolor(L, c.font_color());
+	}
 	// returns a string which can be used in Pango's foreground= attribute
 	if(strcmp(m, "pango_color") == 0) {
-		lua_push(L, c.mid().to_hex_string());
+		lua_push(L, c.font_color().to_hex_string());
 		return 1;
 	}
 	return 0;
@@ -118,7 +121,7 @@ static int impl_color_get(lua_State *L)
 
 static int impl_color_dir(lua_State* L)
 {
-	static const std::vector<std::string> keys{"min", "max", "mid", "minimap", "pango_color"};
+	static const std::vector<std::string> keys{"min", "max", "mid", "minimap", "font_color", "pango_color"};
 	lua_push(L, keys);
 	return 1;
 }

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -937,7 +937,7 @@ color_range team::get_side_color_range(int side)
 		return iter->second;
 	}
 
-	return color_range({255, 0, 0}, {255, 255, 255}, {0, 0, 0}, {255, 0, 0});
+	return color_range({255, 0, 0}, {255, 255, 255}, {0, 0, 0}, {255, 0, 0}, {255, 0, 0});
 }
 
 color_t team::get_side_color(int side)
@@ -950,6 +950,11 @@ color_t team::get_minimap_color(int side)
 	// Note: use mid() instead of rep() unless
 	// high contrast is needed over a map or minimap!
 	return get_side_color_range(side).rep();
+}
+
+color_t team::get_font_color(int side)
+{
+	return get_side_color_range(side).font_color();
 }
 
 std::string team::get_side_color_id(unsigned side)

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -398,6 +398,7 @@ public:
 
 	static color_t get_side_color(int side);
 	static color_t get_minimap_color(int side);
+	static color_t get_font_color(int side);
 
 	static std::string get_side_color_id(unsigned side);
 	static t_string get_side_color_name_for_UI(unsigned side);


### PR DESCRIPTION
Add `[color_range]font_color=` which takes a hex string, and is used for text in UI controls.

For example, doofus-01 would like to make the black team's colors darker (PR #11492). This PR allows font_color to be a gray with equal values for red, green and blue, despite the team color being a purple-black, so that it is readable on a dark background, despite the unit's recoloring being much darker (part of what's requested in issue #11526).

Example WML for the previous paragraph:

```
    [color_range]
        id=black
        rgb=410442,FDFAFF,000000,000000
        name= _ "Black"
        font_color=8A8A8A
        default=yes
    [/color_range]
```

This commit only makes the font_color different if it's specified via WML, there is no automatic calculation of a readable shade. If the WML omits a font_color then that team's text uses the mid color, matching the old behavior.

Both of these show the above example for the black team (the fifth one saying "team color test")
<img width="383" height="326" alt="image" src="https://github.com/user-attachments/assets/4915d811-93f8-4ae5-9293-20889efdea1f" />
In the MP create dialog, the orb is team color, but the name is the lighter color:
<img width="388" height="407" alt="image" src="https://github.com/user-attachments/assets/35ac77be-55d2-4a38-9e17-42a05581afc9" />